### PR TITLE
feat(morpho-test): add convertToAssets method to AnvilTestClient

### DIFF
--- a/packages/test/src/client.ts
+++ b/packages/test/src/client.ts
@@ -71,6 +71,10 @@ export type AnvilTestClient<chain extends Chain = Chain> = Client<
         erc4626: Address;
         assets: bigint;
       }): Promise<bigint>;
+      convertToAssets(args: {
+        erc4626: Address;
+        shares: bigint;
+      }): Promise<bigint>;
       deposit(args: DepositParameters<chain>): Promise<WriteContractReturnType>;
 
       deployContractWait<const abi extends Abi | readonly unknown[]>(
@@ -208,6 +212,17 @@ export const createAnvilTestClient = <chain extends Chain>(
             abi: erc4626Abi,
             functionName: "convertToShares",
             args: [assets],
+          });
+        },
+        async convertToAssets({
+          erc4626,
+          shares,
+        }: { erc4626: Address; shares: bigint }) {
+          return client.readContract({
+            address: erc4626,
+            abi: erc4626Abi,
+            functionName: "convertToAssets",
+            args: [shares],
           });
         },
         async deposit<chainOverride extends Chain | undefined = undefined>(


### PR DESCRIPTION
## Motivation

The purpose of this PR is to add the `convertToAssets` function to the anvil test client. In the frontend we are doing `client.convertToShares`. I want to be able to do `client.convertToAssets` for my migrations e2e tests. I could do `.readContract(....)` but it is not iso with the rest of our tests.

## Solution

- Added `convertToAssets` in the interface and added the function definition.
