### PR TITLE
Fix/merge deep equal

### DIFF
--- a/packages/blue-sdk-wagmi/src/hooks/useHolding.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useHolding.ts
@@ -8,7 +8,7 @@ import {
   fetchHoldingQueryOptions,
 } from "../queries/fetchHolding.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UseHoldingParameters<
@@ -48,7 +48,7 @@ export function useHolding<
     ...options,
     enabled:
       parameters.user != null && parameters.token != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/useHoldings.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useHoldings.ts
@@ -8,7 +8,7 @@ import {
   fetchHoldingQueryOptions,
 } from "../queries/fetchHolding.js";
 import type { UseCompositeQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual, uniqBy } from "../utils/index.js";
+import { replaceDeepEqual, uniqBy } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type {
   UseHoldingParameters,
@@ -53,7 +53,7 @@ export function useHoldings<
         chainId,
       }),
       enabled: holding.user != null && holding.token != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -81,7 +81,7 @@ export function useHoldings<
   });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useMarket.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useMarket.ts
@@ -8,7 +8,7 @@ import {
   fetchMarketQueryOptions,
 } from "../queries/fetchMarket.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UseMarketParameters<
@@ -47,7 +47,7 @@ export function useMarket<
     ...query,
     ...options,
     enabled: parameters.marketId != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/useMarketParams.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useMarketParams.ts
@@ -8,7 +8,7 @@ import {
   fetchMarketParamsQueryOptions,
 } from "../queries/fetchMarketParams.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UseMarketParamsParameters<
@@ -48,6 +48,6 @@ export function useMarketParams<
     ...query,
     ...options,
     enabled: parameters.marketId != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
   });
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useMarkets.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useMarkets.ts
@@ -9,7 +9,7 @@ import {
   fetchMarketQueryOptions,
 } from "../queries/fetchMarket.js";
 import type { UseIndexedQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type { UseMarketParameters, UseMarketReturnType } from "./useMarket.js";
 
@@ -45,7 +45,7 @@ export function useMarkets<config extends Config = ResolvedRegister["config"]>({
         chainId,
       }),
       enabled: marketId != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -74,7 +74,7 @@ export function useMarkets<config extends Config = ResolvedRegister["config"]>({
     });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useMarketsParams.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useMarketsParams.ts
@@ -7,7 +7,7 @@ import { type Config, type ResolvedRegister, useConfig } from "wagmi";
 import { fetchMarketParamsQueryOptions } from "../queries/fetchMarketParams.js";
 import type { MarketParamsParameters } from "../queries/fetchMarketParams.js";
 import type { UseIndexedQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type {
   UseMarketParamsParameters,
@@ -48,7 +48,7 @@ export function useMarketsParams<
         chainId,
       }),
       enabled: marketId != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     })),
   });
 
@@ -73,7 +73,7 @@ export function useMarketsParams<
     });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/usePosition.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/usePosition.ts
@@ -8,7 +8,7 @@ import {
   fetchPositionQueryOptions,
 } from "../queries/fetchPosition.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UsePositionParameters<
@@ -51,7 +51,7 @@ export function usePosition<
     ...options,
     enabled:
       parameters.user != null && parameters.marketId != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/usePositions.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/usePositions.ts
@@ -8,7 +8,7 @@ import {
   fetchPositionQueryOptions,
 } from "../queries/fetchPosition.js";
 import type { UseCompositeQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual, uniqBy } from "../utils/index.js";
+import { replaceDeepEqual, uniqBy } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type {
   UsePositionParameters,
@@ -54,7 +54,7 @@ export function usePositions<
       }),
       enabled:
         position.user != null && position.marketId != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -82,7 +82,7 @@ export function usePositions<
   });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useReadContracts.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useReadContracts.ts
@@ -1,6 +1,6 @@
 import type { Abi, ContractFunctionArgs, ContractFunctionName } from "viem";
 import { type ReadContractData, readContractQueryOptions } from "wagmi/query";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 
 import { useQueries } from "@tanstack/react-query";
 import {
@@ -84,7 +84,7 @@ export function useReadContracts<
         ...query,
         ...options,
         enabled,
-        structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+        structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       };
     }),
   });

--- a/packages/blue-sdk-wagmi/src/hooks/useToken.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useToken.ts
@@ -8,7 +8,7 @@ import {
   fetchTokenQueryOptions,
 } from "../queries/fetchToken.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UseTokenParameters<
@@ -42,7 +42,7 @@ export function useToken<
     ...query,
     ...options,
     enabled: parameters.token != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/useTokens.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useTokens.ts
