### PR TITLE
Improve formatters customisation

### DIFF
--- a/packages/morpho-ts/README.md
+++ b/packages/morpho-ts/README.md
@@ -188,7 +188,7 @@ format.percent.digits(1).sign().of(0.123456); // "+12.3%"
 
 ### Create custom formatters
 
-You can create a custom `format` object with default options that will be applied to all formatters created from it.
+You can create a custom `format` object with default options that will be applied to all formatters created from it. You can also create custom formatters with specific names and options using the second argument.
 
 ```typescript
 import { createFormat } from "@morpho-org/morpho-ts";
@@ -198,14 +198,19 @@ const customFormat = createFormat({
     short: { digits: 3 }, // all short formatters will format with 3 digits
     number: { sign: true }, // all number formatters will display signed values
     ...
+}, {
+    custom: { format: Format.number, unit: "$" }, // this will add a `custom` key in `customFormat` that creates a formatter with these options
 })
 
 customFormat.short.of(1234.5678); // "1234.567"
 customFormat.number.of(1234.5678); // "+1234.56"
+customFormat.custom.of(1234.5678); // "$1234.56"
 
 // Default options can be normally overriden
 customFormat.short.digits(1).of(1234.5678); // "1234.5"
 ```
+
+> [!NOTE] > custom formatters will be impacted by `all` default options but not by type-specific default options
 
 ---
 

