### PR TITLE
refactor(ethers-liquidation): export market position type

### DIFF
--- a/packages/blue-sdk-ethers-liquidation/src/api/types.ts
+++ b/packages/blue-sdk-ethers-liquidation/src/api/types.ts
@@ -9,40 +9,37 @@ export type GetLiquidatablePositionsQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
 }>;
 
+type Asset = {
+  __typename?: "Asset";
+  address: Types.Scalars["Address"]["output"];
+  decimals: number;
+  symbol: string;
+  priceUsd: number | null;
+  spotPriceEth: number | null;
+};
+
+export type MarketPosition = {
+  __typename?: "MarketPosition";
+  user: {
+    __typename?: "User";
+    address: Types.Scalars["Address"]["output"];
+  };
+  market: {
+    __typename?: "Market";
+    oracleAddress: Types.Scalars["Address"]["output"];
+    irmAddress: Types.Scalars["Address"]["output"];
+    lltv: Types.Scalars["BigInt"]["output"];
+    collateralAsset: Asset | null;
+    loanAsset: Asset;
+  };
+};
+
 export type GetLiquidatablePositionsQuery = {
   __typename?: "Query";
   assetByAddress: { __typename?: "Asset"; priceUsd: number | null };
   marketPositions: {
     __typename?: "PaginatedMarketPositions";
-    items: Array<{
-      __typename?: "MarketPosition";
-      user: {
-        __typename?: "User";
-        address: Types.Scalars["Address"]["output"];
-      };
-      market: {
-        __typename?: "Market";
-        oracleAddress: Types.Scalars["Address"]["output"];
-        irmAddress: Types.Scalars["Address"]["output"];
-        lltv: Types.Scalars["BigInt"]["output"];
-        collateralAsset: {
-          __typename?: "Asset";
-          address: Types.Scalars["Address"]["output"];
-          decimals: number;
-          symbol: string;
-          priceUsd: number | null;
-          spotPriceEth: number | null;
-        } | null;
-        loanAsset: {
-          __typename?: "Asset";
-          address: Types.Scalars["Address"]["output"];
-          decimals: number;
-          symbol: string;
-          priceUsd: number | null;
-          spotPriceEth: number | null;
-        };
-      };
-    }> | null;
+    items: Array<MarketPosition> | null;
   };
 };
 


### PR DESCRIPTION
Without this change, if you wanted to do something like this:
```ts
const {
  assetByAddress: { priceUsd: wethPriceUsd },
  marketPositions: { items: positions }
} = await apiSdk.getLiquidatablePositions({
  chainId: this.config.chainId,
  wNative,
  marketIds
});

if (wethPriceUsd == null) {
  return;
}

await Promise.all(
  positions.map((position) => {
    return processPosition(position, wethPriceUsd);
  })
);
```
And preserve the types, you had to create your own market position type or do tricks. 


```ts
async processPosition(
    position: MarketPosition, // Self-created Market position type
    wethPriceUsd: number
  ): Promise<PositionResult>
```
I believe it would be feasible to export the type right away to avoid this.

This is my first PR so I'm not familiar with the process of getting this merged. I built the package and used it locally which worked fine. This change should not be breaking because its the same types, just used/exported differently.

I tried running both `test-jest` and `test-hardhat` but for the latter I need an 1INCH API KEY.