@@ -8,7 +8,7 @@ import {
   fetchTokenQueryOptions,
 } from "../queries/fetchToken.js";
 import type { UseIndexedQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type { UseTokenParameters, UseTokenReturnType } from "./useToken.js";
 
@@ -44,7 +44,7 @@ export function useTokens<config extends Config = ResolvedRegister["config"]>({
         chainId,
       }),
       enabled: token != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -73,7 +73,7 @@ export function useTokens<config extends Config = ResolvedRegister["config"]>({
     });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useUser.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useUser.ts
@@ -8,7 +8,7 @@ import {
   fetchUserQueryOptions,
 } from "../queries/fetchUser.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UseUserParameters<
@@ -42,7 +42,7 @@ export function useUser<
     ...query,
     ...options,
     enabled: parameters.user != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/useUsers.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useUsers.ts
@@ -8,7 +8,7 @@ import {
   fetchUserQueryOptions,
 } from "../queries/fetchUser.js";
 import type { UseIndexedQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type { UseUserParameters, UseUserReturnType } from "./useUser.js";
 
@@ -44,7 +44,7 @@ export function useUsers<config extends Config = ResolvedRegister["config"]>({
         chainId,
       }),
       enabled: user != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -73,7 +73,7 @@ export function useUsers<config extends Config = ResolvedRegister["config"]>({
     });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useVault.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVault.ts
@@ -8,7 +8,7 @@ import {
   fetchVaultQueryOptions,
 } from "../queries/fetchVault.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UseVaultParameters<
@@ -42,7 +42,7 @@ export function useVault<
     ...query,
     ...options,
     enabled: parameters.vault != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/useVaultConfig.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVaultConfig.ts
@@ -2,7 +2,7 @@ import type { VaultConfig } from "@morpho-org/blue-sdk";
 import type { ReadContractErrorType } from "viem";
 import { type Config, type ResolvedRegister, useConfig } from "wagmi";
 import { type UseQueryReturnType, useQuery } from "wagmi/query";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 
 import {
   type FetchVaultConfigParameters,
@@ -49,6 +49,6 @@ export function useVaultConfig<
     ...query,
     ...options,
     enabled: parameters.vault != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
   });
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useVaultConfigs.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVaultConfigs.ts
@@ -8,7 +8,7 @@ import {
   fetchVaultConfigQueryOptions,
 } from "../queries/fetchVaultConfig.js";
 import type { UseIndexedQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type {
   UseVaultConfigParameters,
@@ -49,7 +49,7 @@ export function useVaultConfigs<
         chainId,
       }),
       enabled: vault != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     })),
   });
 
@@ -74,7 +74,7 @@ export function useVaultConfigs<
     });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useVaultMarketConfig.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVaultMarketConfig.ts
@@ -8,7 +8,7 @@ import {
   fetchVaultMarketConfigQueryOptions,
 } from "../queries/fetchVaultMarketConfig.js";
 import type { ConfigParameter, QueryParameter } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 
 export type UseVaultMarketConfigParameters<
@@ -49,7 +49,7 @@ export function useVaultMarketConfig<
     ...options,
     enabled:
       parameters.vault != null && parameters.marketId != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/useVaultMarketConfigs.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVaultMarketConfigs.ts
@@ -8,7 +8,7 @@ import {
   fetchVaultMarketConfigQueryOptions,
 } from "../queries/fetchVaultMarketConfig.js";
 import type { UseCompositeQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual, uniqBy } from "../utils/index.js";
+import { replaceDeepEqual, uniqBy } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type {
   UseVaultMarketConfigParameters,
@@ -59,7 +59,7 @@ export function useVaultMarketConfigs<
         vaultMarketConfig.vault != null &&
         vaultMarketConfig.marketId != null &&
         query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -87,7 +87,7 @@ export function useVaultMarketConfigs<
   });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useVaultUser.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVaultUser.ts
@@ -2,7 +2,7 @@ import type { VaultUser } from "@morpho-org/blue-sdk";
 import type { ReadContractErrorType } from "viem";
 import { type Config, type ResolvedRegister, useConfig } from "wagmi";
 import { type UseQueryReturnType, useQuery } from "wagmi/query";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 
 import {
   type FetchVaultUserParameters,
@@ -52,7 +52,7 @@ export function useVaultUser<
     ...options,
     enabled:
       parameters.vault != null && parameters.user != null && query.enabled,
-    structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+    structuralSharing: query.structuralSharing ?? replaceDeepEqual,
     staleTime:
       (query.staleTime ?? parameters.blockNumber != null)
         ? Number.POSITIVE_INFINITY

--- a/packages/blue-sdk-wagmi/src/hooks/useVaultUsers.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVaultUsers.ts
@@ -7,7 +7,7 @@ import {
   fetchVaultUserQueryOptions,
 } from "../queries/fetchVaultUser.js";
 import type { UseCompositeQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual, uniqBy } from "../utils/index.js";
+import { replaceDeepEqual, uniqBy } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type {
   UseVaultUserParameters,
@@ -53,7 +53,7 @@ export function useVaultUsers<
         chainId,
       }),
       enabled: vault != null && user != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -81,7 +81,7 @@ export function useVaultUsers<
   });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/hooks/useVaults.ts
