### PR TITLE
fix(liquidation-sdk-viem): fix fetching from Paraswap API

### DIFF
--- a/packages/liquidation-sdk-viem/examples/whitelisted-erc4626-1inch.ts
+++ b/packages/liquidation-sdk-viem/examples/whitelisted-erc4626-1inch.ts
@@ -255,7 +255,7 @@ export const check = async <
                       srcToken,
                       srcAmount,
                       market.params,
-                      slippage / 10n ** 16n,
+                      slippage / 10n ** 14n,
                       repaidAssets,
                       client.account.address,
                     );

--- a/packages/liquidation-sdk-viem/src/swap/1inch.ts
+++ b/packages/liquidation-sdk-viem/src/swap/1inch.ts
@@ -14,10 +14,15 @@ export namespace OneInch {
     apiKey = process.env.ONE_INCH_SWAP_API_KEY,
   ) {
     const url = new URL(getSwapApiPath(swapParams.chainId), API_BASE_URL);
-    url.searchParams.set("slippage", BigInt(swapParams.slippage).toString(16));
     Object.entries(swapParams).forEach(([key, value]) => {
-      if (value != null) {
-        url.searchParams.set(key, value.toString());
+      if (value == null) return;
+      switch (key) {
+        case "slippage":
+          // 1inch expects slippage as a percentage, so we divide our value (in basis points) by 100
+          url.searchParams.set(key, (Number(value) / 100).toString(10));
+          break;
+        default:
+          url.searchParams.set(key, value);
       }
     });
 

--- a/packages/liquidation-sdk-viem/src/swap/paraswap.ts
+++ b/packages/liquidation-sdk-viem/src/swap/paraswap.ts
@@ -22,14 +22,20 @@ export namespace Paraswap {
       side: SwapSide.SELL,
     });
 
-    const calldata = await paraSwap.swap.buildTx({
-      srcToken: swapParams.src,
-      destToken: swapParams.dst,
-      srcAmount: swapParams.amount.toString(),
-      userAddress: swapParams.from,
-      priceRoute: priceRoute,
-      slippage: Number(swapParams.slippage.toString(16)),
-    });
+    const calldata = await paraSwap.swap.buildTx(
+      {
+        srcToken: swapParams.src,
+        destToken: swapParams.dst,
+        srcAmount: swapParams.amount.toString(),
+        userAddress: swapParams.from,
+        priceRoute: priceRoute,
+        slippage: Number(swapParams.slippage.toString(16)),
+      },
+      {
+        // Necessary so that Paraswap skips balance checks (we won't have tokens until contract callback)
+        ignoreChecks: true,
+      },
+    );
 
     return {
       dstAmount: priceRoute.destAmount,


### PR DESCRIPTION
Fixes two things:

- Since the executooor contract doesn't have tokens until inside a callback, we have to tell Paraswap to skip balance checks by passing `{ ignoreChecks: true }`
- Paraswap API expects slippage in basis points; we were passing percentages