### PR TITLE
feat: add option to attach anvil logs to playwright report

### DIFF
--- a/packages/test/src/anvil.ts
+++ b/packages/test/src/anvil.ts
@@ -314,12 +314,6 @@ const basePort =
 
 let workerInstances = 0;
 
-export interface Props {
-  args: AnvilArgs;
-  index?: number;
-  callbacks?: AnvilProcessCallbacks;
-}
-
 export const spawnAnvil = async (
   args: AnvilArgs,
   index = workerInstances++,


### PR DESCRIPTION
- add option to attach anvil logs in `createViemTest` to playwright report. 

Can be seen here:
<img width="1378" alt="Screenshot 2025-02-27 at 15 15 15" src="https://github.com/user-attachments/assets/bba9a419-4747-4481-8d3d-aa1248ce72aa" />