+++ b/packages/blue-sdk-wagmi/src/hooks/useVaults.ts
@@ -8,7 +8,7 @@ import {
   fetchVaultQueryOptions,
 } from "../queries/fetchVault.js";
 import type { UseIndexedQueriesReturnType } from "../types/index.js";
-import { mergeDeepEqual } from "../utils/index.js";
+import { replaceDeepEqual } from "../utils/index.js";
 import { useChainId } from "./useChainId.js";
 import type { UseVaultParameters, UseVaultReturnType } from "./useVault.js";
 
@@ -44,7 +44,7 @@ export function useVaults<config extends Config = ResolvedRegister["config"]>({
         chainId,
       }),
       enabled: vault != null && query.enabled,
-      structuralSharing: query.structuralSharing ?? mergeDeepEqual,
+      structuralSharing: query.structuralSharing ?? replaceDeepEqual,
       staleTime:
         (query.staleTime ?? parameters.blockNumber != null)
           ? Number.POSITIVE_INFINITY
@@ -73,7 +73,7 @@ export function useVaults<config extends Config = ResolvedRegister["config"]>({
     });
 
   const resultRef = useRef(result);
-  resultRef.current = mergeDeepEqual(resultRef.current, result);
+  resultRef.current = replaceDeepEqual(resultRef.current, result);
 
   return resultRef.current;
 }

--- a/packages/blue-sdk-wagmi/src/utils/index.ts
+++ b/packages/blue-sdk-wagmi/src/utils/index.ts
@@ -1,2 +1,2 @@
-export * from "./mergeDeepEqual.js";
+export * from "./replaceDeepEqual.js";
 export * from "./uniqBy.js";

