### PR TITLE
refactor(liquidation-sdk-viem): export market position fragment

### DIFF
--- a/packages/liquidation-sdk-viem/graphql/GetLiquidatablePositions.query.gql
+++ b/packages/liquidation-sdk-viem/graphql/GetLiquidatablePositions.query.gql
@@ -17,26 +17,7 @@ query getLiquidatablePositions(
     }
   ) {
     items {
-      user {
-        address
-      }
-      market {
-        uniqueKey
-        collateralAsset {
-          address
-          decimals
-          symbol
-          priceUsd
-          spotPriceEth
-        }
-        loanAsset {
-          address
-          decimals
-          symbol
-          priceUsd
-          spotPriceEth
-        }
-      }
+      ...MarketPosition
     }
   }
 }

--- a/packages/liquidation-sdk-viem/graphql/MarketPosition.fragment.gql
+++ b/packages/liquidation-sdk-viem/graphql/MarketPosition.fragment.gql
@@ -1,0 +1,22 @@
+fragment MarketPosition on MarketPosition {
+  user {
+        address
+      }
+      market {
+        uniqueKey
+        collateralAsset {
+          address
+          decimals
+          symbol
+          priceUsd
+          spotPriceEth
+        }
+        loanAsset {
+          address
+          decimals
+          symbol
+          priceUsd
+          spotPriceEth
+        }
+      }
+}

--- a/packages/liquidation-sdk-viem/src/api/sdk.ts
+++ b/packages/liquidation-sdk-viem/src/api/sdk.ts
@@ -3,7 +3,30 @@ import * as Types from './types.js';
 import { GraphQLClient, RequestOptions } from 'graphql-request';
 import gql from 'graphql-tag';
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
-
+export const MarketPositionFragmentDoc = gql`
+    fragment MarketPosition on MarketPosition {
+  user {
+    address
+  }
+  market {
+    uniqueKey
+    collateralAsset {
+      address
+      decimals
+      symbol
+      priceUsd
+      spotPriceEth
+    }
+    loanAsset {
+      address
+      decimals
+      symbol
+      priceUsd
+      spotPriceEth
+    }
+  }
+}
+    `;
 export const GetLiquidatablePositionsDocument = gql`
     query getLiquidatablePositions($chainId: Int!, $wNative: String!, $marketIds: [String!], $first: Int = 1000) {
   assetByAddress(chainId: $chainId, address: $wNative) {
@@ -14,30 +37,11 @@ export const GetLiquidatablePositionsDocument = gql`
     where: {chainId_in: [$chainId], marketUniqueKey_in: $marketIds, healthFactor_lte: 1}
   ) {
     items {
-      user {
-        address
-      }
-      market {
-        uniqueKey
-        collateralAsset {
-          address
-          decimals
-          symbol
-          priceUsd
-          spotPriceEth
-        }
-        loanAsset {
-          address
-          decimals
-          symbol
-          priceUsd
-          spotPriceEth
-        }
-      }
+      ...MarketPosition
     }
   }
 }
-    `;
+    ${MarketPositionFragmentDoc}`;
 export const GetWhitelistedMarketIdsDocument = gql`
     query getWhitelistedMarketIds($chainId: Int!) {
   markets(where: {chainId_in: [$chainId], whitelisted: true}) {

--- a/packages/liquidation-sdk-viem/src/api/types.ts
+++ b/packages/liquidation-sdk-viem/src/api/types.ts
@@ -58,3 +58,28 @@ export type GetWhitelistedMarketIdsQuery = {
     }> | null;
   };
 };
+
+export type MarketPositionFragment = {
+  __typename?: "MarketPosition";
+  user: { __typename?: "User"; address: Types.Scalars["Address"]["output"] };
+  market: {
+    __typename?: "Market";
+    uniqueKey: Types.Scalars["MarketId"]["output"];
+    collateralAsset: {
+      __typename?: "Asset";
+      address: Types.Scalars["Address"]["output"];
+      decimals: number;
+      symbol: string;
+      priceUsd: number | null;
+      spotPriceEth: number | null;
+    } | null;
+    loanAsset: {
+      __typename?: "Asset";
+      address: Types.Scalars["Address"]["output"];
+      decimals: number;
+      symbol: string;
+      priceUsd: number | null;
+      spotPriceEth: number | null;
+    };
+  };
+};


### PR DESCRIPTION
Explanation can be found in the following PR https://github.com/morpho-org/sdks/pull/198

Now devs can import it as follows:
```ts
import {
  MarketPositionFragment as MarketPosition,
} from "@morpho-org/liquidation-sdk-viem";
```