### PR TITLE
Refactor/prevent existing addresses overiding

### DIFF
--- a/packages/blue-sdk/README.md
+++ b/packages/blue-sdk/README.md
@@ -146,7 +146,7 @@ Extends the default address registry and unwrapped token mapping for known or cu
 
 ```ts
 registerCustomAddresses(options?: {
-  customAddresses?: Record<number, ChainAddresses>; // Can be a subset of ChainAddresses if chain is known
+  addresses?: Record<number, ChainAddresses>; // Can be a subset of ChainAddresses if chain is known
   unwrappedTokens?: Record<number, Record<Address, Address>>;
 }): void
 ```
@@ -155,7 +155,7 @@ registerCustomAddresses(options?: {
 
 ##### **Parameters**
 
-- `customAddresses` *(optional)*  
+- `addresses` *(optional)*  
   A map of `chainId → ChainAddresses`.  
   - For **known chains**, partial overrides are allowed (e.g., add a missing adapter).
   - For **unknown chains**, a complete `ChainAddresses` object with required addresses must be provided.
@@ -180,7 +180,7 @@ registerCustomAddresses(options?: {
 
 ```ts
 registerCustomAddresses({
-  customAddresses: {
+  addresses: {
     8453: { stEth: "0xabc..." }, // provide stEth address on base
     31337: {
       morpho: "0x123...",

--- a/packages/blue-sdk/package.json
+++ b/packages/blue-sdk/package.json
@@ -20,8 +20,10 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.6.1",
-    "@types/lodash": "^4.17.12",
-    "lodash": "^4.17.21"
+    "@types/lodash.isplainobject": "^4.0.9",
+    "@types/lodash.mergewith": "^4.6.9",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.mergewith": "^4.6.2"
   },
   "peerDependencies": {
     "@morpho-org/morpho-ts": "workspace:^"

--- a/packages/blue-sdk/package.json
+++ b/packages/blue-sdk/package.json
@@ -19,7 +19,9 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@noble/hashes": "^1.6.1"
+    "@noble/hashes": "^1.6.1",
+    "@types/lodash": "^4.17.12",
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "@morpho-org/morpho-ts": "workspace:^"

--- a/packages/blue-sdk/src/addresses.ts
+++ b/packages/blue-sdk/src/addresses.ts
@@ -381,10 +381,7 @@ export const getChainAddresses = (chainId: number): ChainAddresses => {
  * Assumptions:
  * - unwrapped token has same number of decimals than wrapped tokens.
  */
-export const unwrappedTokensMapping: Record<
-  ChainId,
-  Record<Address, Address>
-> = {
+const _unwrappedTokensMapping: Record<ChainId, Record<Address, Address>> = {
   [ChainId.EthMainnet]: {
     [_addressesRegistry[ChainId.EthMainnet].wbIB01]:
       _addressesRegistry[ChainId.EthMainnet].bIB01,
@@ -507,11 +504,15 @@ export const convexWrapperTokens: Record<number, Set<Address>> = {
 
 export let addressesRegistry = Object.freeze(_addressesRegistry);
 export let addresses = addressesRegistry as Record<number, ChainAddresses>;
+export let unwrappedTokensMapping = Object.freeze(_unwrappedTokensMapping);
 
 export function registerCustomAddresses(
   customAddresses:
     | Record<keyof typeof _addressesRegistry, DeepPartial<ChainAddresses>>
-    | Record<number, ChainAddresses>,
+    | Record<number, ChainAddresses> = {},
+  {
+    unwrappedTokens,
+  }: { unwrappedTokens?: Record<number, Record<Address, Address>> } = {},
 ) {
   // biome-ignore lint/suspicious/noExplicitAny: type is not trivial and not important here
   const customizer = (objValue: any, _srcValue: any, key: string) => {
@@ -522,4 +523,9 @@ export function registerCustomAddresses(
   addresses = addressesRegistry = Object.freeze(
     mergeWith({}, _addressesRegistry, customAddresses, customizer),
   );
+
+  if (unwrappedTokens)
+    unwrappedTokensMapping = Object.freeze(
+      mergeWith({}, _unwrappedTokensMapping, unwrappedTokens, customizer),
+    );
 }

--- a/packages/blue-sdk/src/addresses.ts
+++ b/packages/blue-sdk/src/addresses.ts
@@ -1,6 +1,7 @@
 import {
   type DeepPartial,
   type DottedKeys,
+  deepFreeze,
   entries,
 } from "@morpho-org/morpho-ts";
 import isPlainObject from "lodash.isplainobject";
@@ -489,9 +490,9 @@ export const convexWrapperTokens: Record<number, Set<Address>> = {
   ]),
 };
 
-export let addressesRegistry = Object.freeze(_addressesRegistry);
+export let addressesRegistry = deepFreeze(_addressesRegistry);
 export let addresses = addressesRegistry as Record<number, ChainAddresses>;
-export let unwrappedTokensMapping = Object.freeze(_unwrappedTokensMapping);
+export let unwrappedTokensMapping = deepFreeze(_unwrappedTokensMapping);
 
 /**
  * Registers custom addresses and unwrapped token mappings to extend
@@ -538,12 +539,12 @@ export function registerCustomAddresses({
   };
 
   if (customAddresses)
-    addresses = addressesRegistry = Object.freeze(
+    addresses = addressesRegistry = deepFreeze(
       mergeWith({}, addressesRegistry, customAddresses, customizer),
     );
 
   if (unwrappedTokens)
-    unwrappedTokensMapping = Object.freeze(
+    unwrappedTokensMapping = deepFreeze(
       mergeWith({}, unwrappedTokensMapping, unwrappedTokens, customizer),
     );
 }

--- a/packages/blue-sdk/src/addresses.ts
+++ b/packages/blue-sdk/src/addresses.ts
@@ -506,23 +506,25 @@ export let addressesRegistry = Object.freeze(_addressesRegistry);
 export let addresses = addressesRegistry as Record<number, ChainAddresses>;
 export let unwrappedTokensMapping = Object.freeze(_unwrappedTokensMapping);
 
-export function registerCustomAddresses(
-  customAddresses:
+export function registerCustomAddresses({
+  unwrappedTokens,
+  customAddresses,
+}: {
+  unwrappedTokens?: Record<number, Record<Address, Address>>;
+  customAddresses?:
     | Record<keyof typeof _addressesRegistry, DeepPartial<ChainAddresses>>
-    | Record<number, ChainAddresses> = {},
-  {
-    unwrappedTokens,
-  }: { unwrappedTokens?: Record<number, Record<Address, Address>> } = {},
-) {
+    | Record<number, ChainAddresses>;
+} = {}) {
   // biome-ignore lint/suspicious/noExplicitAny: type is not trivial and not important here
   const customizer = (objValue: any, _srcValue: any, key: string) => {
     if (objValue !== undefined && !isPlainObject(objValue))
       throw new Error(`Cannot override existing address: ${key}`);
   };
 
-  addresses = addressesRegistry = Object.freeze(
-    mergeWith({}, _addressesRegistry, customAddresses, customizer),
-  );
+  if (customAddresses)
+    addresses = addressesRegistry = Object.freeze(
+      mergeWith({}, _addressesRegistry, customAddresses, customizer),
+    );
 
   if (unwrappedTokens)
     unwrappedTokensMapping = Object.freeze(

--- a/packages/blue-sdk/src/addresses.ts
+++ b/packages/blue-sdk/src/addresses.ts
@@ -1,5 +1,10 @@
-import { type DottedKeys, entries } from "@morpho-org/morpho-ts";
-
+import {
+  type DeepPartial,
+  type DottedKeys,
+  entries,
+} from "@morpho-org/morpho-ts";
+import isPlainObject from "lodash/isPlainObject";
+import mergeWith from "lodash/mergeWith";
 import { ChainId } from "./chain.js";
 import { UnsupportedChainIdError } from "./errors.js";
 import type { Address } from "./types.js";
@@ -54,7 +59,7 @@ export interface ChainAddresses {
   wstEth?: Address;
 }
 
-export const addressesRegistry = {
+const _addressesRegistry = {
   [ChainId.EthMainnet]: {
     morpho: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
     permit2: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
@@ -363,9 +368,9 @@ export const addressesRegistry = {
   },
 } as const;
 
-export const addresses = addressesRegistry as Record<number, ChainAddresses>;
+export const addresses = _addressesRegistry as Record<number, ChainAddresses>;
 
-export type AddressLabel = DottedKeys<(typeof addressesRegistry)[ChainId]>;
+export type AddressLabel = DottedKeys<(typeof _addressesRegistry)[ChainId]>;
 
 export const getChainAddresses = (chainId: number): ChainAddresses => {
   const chainAddresses = addresses[chainId];
@@ -383,33 +388,34 @@ export const unwrappedTokensMapping: Record<
   Record<Address, Address>
 > = {
   [ChainId.EthMainnet]: {
-    [addressesRegistry[ChainId.EthMainnet].wbIB01]:
-      addressesRegistry[ChainId.EthMainnet].bIB01,
-    [addressesRegistry[ChainId.EthMainnet].wbC3M]:
-      addressesRegistry[ChainId.EthMainnet].bC3M,
-    [addressesRegistry[ChainId.EthMainnet].wNative]: NATIVE_ADDRESS,
-    [addressesRegistry[ChainId.EthMainnet].stEth]: NATIVE_ADDRESS,
-    [addressesRegistry[ChainId.EthMainnet].wstEth]:
-      addressesRegistry[ChainId.EthMainnet].stEth,
-    [addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDTWBTCWETH-morpho"]]:
-      addressesRegistry[ChainId.EthMainnet].crvUSDTWBTCWETH,
-    [addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDCWBTCWETH-morpho"]]:
-      addressesRegistry[ChainId.EthMainnet].crvUSDCWBTCWETH,
-    [addressesRegistry[ChainId.EthMainnet]["stkcvxcrvCRVUSDTBTCWSTETH-morpho"]]:
-      addressesRegistry[ChainId.EthMainnet].crvCRVUSDTBTCWSTETH,
-    [addressesRegistry[ChainId.EthMainnet]["stkcvxTryLSD-morpho"]]:
-      addressesRegistry[ChainId.EthMainnet].tryLSD,
-    [addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDETHCRV-morpho"]]:
-      addressesRegistry[ChainId.EthMainnet].crvUSDETHCRV,
-    [addressesRegistry[ChainId.EthMainnet]["stkcvx2BTC-f-morpho"]]:
-      addressesRegistry[ChainId.EthMainnet]["2BTC-f"],
+    [_addressesRegistry[ChainId.EthMainnet].wbIB01]:
+      _addressesRegistry[ChainId.EthMainnet].bIB01,
+    [_addressesRegistry[ChainId.EthMainnet].wbC3M]:
+      _addressesRegistry[ChainId.EthMainnet].bC3M,
+    [_addressesRegistry[ChainId.EthMainnet].wNative]: NATIVE_ADDRESS,
+    [_addressesRegistry[ChainId.EthMainnet].stEth]: NATIVE_ADDRESS,
+    [_addressesRegistry[ChainId.EthMainnet].wstEth]:
+      _addressesRegistry[ChainId.EthMainnet].stEth,
+    [_addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDTWBTCWETH-morpho"]]:
+      _addressesRegistry[ChainId.EthMainnet].crvUSDTWBTCWETH,
+    [_addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDCWBTCWETH-morpho"]]:
+      _addressesRegistry[ChainId.EthMainnet].crvUSDCWBTCWETH,
+    [_addressesRegistry[ChainId.EthMainnet][
+      "stkcvxcrvCRVUSDTBTCWSTETH-morpho"
+    ]]: _addressesRegistry[ChainId.EthMainnet].crvCRVUSDTBTCWSTETH,
+    [_addressesRegistry[ChainId.EthMainnet]["stkcvxTryLSD-morpho"]]:
+      _addressesRegistry[ChainId.EthMainnet].tryLSD,
+    [_addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDETHCRV-morpho"]]:
+      _addressesRegistry[ChainId.EthMainnet].crvUSDETHCRV,
+    [_addressesRegistry[ChainId.EthMainnet]["stkcvx2BTC-f-morpho"]]:
+      _addressesRegistry[ChainId.EthMainnet]["2BTC-f"],
   },
   [ChainId.BaseMainnet]: {
-    [addressesRegistry[ChainId.BaseMainnet].wNative]: NATIVE_ADDRESS,
-    [addressesRegistry[ChainId.BaseMainnet].verUsdc]:
-      addressesRegistry[ChainId.BaseMainnet].usdc,
-    [addressesRegistry[ChainId.BaseMainnet].testUsdc]:
-      addressesRegistry[ChainId.BaseMainnet].usdc,
+    [_addressesRegistry[ChainId.BaseMainnet].wNative]: NATIVE_ADDRESS,
+    [_addressesRegistry[ChainId.BaseMainnet].verUsdc]:
+      _addressesRegistry[ChainId.BaseMainnet].usdc,
+    [_addressesRegistry[ChainId.BaseMainnet].testUsdc]:
+      _addressesRegistry[ChainId.BaseMainnet].usdc,
   },
   [ChainId.PolygonMainnet]: {},
   [ChainId.ArbitrumMainnet]: {},
@@ -441,7 +447,7 @@ export const erc20WrapperTokens: Record<number, Set<Address>> = {};
  */
 export const permissionedWrapperTokens: Record<number, Set<Address>> = {
   [ChainId.BaseMainnet]: new Set([
-    addressesRegistry[ChainId.BaseMainnet].testUsdc,
+    _addressesRegistry[ChainId.BaseMainnet].testUsdc,
   ]),
 };
 
@@ -451,8 +457,8 @@ export const permissionedWrapperTokens: Record<number, Set<Address>> = {
  */
 export const permissionedBackedTokens: Record<number, Set<Address>> = {
   [ChainId.EthMainnet]: new Set([
-    addressesRegistry[ChainId.EthMainnet].wbIB01,
-    addressesRegistry[ChainId.EthMainnet].wbC3M,
+    _addressesRegistry[ChainId.EthMainnet].wbIB01,
+    _addressesRegistry[ChainId.EthMainnet].wbC3M,
   ]),
 };
 
@@ -462,7 +468,7 @@ export const permissionedBackedTokens: Record<number, Set<Address>> = {
  */
 export const permissionedCoinbaseTokens: Record<number, Set<Address>> = {
   [ChainId.BaseMainnet]: new Set([
-    addressesRegistry[ChainId.BaseMainnet].verUsdc,
+    _addressesRegistry[ChainId.BaseMainnet].verUsdc,
   ]),
 };
 
@@ -492,11 +498,29 @@ entries(permissionedWrapperTokens).forEach(([chainId, tokens]) => {
  */
 export const convexWrapperTokens: Record<number, Set<Address>> = {
   [ChainId.EthMainnet]: new Set([
-    addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDTWBTCWETH-morpho"],
-    addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDCWBTCWETH-morpho"],
-    addressesRegistry[ChainId.EthMainnet]["stkcvxcrvCRVUSDTBTCWSTETH-morpho"],
-    addressesRegistry[ChainId.EthMainnet]["stkcvxTryLSD-morpho"],
-    addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDETHCRV-morpho"],
-    addressesRegistry[ChainId.EthMainnet]["stkcvx2BTC-f-morpho"],
+    _addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDTWBTCWETH-morpho"],
+    _addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDCWBTCWETH-morpho"],
+    _addressesRegistry[ChainId.EthMainnet]["stkcvxcrvCRVUSDTBTCWSTETH-morpho"],
+    _addressesRegistry[ChainId.EthMainnet]["stkcvxTryLSD-morpho"],
+    _addressesRegistry[ChainId.EthMainnet]["stkcvxcrvUSDETHCRV-morpho"],
+    _addressesRegistry[ChainId.EthMainnet]["stkcvx2BTC-f-morpho"],
   ]),
 };
+
+export let addressesRegistry = Object.freeze(_addressesRegistry);
+
+export function registerCustomAddresses(
+  customAddresses:
+    | Record<keyof typeof _addressesRegistry, DeepPartial<ChainAddresses>>
+    | Record<number, ChainAddresses>,
+) {
+  // biome-ignore lint/suspicious/noExplicitAny: type is not trivial and not important here
+  const customizer = (objValue: any, _srcValue: any, key: string) => {
+    if (objValue !== undefined && !isPlainObject(objValue))
+      throw new Error(`Cannot override existing address: ${key}`);
+  };
+
+  addressesRegistry = Object.freeze(
+    mergeWith({}, _addressesRegistry, customAddresses, customizer),
+  );
+}

--- a/packages/blue-sdk/src/addresses.ts
+++ b/packages/blue-sdk/src/addresses.ts
@@ -501,7 +501,7 @@ export let unwrappedTokensMapping = deepFreeze(_unwrappedTokensMapping);
  * @param options - Optional configuration object
  * @param options.unwrappedTokens - A mapping of chain IDs to token address maps,
  *                                  where each entry maps wrapped tokens to their unwrapped equivalents.
- * @param options.customAddresses - Custom address entries to merge into the default registry.
+ * @param options.addresses - Custom address entries to merge into the default registry.
  *                                  Can be a subset of `ChainAddresses` if chain is already known.
  *                                  Must provide all required addresses if chain is unknown.
  *
@@ -510,7 +510,7 @@ export let unwrappedTokensMapping = deepFreeze(_unwrappedTokensMapping);
  * @example
  * ```ts
  * registerCustomAddresses({
- *   customAddresses: {
+ *   addresses: {
  *     1: { contract: "0xabc..." }
  *   },
  *   unwrappedTokens: {
@@ -521,10 +521,10 @@ export let unwrappedTokensMapping = deepFreeze(_unwrappedTokensMapping);
  */
 export function registerCustomAddresses({
   unwrappedTokens,
-  customAddresses,
+  addresses: customAddresses,
 }: {
   unwrappedTokens?: Record<number, Record<Address, Address>>;
-  customAddresses?:
+  addresses?:
     | DeepPartial<Record<keyof typeof _addressesRegistry, ChainAddresses>>
     | Record<number, ChainAddresses>;
 } = {}) {

--- a/packages/blue-sdk/src/addresses.ts
+++ b/packages/blue-sdk/src/addresses.ts
@@ -3,8 +3,8 @@ import {
   type DottedKeys,
   entries,
 } from "@morpho-org/morpho-ts";
-import isPlainObject from "lodash/isPlainObject";
-import mergeWith from "lodash/mergeWith";
+import isPlainObject from "lodash.isplainobject";
+import mergeWith from "lodash.mergewith";
 import { ChainId } from "./chain.js";
 import { UnsupportedChainIdError } from "./errors.js";
 import type { Address } from "./types.js";
@@ -368,8 +368,6 @@ const _addressesRegistry = {
   },
 } as const;
 
-export const addresses = _addressesRegistry as Record<number, ChainAddresses>;
-
 export type AddressLabel = DottedKeys<(typeof _addressesRegistry)[ChainId]>;
 
 export const getChainAddresses = (chainId: number): ChainAddresses => {
@@ -508,6 +506,7 @@ export const convexWrapperTokens: Record<number, Set<Address>> = {
 };
 
 export let addressesRegistry = Object.freeze(_addressesRegistry);
+export let addresses = addressesRegistry as Record<number, ChainAddresses>;
 
 export function registerCustomAddresses(
   customAddresses:
@@ -520,7 +519,7 @@ export function registerCustomAddresses(
       throw new Error(`Cannot override existing address: ${key}`);
   };
 
-  addressesRegistry = Object.freeze(
+  addresses = addressesRegistry = Object.freeze(
     mergeWith({}, _addressesRegistry, customAddresses, customizer),
   );
 }

--- a/packages/blue-sdk/test/unit/addresses.test.ts
+++ b/packages/blue-sdk/test/unit/addresses.test.ts
@@ -1,0 +1,151 @@
+import { randomAddress } from "@morpho-org/test/fixtures";
+import { describe, expect, test } from "vitest";
+import {
+  type ChainAddresses,
+  ChainId,
+  addresses,
+  addressesRegistry,
+  getChainAddresses,
+  getUnwrappedToken,
+  registerCustomAddresses,
+} from "../../src/index.js";
+
+describe("addresses", () => {
+  test("should be extendable on existing chain (and revertable)", () => {
+    const randomAddress1 = randomAddress();
+    const randomAddress2 = randomAddress();
+    const unwrappedToken = randomAddress();
+    const wrappedToken = randomAddress();
+
+    expect(
+      getChainAddresses(ChainId.BaseMainnet).bundler3.aaveV2MigrationAdapter,
+    ).toBeUndefined();
+    expect(getChainAddresses(ChainId.BaseMainnet).stEth).toBeUndefined();
+    expect(
+      getUnwrappedToken(wrappedToken, ChainId.BaseMainnet),
+    ).toBeUndefined();
+
+    registerCustomAddresses({
+      customAddresses: {
+        [ChainId.BaseMainnet]: {
+          bundler3: {
+            aaveV2MigrationAdapter: randomAddress1,
+          },
+          stEth: randomAddress2,
+        },
+      },
+      unwrappedTokens: {
+        [ChainId.BaseMainnet]: {
+          [wrappedToken]: unwrappedToken,
+        },
+      },
+    });
+
+    expect(
+      getChainAddresses(ChainId.BaseMainnet).bundler3.aaveV2MigrationAdapter,
+    ).toEqual(randomAddress1);
+    expect(getChainAddresses(ChainId.BaseMainnet).stEth).toEqual(
+      randomAddress2,
+    );
+    expect(getUnwrappedToken(wrappedToken, ChainId.BaseMainnet)).toEqual(
+      unwrappedToken,
+    );
+  });
+
+  test("should be extendable on custom chain (and revertable)", () => {
+    const chainId = 11235813;
+    const chainAddresses = {
+      morpho: randomAddress(),
+      bundler3: {
+        bundler3: randomAddress(),
+        generalAdapter1: randomAddress(),
+      },
+      adaptiveCurveIrm: randomAddress(),
+      wstEth: randomAddress(),
+      stEth: randomAddress(),
+    } satisfies ChainAddresses;
+
+    registerCustomAddresses({
+      customAddresses: {
+        [chainId]: chainAddresses,
+      },
+      unwrappedTokens: {
+        [chainId]: {
+          [chainAddresses.wstEth]: chainAddresses.stEth,
+        },
+      },
+    });
+
+    expect(addresses[chainId]).toEqual(chainAddresses);
+    expect(getUnwrappedToken(chainAddresses.wstEth, chainId)).toEqual(
+      chainAddresses.stEth,
+    );
+  });
+
+  test("should throw when overriding existing address", () => {
+    const randomAddress1 = randomAddress();
+
+    expect(
+      getChainAddresses(ChainId.EthMainnet).bundler3.bundler3,
+    ).toBeDefined();
+
+    expect(() =>
+      registerCustomAddresses({
+        customAddresses: {
+          [ChainId.EthMainnet]: {
+            bundler3: {
+              bundler3: randomAddress1,
+            },
+          },
+        },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      registerCustomAddresses({
+        unwrappedTokens: {
+          [ChainId.EthMainnet]: {
+            [addressesRegistry[ChainId.EthMainnet].wstEth]: randomAddress1,
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("should throw if trying to modify custom address", () => {
+    const randomAddress1 = randomAddress();
+
+    registerCustomAddresses({
+      customAddresses: {
+        [ChainId.BaseMainnet]: {
+          wstEth: randomAddress1,
+        },
+      },
+    });
+    expect(getChainAddresses(ChainId.BaseMainnet).wstEth).toEqual(
+      randomAddress1,
+    );
+
+    /* Shouldn't throw since address is the same */
+    expect(() =>
+      registerCustomAddresses({
+        customAddresses: {
+          [ChainId.BaseMainnet]: {
+            wstEth: randomAddress1,
+          },
+        },
+      }),
+    ).not.toThrow();
+
+    /* Should throw since address is different */
+    expect(() =>
+      registerCustomAddresses({
+        customAddresses: {
+          [ChainId.BaseMainnet]: {
+            wstEth: randomAddress(),
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/blue-sdk/test/unit/addresses.test.ts
+++ b/packages/blue-sdk/test/unit/addresses.test.ts
@@ -148,4 +148,30 @@ describe("addresses", () => {
       }),
     ).toThrow();
   });
+
+  test("should prevent manual overrides", () => {
+    const chainAddresses = {
+      morpho: randomAddress(),
+      bundler3: {
+        bundler3: randomAddress(),
+        generalAdapter1: randomAddress(),
+      },
+      adaptiveCurveIrm: randomAddress(),
+      wstEth: randomAddress(),
+      stEth: randomAddress(),
+    } satisfies ChainAddresses;
+
+    expect(() => {
+      addresses[ChainId.EthMainnet] = chainAddresses;
+    }).toThrow();
+
+    expect(() => {
+      addresses[ChainId.EthMainnet]!.morpho = chainAddresses.morpho;
+    }).toThrow();
+
+    expect(() => {
+      addresses[ChainId.EthMainnet]!.bundler3.bundler3 =
+        chainAddresses.bundler3.bundler3;
+    }).toThrow();
+  });
 });

--- a/packages/blue-sdk/test/unit/addresses.test.ts
+++ b/packages/blue-sdk/test/unit/addresses.test.ts
@@ -26,7 +26,7 @@ describe("addresses", () => {
     ).toBeUndefined();
 
     registerCustomAddresses({
-      customAddresses: {
+      addresses: {
         [ChainId.BaseMainnet]: {
           bundler3: {
             aaveV2MigrationAdapter: randomAddress1,
@@ -66,7 +66,7 @@ describe("addresses", () => {
     } satisfies ChainAddresses;
 
     registerCustomAddresses({
-      customAddresses: {
+      addresses: {
         [chainId]: chainAddresses,
       },
       unwrappedTokens: {
@@ -91,7 +91,7 @@ describe("addresses", () => {
 
     expect(() =>
       registerCustomAddresses({
-        customAddresses: {
+        addresses: {
           [ChainId.EthMainnet]: {
             bundler3: {
               bundler3: randomAddress1,
@@ -116,7 +116,7 @@ describe("addresses", () => {
     const randomAddress1 = randomAddress();
 
     registerCustomAddresses({
-      customAddresses: {
+      addresses: {
         [ChainId.BaseMainnet]: {
           wstEth: randomAddress1,
         },
@@ -129,7 +129,7 @@ describe("addresses", () => {
     /* Shouldn't throw since address is the same */
     expect(() =>
       registerCustomAddresses({
-        customAddresses: {
+        addresses: {
           [ChainId.BaseMainnet]: {
             wstEth: randomAddress1,
           },
@@ -140,7 +140,7 @@ describe("addresses", () => {
     /* Should throw since address is different */
     expect(() =>
       registerCustomAddresses({
-        customAddresses: {
+        addresses: {
           [ChainId.BaseMainnet]: {
             wstEth: randomAddress(),
           },

--- a/packages/liquidation-sdk-viem/src/addresses.ts
+++ b/packages/liquidation-sdk-viem/src/addresses.ts
@@ -44,7 +44,7 @@ type PreLiquidationFactoryConfig = {
 };
 
 registerCustomAddresses({
-  customAddresses: {
+  addresses: {
     [ChainId.EthMainnet]: {
       usd0: "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5",
       "usd0++": "0x35D8949372D46B7a3D5A56006AE77B215fc69bC0",

--- a/packages/liquidation-sdk-viem/src/addresses.ts
+++ b/packages/liquidation-sdk-viem/src/addresses.ts
@@ -3,6 +3,7 @@ import {
   ChainId,
   addresses,
   addressesRegistry,
+  registerCustomAddresses,
 } from "@morpho-org/blue-sdk";
 import type { MidasConfig } from "./tokens/midas";
 
@@ -42,18 +43,22 @@ type PreLiquidationFactoryConfig = {
   startBlock: bigint;
 };
 
-export const mainnetAddresses = addresses[ChainId.EthMainnet]!;
-export const baseAddresses = addresses[ChainId.BaseMainnet]!;
+registerCustomAddresses({
+  customAddresses: {
+    [ChainId.EthMainnet]: {
+      usd0: "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5",
+      "usd0++": "0x35D8949372D46B7a3D5A56006AE77B215fc69bC0",
+      "usd0usd0++": "0x1d08E7adC263CfC70b1BaBe6dC5Bb339c16Eec52",
+      sUsds: "0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD",
+      usds: "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
+      sky: "0x56072C95FAA701256059aa122697B133aDEd9279",
+      mkrSkyConverter: "0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B",
+      daiUsdsConverter: "0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A",
+    },
+  },
+});
 
-mainnetAddresses.usd0 = "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5";
-mainnetAddresses["usd0++"] = "0x35D8949372D46B7a3D5A56006AE77B215fc69bC0";
-mainnetAddresses["usd0usd0++"] = "0x1d08E7adC263CfC70b1BaBe6dC5Bb339c16Eec52";
-mainnetAddresses.sUsds = "0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD";
-mainnetAddresses.usds = "0xdC035D45d973E3EC169d2276DDab16f1e407384F";
-mainnetAddresses.sky = "0x56072C95FAA701256059aa122697B133aDEd9279";
-mainnetAddresses.mkrSkyConverter = "0xBDcFCA946b6CDd965f99a839e4435Bcdc1bc470B";
-mainnetAddresses.daiUsdsConverter =
-  "0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A";
+export const mainnetAddresses = addresses[ChainId.EthMainnet]!;
 
 export const curvePools = {
   "usd0usd0++": "0x1d08E7adC263CfC70b1BaBe6dC5Bb339c16Eec52",

--- a/packages/migration-sdk-viem/src/config.ts
+++ b/packages/migration-sdk-viem/src/config.ts
@@ -35,7 +35,7 @@ declare module "@morpho-org/blue-sdk" {
 }
 
 registerCustomAddresses({
-  customAddresses: {
+  addresses: {
     [ChainId.EthMainnet]: {
       aaveV3Optimizer: "0x33333aea097c193e66081E930c33020272b33333",
       cEth: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",

--- a/packages/migration-sdk-viem/src/config.ts
+++ b/packages/migration-sdk-viem/src/config.ts
@@ -1,5 +1,10 @@
-import { type Address, ChainId, addresses } from "@morpho-org/blue-sdk";
+import {
+  type Address,
+  ChainId,
+  registerCustomAddresses,
+} from "@morpho-org/blue-sdk";
 
+import { deepFreeze } from "@morpho-org/morpho-ts";
 import type { Abi } from "viem";
 import {
   addressesProviderAbi as addressesProviderAbi_v2,
@@ -29,9 +34,14 @@ declare module "@morpho-org/blue-sdk" {
   }
 }
 
-const mainnetAddresses = addresses[ChainId.EthMainnet]!;
-mainnetAddresses.aaveV3Optimizer = "0x33333aea097c193e66081E930c33020272b33333";
-mainnetAddresses.cEth = "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5";
+registerCustomAddresses({
+  customAddresses: {
+    [ChainId.EthMainnet]: {
+      aaveV3Optimizer: "0x33333aea097c193e66081E930c33020272b33333",
+      cEth: "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+    },
+  },
+});
 
 interface Contract<abi extends Abi> {
   abi: abi;
@@ -178,3 +188,6 @@ export const migrationAddresses =
     number,
     ProtocolMigrationContracts
   >;
+
+// prevent manual update of addresses
+deepFreeze(migrationAddresses);

--- a/packages/morpho-ts/src/types.ts
+++ b/packages/morpho-ts/src/types.ts
@@ -1,6 +1,10 @@
 export type WithId<T> = T & { id: string };
 export type WithIndex<T> = T & { index: number };
 
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
 export type ArrayElementType<T> = T extends (infer U)[] ? U : never;
 
 type Digit = 1 | 2 | 3 | 4 | 5 | 6 | 7;

--- a/packages/morpho-ts/src/utils.ts
+++ b/packages/morpho-ts/src/utils.ts
@@ -150,3 +150,18 @@ export function getLastDefined<T>(
 export function getLastDefined<T>(array: T[]) {
   return getLast(filterDefined(array));
 }
+
+export function deepFreeze<T>(obj: T): T {
+  const propNames = Object.getOwnPropertyNames(obj);
+
+  for (const name of propNames) {
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    const value = (obj as any)[name];
+
+    if (value && typeof value === "object") {
+      deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(obj);
+}

--- a/packages/morpho-ts/src/utils.ts
+++ b/packages/morpho-ts/src/utils.ts
@@ -155,7 +155,7 @@ export function deepFreeze<T>(obj: T): T {
   const propNames = Object.getOwnPropertyNames(obj);
 
   for (const name of propNames) {
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    // biome-ignore lint/suspicious/noExplicitAny: name is a property of obj
     const value = (obj as any)[name];
 
     if (value && typeof value === "object") {

--- a/packages/simulation-sdk/test/fixtures.ts
+++ b/packages/simulation-sdk/test/fixtures.ts
@@ -12,7 +12,7 @@ import {
   Token,
   User,
   Vault,
-  unwrappedTokensMapping,
+  registerCustomAddresses,
 } from "@morpho-org/blue-sdk";
 import { randomMarket, randomVault } from "@morpho-org/morpho-test";
 import { randomAddress } from "@morpho-org/test";
@@ -28,7 +28,13 @@ export const userC = "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC";
 export const tokenA = "0x1111111111111111111111111111111111111111";
 export const tokenB = "0x2222222222222222222222222222222222222222";
 
-unwrappedTokensMapping[ChainId.EthMainnet][tokenB] = tokenA;
+registerCustomAddresses({
+  unwrappedTokens: {
+    [ChainId.EthMainnet]: {
+      [tokenB]: tokenA,
+    },
+  },
+});
 
 export const marketA1 = new Market({
   params: randomMarket({ loanToken: tokenA }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       '@noble/hashes':
         specifier: ^1.6.1
         version: 1.6.1
+      '@types/lodash':
+        specifier: ^4.17.12
+        version: 4.17.12
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@morpho-org/morpho-ts':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,13 +88,22 @@ importers:
     dependencies:
       '@noble/hashes':
         specifier: ^1.6.1
-        version: 1.6.1
+        version: 1.7.1
       '@types/lodash':
         specifier: ^4.17.12
         version: 4.17.12
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+      '@types/lodash.isplainobject':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/lodash.mergewith':
+        specifier: ^4.6.9
+        version: 4.6.9
+      lodash.isplainobject:
+        specifier: ^4.0.6
+        version: 4.0.6
+      lodash.mergewith:
+        specifier: ^4.6.2
+        version: 4.6.2
     devDependencies:
       '@morpho-org/morpho-ts':
         specifier: workspace:^
@@ -732,7 +741,7 @@ importers:
         version: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.0.0)(terser@5.36.0)
       wagmi:
         specifier: ^2.14.10
-        version: 2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
+        version: 2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
 
   packages/test-wagmi:
     devDependencies:
@@ -1918,10 +1927,6 @@ packages:
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
 
-  '@noble/hashes@1.6.1':
-    resolution: {integrity: sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==}
-    engines: {node: ^14.21.3 || >=16}
-
   '@noble/hashes@1.7.1':
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
@@ -2145,6 +2150,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
+    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2443,8 +2449,14 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
+  '@types/lodash.isplainobject@4.0.9':
+    resolution: {integrity: sha512-QC8nKcap5hRrbtIaPRjUMlcXXnLeayqQZPSaWJDx3xeuN17+2PW5wkmEJ4+lZgNnQRlSPzxjTYKCfV1uTnPaEg==}
+
   '@types/lodash.kebabcase@4.1.9':
     resolution: {integrity: sha512-kPrrmcVOhSsjAVRovN0lRfrbuidfg0wYsrQa5IYuoQO1fpHHGSme66oyiYA/5eQPVl8Z95OA3HG0+d2SvYC85w==}
+
+  '@types/lodash.mergewith@4.6.9':
+    resolution: {integrity: sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==}
 
   '@types/lodash@4.17.12':
     resolution: {integrity: sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ==}
@@ -2611,6 +2623,7 @@ packages:
 
   '@walletconnect/sign-client@2.17.0':
     resolution: {integrity: sha512-sErYwvSSHQolNXni47L3Bm10ptJc1s1YoJvJd34s5E9h9+d3rj7PrhbiW9X82deN+Dm5oA8X9tC4xty1yIBrVg==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/time@1.0.2':
     resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
@@ -7400,8 +7413,6 @@ snapshots:
 
   '@noble/hashes@1.4.0': {}
 
-  '@noble/hashes@1.6.1': {}
-
   '@noble/hashes@1.7.1': {}
 
   '@noble/secp256k1@1.7.1': {}
@@ -7907,7 +7918,15 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
+  '@types/lodash.isplainobject@4.0.9':
+    dependencies:
+      '@types/lodash': 4.17.12
+
   '@types/lodash.kebabcase@4.1.9':
+    dependencies:
+      '@types/lodash': 4.17.12
+
+  '@types/lodash.mergewith@4.6.9':
     dependencies:
       '@types/lodash': 4.17.12
 
@@ -8018,7 +8037,7 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 2.0.0
 
-  '@wagmi/connectors@5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
+  '@wagmi/connectors@5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
     dependencies:
       '@coinbase/wallet-sdk': 4.2.3
       '@metamask/sdk': 0.32.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -8052,56 +8071,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/connectors@5.7.6(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@coinbase/wallet-sdk': 4.2.3
-      '@metamask/sdk': 0.32.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.5(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-      '@wagmi/core': 2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
-      '@walletconnect/ethereum-provider': 2.17.0(@types/react@19.0.7)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(utf-8-validate@5.0.10)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.7.2
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - bufferutil
-      - encoding
-      - ioredis
-      - react
-      - supports-color
-      - utf-8-validate
-      - zod
-
   '@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.7.2)
-      viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-      zustand: 5.0.0(@types/react@19.0.7)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
-    optionalDependencies:
-      '@tanstack/query-core': 5.62.16
-      typescript: 5.7.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.7.2)
@@ -11484,41 +11454,8 @@ snapshots:
   wagmi@2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)):
     dependencies:
       '@tanstack/react-query': 5.62.11(react@19.0.0)
-      '@wagmi/connectors': 5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
+      '@wagmi/connectors': 5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
       '@wagmi/core': 2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
-      react: 19.0.0
-      use-sync-external-store: 1.4.0(react@19.0.0)
-      viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.7.2
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - bufferutil
-      - encoding
-      - immer
-      - ioredis
-      - supports-color
-      - utf-8-validate
-      - zod
-
-  wagmi@2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@tanstack/react-query': 5.62.11(react@19.0.0)
-      '@wagmi/connectors': 5.7.6(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
-      '@wagmi/core': 2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
       react: 19.0.0
       use-sync-external-store: 1.4.0(react@19.0.0)
       viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       '@noble/hashes':
         specifier: ^1.6.1
         version: 1.7.1
-      '@types/lodash':
-        specifier: ^4.17.12
-        version: 4.17.12
       '@types/lodash.isplainobject':
         specifier: ^4.0.9
         version: 4.0.9
@@ -741,7 +738,7 @@ importers:
         version: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)(@vitest/ui@3.0.5)(happy-dom@17.0.0)(terser@5.36.0)
       wagmi:
         specifier: ^2.14.10
-        version: 2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
+        version: 2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
 
   packages/test-wagmi:
     devDependencies:
@@ -8037,7 +8034,7 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 2.0.0
 
-  '@wagmi/connectors@5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
+  '@wagmi/connectors@5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
     dependencies:
       '@coinbase/wallet-sdk': 4.2.3
       '@metamask/sdk': 0.32.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -8071,7 +8068,56 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@wagmi/connectors@5.7.6(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@coinbase/wallet-sdk': 4.2.3
+      '@metamask/sdk': 0.32.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-provider': 0.18.5(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
+      '@wagmi/core': 2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
+      '@walletconnect/ethereum-provider': 2.17.0(@types/react@19.0.7)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(utf-8-validate@5.0.10)
+      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - supports-color
+      - utf-8-validate
+      - zod
+
   '@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.7.2)
+      viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
+      zustand: 5.0.0(@types/react@19.0.7)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
+    optionalDependencies:
+      '@tanstack/query-core': 5.62.16
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.7.2)
@@ -11454,8 +11500,41 @@ snapshots:
   wagmi@2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(@types/react@19.0.7)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)):
     dependencies:
       '@tanstack/react-query': 5.62.11(react@19.0.0)
-      '@wagmi/connectors': 5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
+      '@wagmi/connectors': 5.7.6(@types/react@19.0.7)(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
       '@wagmi/core': 2.16.3(@tanstack/query-core@5.62.16)(@types/react@19.0.7)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
+      react: 19.0.0
+      use-sync-external-store: 1.4.0(react@19.0.0)
+      viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - immer
+      - ioredis
+      - supports-color
+      - utf-8-validate
+      - zod
+
+  wagmi@2.14.10(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.62.11(react@19.0.0))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@tanstack/react-query': 5.62.11(react@19.0.0)
+      '@wagmi/connectors': 5.7.6(@wagmi/core@2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.0.0)(typescript@5.7.2)(utf-8-validate@5.0.10)(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
+      '@wagmi/core': 2.16.3(@tanstack/query-core@5.62.16)(react@19.0.0)(typescript@5.7.2)(use-sync-external-store@1.4.0(react@19.0.0))(viem@2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10))
       react: 19.0.0
       use-sync-external-store: 1.4.0(react@19.0.0)
       viem: 2.23.0(bufferutil@4.0.8)(typescript@5.7.2)(utf-8-validate@5.0.10)


### PR DESCRIPTION
The objective of this PR is to make addresses customization more straightforward and safer.

Left TODO:

- [x] Add docs
- [x] Add tests
  - [x] Existing chain can be extended with new addresses (nested or not)
  - [x] Custom chain can be registered
  - [x] Overriding an existing address is throwing (nested or not)
- [x] propagate change to other registries (wrappers, ...)