--- a/packages/blue-sdk-wagmi/src/utils/mergeDeepEqual.ts
+++ b/packages/blue-sdk-wagmi/src/utils/mergeDeepEqual.ts
@@ -37,10 +37,15 @@ export function mergeDeepEqual(a: any, b: any): any {
 
   let equalItems = 0;
 
-  for (let i = 0; i < bSize; i++) {
-    const key = array ? i : bItems[i];
+  for (let i = 0; i < aSize; i++) {
+    const key = array ? i : aItems[i];
+
+    if (!array && !bItems.includes(key)) {
+      delete copy[key];
+      continue;
+    }
     if (
-      ((!array && aItems.includes(key)) || array) &&
+      ((!array && bItems.includes(key)) || array) &&
       a[key] === undefined &&
       b[key] === undefined
     ) {

--- a/packages/blue-sdk-wagmi/src/utils/replaceDeepEqual.ts
+++ b/packages/blue-sdk-wagmi/src/utils/replaceDeepEqual.ts
@@ -8,9 +8,9 @@ export function isPlainArray(value: unknown) {
  * This can be used for structural sharing between JSON values for example.
  * It may be unsafe to use with JS classes or other non-plain objects because it will not preserve the prototype chain.
  */
-export function mergeDeepEqual<T>(a: unknown, b: T): T;
+export function replaceDeepEqual<T>(a: unknown, b: T): T;
 // biome-ignore lint/suspicious/noExplicitAny: safe implementation
-export function mergeDeepEqual(a: any, b: any): any {
+export function replaceDeepEqual(a: any, b: any): any {
   if (a === b) return a;
 
   if (
@@ -52,7 +52,7 @@ export function mergeDeepEqual(a: any, b: any): any {
       copy[key] = undefined;
       equalItems++;
     } else {
-      copy[key] = mergeDeepEqual(a[key], b[key]);
+      copy[key] = replaceDeepEqual(a[key], b[key]);
       if (copy[key] === a[key] && a[key] !== undefined) {
         equalItems++;
       }

--- a/packages/blue-sdk-wagmi/src/utils/replaceDeepEqual.ts
+++ b/packages/blue-sdk-wagmi/src/utils/replaceDeepEqual.ts
@@ -37,15 +37,10 @@ export function replaceDeepEqual(a: any, b: any): any {
 
   let equalItems = 0;
 
-  for (let i = 0; i < aSize; i++) {
-    const key = array ? i : aItems[i];
-
-    if (!array && !bItems.includes(key)) {
-      delete copy[key];
-      continue;
-    }
+  for (let i = 0; i < bSize; i++) {
+    const key = array ? i : bItems[i];
     if (
-      ((!array && bItems.includes(key)) || array) &&
+      ((!array && aItems.includes(key)) || array) &&
       a[key] === undefined &&
       b[key] === undefined
     ) {
@@ -57,6 +52,11 @@ export function replaceDeepEqual(a: any, b: any): any {
         equalItems++;
       }
     }
+  }
+
+  for (let i = 0; i < aSize; i++) {
+    const key = array ? i : aItems[i];
+    if (!array && !bItems.includes(key)) delete copy[key];
   }
 
   return aSize === bSize && equalItems === aSize ? a : copy;

--- a/packages/blue-sdk-wagmi/test/unit/structuralSharing.test.ts
+++ b/packages/blue-sdk-wagmi/test/unit/structuralSharing.test.ts
@@ -1,7 +1,7 @@
 import { Market, MarketParams } from "@morpho-org/blue-sdk";
 import { replaceEqualDeep } from "@tanstack/query-core";
 import { describe, expect } from "vitest";
-import { mergeDeepEqual } from "../../src/index.js";
+import { replaceDeepEqual } from "../../src/index.js";
 import { test } from "../e2e/setup.js";
 
 const prevMarket = new Market({
@@ -46,7 +46,7 @@ describe("structuralSharing", () => {
   });
 
   test("mergeDeepEqual should be optimal with classes", () => {
-    const merged = mergeDeepEqual(prevMarket, newMarket);
+    const merged = replaceDeepEqual(prevMarket, newMarket);
 
     expect(merged).toBe(prevMarket);
     expect(Object.getPrototypeOf(merged)).toBe(
@@ -68,7 +68,7 @@ describe("structuralSharing", () => {
   test("mergeDeepEqual should update reference if at least one reference changed", () => {
     newMarket.fee = 1n;
 
-    const merged = mergeDeepEqual(prevMarket, newMarket);
+    const merged = replaceDeepEqual(prevMarket, newMarket);
 
     expect(merged).not.toBe(prevMarket);
     expect(merged.params).toBe(prevMarket.params);
@@ -88,7 +88,7 @@ describe("structuralSharing", () => {
   test("mergeDeepEqual should work with arrays", () => {
     newMarket.fee = 1n;
 
-    const merged = mergeDeepEqual([prevMarket], [newMarket])[0]!;
+    const merged = replaceDeepEqual([prevMarket], [newMarket])[0]!;
 
     expect(merged).not.toBe(prevMarket);
     expect(merged.params).toBe(prevMarket.params);
@@ -112,7 +112,7 @@ describe("structuralSharing", () => {
     };
     const a = { ...b, property3: "property3" };
 
-    const merged = mergeDeepEqual(a, b);
+    const merged = replaceDeepEqual(a, b);
 
     expect(merged).not.toBe(a);
     expect(merged).not.toBe(b);

--- a/packages/blue-sdk-wagmi/test/unit/structuralSharing.test.ts
+++ b/packages/blue-sdk-wagmi/test/unit/structuralSharing.test.ts
@@ -104,4 +104,18 @@ describe("structuralSharing", () => {
     // biome-ignore lint/suspicious/noPrototypeBuiltins: inside test
     expect(merged.constructor.prototype.isPrototypeOf(prevMarket)).toBe(true);
   });
+
+  test("mergeDeepEqual should update reference if b is a subset of a", () => {
+    const b = {
+      property1: "property1",
+      property2: "property2",
+    };
+    const a = { ...b, property3: "property3" };
+
+    const merged = mergeDeepEqual(a, b);
+
+    expect(merged).not.toBe(a);
+    expect(merged).not.toBe(b);
+    expect(merged).toEqual(b);
+  });
 });


### PR DESCRIPTION
In the previous behaviour, we had the following issue:

```ts
const objA = {
    a: "1",
    b: "2",
    c: "3"
}

const objB = {
    a: "1B",
    b: "2B"
}

//With the current behaviour of `mergeDeepEqual`:

let objC = mergeDeepEqual(objA, objB);

/* objC =  {
    a: "1B",
    b: "2B",
    c: "3"
} */


objC = mergeDeepEqual(objC, objB);

/* Since sizes of objC and objB are different, mergeDeepEqual creates a new ojbect even if neither objC nor objB changed

objC =  {
    a: "1B",
    b: "2B",
    c: "3"
}
    
*/

objC = mergeDeepEqual(objC, objB); // New reference but same object
objC = mergeDeepEqual(objC, objB); // New reference but same object
objC = mergeDeepEqual(objC, objB); // New reference but same object
objC = mergeDeepEqual(objC, objB); // New reference but same object
objC = mergeDeepEqual(objC, objB); // New reference but same object
objC = mergeDeepEqual(objC, objB); // New reference but same object
objC = mergeDeepEqual(objC, objB); // New reference but same object
//...·
```