--- a/packages/morpho-ts/src/format/format/format.ts
+++ b/packages/morpho-ts/src/format/format/format.ts
@@ -280,12 +280,14 @@ type FormatterWithDefault<F extends BaseFormatter> = {
 };
 
 export abstract class BaseFormatter {
-  protected abstract _options: FormatOptions;
+  protected abstract _options: Readonly<FormatOptions>;
+
+  protected abstract _clone(_options: FormatOptions): this;
 
   default(_d: string) {
-    this._options.default = _d;
+    const newOptions = { ...this._options, default: _d };
 
-    return this as FormatterWithDefault<this>;
+    return this._clone(newOptions) as FormatterWithDefault<this>;
   }
 
   createOf() {
@@ -333,7 +335,7 @@ export abstract class BaseFormatter {
 }
 
 export class HexFormatter extends BaseFormatter {
-  protected _options: FormatHexOptions = {
+  protected _options: Readonly<FormatHexOptions> = {
     format: Format.hex,
     prefix: false,
   };
@@ -344,75 +346,96 @@ export class HexFormatter extends BaseFormatter {
   }
 
   prefix() {
-    this._options.prefix = true;
-    return this;
+    const newOptions = { ...this._options, prefix: true };
+
+    return this._clone(newOptions);
+  }
+
+  _clone(_options: FormatHexOptions) {
+    return new HexFormatter(_options) as this;
   }
 }
 
 export abstract class CommonFormatter extends BaseFormatter {
-  protected abstract _options: BaseFormatOptions;
+  protected abstract _options: Readonly<BaseFormatOptions>;
 
   digits(_d: number) {
-    this._options.digits = _d;
-    return this;
+    const newOptions = { ...this._options, digits: _d };
+
+    return this._clone(newOptions);
   }
 
   removeTrailingZero() {
-    this._options.removeTrailingZero = true;
-    return this;
+    const newOptions = { ...this._options, removeTrailingZero: true };
+
+    return this._clone(newOptions);
   }
 
   readable() {
-    this._options.readable = true;
-    return this;
+    const newOptions = { ...this._options, readable: true };
+
+    return this._clone(newOptions);
   }
 
   min(_m: number) {
-    this._options.min = _m;
-    return this;
+    const newOptions = { ...this._options, min: _m };
+
+    return this._clone(newOptions);
   }
 
   max(_m: number) {
-    this._options.max = _m;
-    return this;
+    const newOptions = { ...this._options, max: _m };
+
+    return this._clone(newOptions);
   }
 
   sign() {
-    this._options.sign = true;
-    return this;
+    const newOptions = { ...this._options, sign: true };
+
+    return this._clone(newOptions);
   }
 
   unit(_u: string) {
-    this._options.unit = _u;
-    return this;
+    const newOptions = { ...this._options, unit: _u };
+
+    return this._clone(newOptions);
   }
 
   locale(_l: string) {
-    this._options.locale = _l;
-    return this;
+    const newOptions = { ...this._options, locale: _l };
+
+    return this._clone(newOptions);
   }
 }
 
 export class NumberFormatter extends CommonFormatter {
-  protected _options: FormatNumberOptions = { format: Format.number };
+  protected _options: Readonly<FormatNumberOptions> = { format: Format.number };
 
   constructor(__options: Partial<FormatNumberOptions> = {}) {
     super();
     this._options = { ...this._options, ...__options };
   }
+
+  _clone(_options: FormatNumberOptions) {
+    return new NumberFormatter(_options) as this;
+  }
 }
 
 export class CommasFormatter extends CommonFormatter {
-  protected _options: FormatCommasOptions = { format: Format.commas };
+  protected _options: Readonly<FormatCommasOptions> = { format: Format.commas };
 
   constructor(__options: Partial<FormatCommasOptions> = {}) {
     super();
     this._options = { ...this._options, ...__options };
   }
+
+  _clone(_options: FormatCommasOptions) {
+    return new CommasFormatter(_options) as this;
+  }
 }
 
 export class ShortFormatter extends CommonFormatter {
-  protected _options: FormatShortOptions = { format: Format.short };
+  protected _options: Readonly<FormatShortOptions> = { format: Format.short };
 
   constructor(__options: Partial<FormatShortOptions> = {}) {
     super();
@@ -420,19 +443,28 @@ export class ShortFormatter extends CommonFormatter {
   }
 
   smallValuesWithCommas() {
-    this._options.smallValuesWithCommas = true;
-    return this;
+    const newOptions = { ...this._options, smallValuesWithCommas: true };
+
+    return this._clone(newOptions);
+  }
+
+  _clone(_options: FormatShortOptions) {
+    return new ShortFormatter(_options) as this;
   }
 }
 
 export class PercentFormatter extends CommonFormatter {
-  protected _options: FormatPercentOptions = {
+  protected _options: Readonly<FormatPercentOptions> = {
     format: Format.percent,
   };
 
   constructor(__options: Partial<FormatPercentOptions> = {}) {
     super();
     this._options = { ...this._options, ...__options };
+  }
+
+  _clone(_options: FormatPercentOptions) {
+    return new PercentFormatter(_options) as this;
   }
 }
 

--- a/packages/morpho-ts/test/format.test.ts
+++ b/packages/morpho-ts/test/format.test.ts
@@ -1,4 +1,4 @@
-import { createFormat, format } from "../src";
+import { Format, createFormat, format } from "../src";
 
 import { describe, expect, test } from "vitest";
 
@@ -9,37 +9,40 @@ describe("format", () => {
 
   describe("createFormat", () => {
     test("should properly initialize format options", () => {
-      const customFormat = createFormat({
-        all: { digits: 2, sign: true },
-        hex: { default: "default hex" },
-        number: {
-          sign: false,
-          unit: "number",
+      const customFormat = createFormat(
+        {
+          all: { digits: 2, sign: true },
+          hex: { default: "default hex" },
+          number: {
+            sign: false,
+            unit: "number",
+          },
+          short: {
+            sign: false,
+            unit: "short",
+            smallValuesWithCommas: true,
+          },
+          percent: {
+            sign: false,
+            unit: "percent",
+          },
+          commas: {
+            sign: false,
+            unit: "commas",
+          },
         },
-        short: {
-          sign: false,
-          unit: "short",
-          smallValuesWithCommas: true,
-        },
-        percent: {
-          sign: false,
-          unit: "percent",
-        },
-        commas: {
-          sign: false,
-          unit: "commas",
-        },
-      });
+        { custom: { format: Format.number, digits: 10, unit: "custom" } },
+      );
 
       //@ts-ignore
       const hexOptions = customFormat.hex._options;
-      expect(hexOptions.format).toBe("hex");
+      expect(hexOptions.format).toBe(Format.hex);
       expect(hexOptions.default).toBe("default hex");
       expect(hexOptions.prefix).toBe(false);
 
       //@ts-ignore
       const numberOptions = customFormat.number._options;
-      expect(numberOptions.format).toBe("number");
+      expect(numberOptions.format).toBe(Format.number);
       expect(numberOptions.unit).toBe("number");
       expect(numberOptions.sign).toBe(false);
       expect(numberOptions.digits).toBe(2);
@@ -47,7 +50,7 @@ describe("format", () => {
 
       //@ts-ignore
       const shortOptions = customFormat.short._options;
-      expect(shortOptions.format).toBe("short");
+      expect(shortOptions.format).toBe(Format.short);
       expect(shortOptions.unit).toBe("short");
       expect(shortOptions.sign).toBe(false);
       expect(shortOptions.digits).toBe(2);
@@ -56,7 +59,7 @@ describe("format", () => {
 
       //@ts-ignore
       const percentOptions = customFormat.percent._options;
-      expect(percentOptions.format).toBe("percent");
+      expect(percentOptions.format).toBe(Format.percent);
       expect(percentOptions.unit).toBe("percent");
       expect(percentOptions.sign).toBe(false);
       expect(percentOptions.digits).toBe(2);
@@ -64,11 +67,39 @@ describe("format", () => {
 
       //@ts-ignore
       const commasOptions = customFormat.commas._options;
-      expect(commasOptions.format).toBe("commas");
+      expect(commasOptions.format).toBe(Format.commas);
       expect(commasOptions.unit).toBe("commas");
       expect(commasOptions.sign).toBe(false);
       expect(commasOptions.digits).toBe(2);
       expect(commasOptions.default).toBe(undefined);
+
+      const customFormatter = customFormat.custom;
+      //@ts-ignore
+      const customOptions = customFormatter._options;
+      expect(customOptions.format).toBe(Format.number);
+      expect(customOptions.unit).toBe("custom");
+      expect(customOptions.sign).toBe(true);
+      expect(customOptions.digits).toBe(10);
+      expect(customOptions.default).toBe(undefined);
+    });
+
+    test("shouldn't create conflicts between formatters", () => {
+      const formatters = createFormat();
+
+      const formatter1 = formatters.number.digits(10);
+      const formatter2 = formatters.number.digits(0);
+      const formatter3 = formatter1.digits(5);
+
+      //@ts-ignore
+      const options1 = formatter1._options;
+      //@ts-ignore
+      const options2 = formatter2._options;
+      //@ts-ignore
+      const options3 = formatter3._options;
+
+      expect(options1.digits).toBe(10);
+      expect(options2.digits).toBe(0);
+      expect(options3.digits).toBe(5);
     });
   });
 
@@ -83,7 +114,7 @@ describe("format", () => {
     });
   });
 
-  describe("hex", () => {
+  describe(Format.hex, () => {
     describe("should properly format number in hex format", () => {
       test("without option", () => {
         expect(format.hex.of(number)).toEqual((123456789).toString(16));


### PR DESCRIPTION
2 things done here:
- Allow dev to create custom formatters via `createFormat` to avoid misusages
- Fix bug related to sibling formatters sharing configuration

eg: before this PR:

const formatter1 = format.number.digits(10);
const formatter2 = formatter1.digits(0); // this would also set `digits` to `0` in `formatter1`
