### PR TITLE
feat(liquidity-loader): add parameters to loader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: foundry-rs/foundry-toolchain@v1.2.0
         with:
           cache: false
+          version: stable
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,9 @@ jobs:
           key: ${{ runner.os }}-foundry-chain-fork-${{ github.job }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-foundry-chain-fork-${{ github.job }}-
 
-      - uses: foundry-rs/foundry-toolchain@v1.2.0
+      - uses: foundry-rs/foundry-toolchain@v1
         with:
           cache: false
-          version: stable
 
       - run: pnpm install --frozen-lockfile
 

--- a/packages/liquidity-sdk-viem/src/loader.ts
+++ b/packages/liquidity-sdk-viem/src/loader.ts
@@ -18,17 +18,17 @@ import { getBlock } from "viem/actions";
 import { apiSdk } from "./api";
 
 export interface LiquidityParameters {
-  /* The delay to consider between the moment reallocations are calculated and the moment they are committed onchain. Defaults to 1h. */
+  /** The delay to consider between the moment reallocations are calculated and the moment they are committed onchain. Defaults to 1h. */
   delay?: bigint;
 
   /** The default maximum utilization allowed to reach to find shared liquidity (scaled by WAD). */
   defaultMaxWithdrawalUtilization?: bigint;
 
   /**
-   * - If `false`, `defaultMaxWithdrawalUtilization` is used for each market
-   * - If `true` (default), the value for maxWithdrawUtilization is taken per-market from morpho API
+   * If set, used to retrieve the max withdraw utilization for each market, defaulting to `defaultMaxWithdrawalUtilization`.
+   * If not, these values are fetched from morpho API
    */
-  fetchMaxWithdrawUtilizations?: boolean;
+  maxWithdrawalUtilization?: Record<MarketId, bigint>;
 }
 
 export class LiquidityLoader<chain extends Chain = Chain> {
@@ -46,8 +46,6 @@ export class LiquidityLoader<chain extends Chain = Chain> {
     public client: Client<Transport, chain>,
     public readonly parameters: LiquidityParameters = {},
   ) {
-    this.parameters.fetchMaxWithdrawUtilizations ??= true;
-
     this.dataLoader = new DataLoader(
       async (marketIds) => {
         const { client, parameters } = this;
@@ -207,17 +205,16 @@ export class LiquidityLoader<chain extends Chain = Chain> {
           ),
         });
 
-        const maxWithdrawalUtilization = this.parameters
-          .fetchMaxWithdrawUtilizations
-          ? fromEntries(
-              allVaultsMarkets.flatMap(([, markets]) =>
-                markets.map((market) => [
-                  market.uniqueKey,
-                  market.targetWithdrawUtilization,
-                ]),
-              ),
-            )
-          : undefined;
+        const maxWithdrawalUtilization =
+          this.parameters.maxWithdrawalUtilization ??
+          fromEntries(
+            allVaultsMarkets.flatMap(([, markets]) =>
+              markets.map((market) => [
+                market.uniqueKey,
+                market.targetWithdrawUtilization,
+              ]),
+            ),
+          );
 
         return apiMarkets.map(({ uniqueKey, targetBorrowUtilization }) => {
           try {

--- a/packages/liquidity-sdk-viem/src/loader.ts
+++ b/packages/liquidity-sdk-viem/src/loader.ts
@@ -26,7 +26,7 @@ export interface LiquidityParameters {
 
   /**
    * - If `false`, `defaultMaxWithdrawalUtilization` is used for each market
-   * - If `true`, the value for maxWithdrawUtilization is taken per-market from morpho API
+   * - If `true` (default), the value for maxWithdrawUtilization is taken per-market from morpho API
    */
   fetchMaxWithdrawUtilizations?: boolean;
 }
@@ -46,6 +46,8 @@ export class LiquidityLoader<chain extends Chain = Chain> {
     public client: Client<Transport, chain>,
     public readonly parameters: LiquidityParameters = {},
   ) {
+    this.parameters.fetchMaxWithdrawUtilizations ??= true;
+
     this.dataLoader = new DataLoader(
       async (marketIds) => {
         const { client, parameters } = this;

--- a/packages/liquidity-sdk-viem/src/loader.ts
+++ b/packages/liquidity-sdk-viem/src/loader.ts
@@ -25,8 +25,8 @@ export interface LiquidityParameters {
   defaultMaxWithdrawalUtilization?: bigint;
 
   /**
-   * If set, used to retrieve the max withdraw utilization for each market, defaulting to `defaultMaxWithdrawalUtilization`.
-   * If not, these values are fetched from morpho API
+   * If provided, defines the maximum utilization allowed to reach for each market, defaulting to `defaultMaxWithdrawalUtilization`.
+   * If not, these values are fetched from Morpho API.
    */
   maxWithdrawalUtilization?: Record<MarketId, bigint>;
 }


### PR DESCRIPTION
User should be able to use his own parameters to compute the shared liquidity. For exemple, interface is enforcing 100% max withdraw utilisation which is not possible with the current implem


TODO: It is currently not possible to filter reallocating vaults by fee for instance

Fixes INFRA-206