### PR TITLE
fix(bundler-sdk-viem): remove duplicates native transfer

### DIFF
--- a/packages/bundler-sdk-viem/src/BundlerAction.ts
+++ b/packages/bundler-sdk-viem/src/BundlerAction.ts
@@ -63,7 +63,6 @@ export namespace BundlerAction {
     } = getChainAddresses(chainId);
 
     let value = 0n;
-    let generalAdapter1Value = 0n;
 
     for (const { type, args } of actions) {
       if (type !== "nativeTransfer") continue;
@@ -76,22 +75,11 @@ export namespace BundlerAction {
         (recipient === bundler3 || recipient === generalAdapter1)
       )
         value += amount;
-
-      if (owner !== generalAdapter1 && recipient === generalAdapter1)
-        generalAdapter1Value += amount;
     }
 
     const encodedActions = actions.flatMap(
       BundlerAction.encode.bind(null, chainId),
     );
-    if (generalAdapter1Value > 0n)
-      encodedActions.unshift({
-        to: generalAdapter1,
-        value: generalAdapter1Value,
-        data: "0x",
-        skipRevert: false,
-        callbackHash: zeroHash,
-      });
 
     return {
       to: bundler3,

--- a/packages/bundler-sdk-viem/test/helpers.ts
+++ b/packages/bundler-sdk-viem/test/helpers.ts
@@ -70,6 +70,7 @@ export const setupTestBundle = async <chain extends Chain = Chain>(
   {
     account: account_ = client.account,
     onBundleTx,
+    gasPrice,
     ...options
   }: BundlingOptions & {
     account?: Address | Account;
@@ -77,6 +78,7 @@ export const setupTestBundle = async <chain extends Chain = Chain>(
     unwrapTokens?: Set<Address>;
     unwrapSlippage?: bigint;
     onBundleTx?: (data: SimulationState) => Promise<void> | void;
+    gasPrice?: bigint;
   } = {},
 ) => {
   const account = parseAccount(account_);
@@ -142,7 +144,7 @@ export const setupTestBundle = async <chain extends Chain = Chain>(
   for (const tx of bundle.txs()) {
     await client.sendTransaction(
       // @ts-ignore
-      { ...tx, account },
+      { ...tx, account, gasPrice },
     );
   }
 


### PR DESCRIPTION
This line was adding a duplicate transfer since native transfer is already handled from the action