### PR TITLE
fix(apys): calculate them on-the-fly instead of step by step

### DIFF
--- a/packages/blue-sdk/src/market/MarketUtils.ts
+++ b/packages/blue-sdk/src/market/MarketUtils.ts
@@ -80,6 +80,7 @@ export namespace MarketUtils {
    * since the last time the market was updated (scaled by WAD).
    * @param borrowRate The average borrow rate since the last market update (scaled by WAD).
    * @param market The market state.
+   * @deprecated There's no such thing as a supply rate in Morpho. Only the supply APY is meaningful.
    */
   export function getSupplyRate(
     borrowRate: BigIntish,

--- a/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.ts
+++ b/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.ts
@@ -136,12 +136,16 @@ export namespace AdaptiveCurveIrmLib {
         ? MathLib.WAD - MathLib.wDivDown(MathLib.WAD, CURVE_STEEPNESS)
         : CURVE_STEEPNESS - MathLib.WAD;
 
+    const _curve = (rateAtTarget: BigIntish) =>
+      MathLib.wMulDown(
+        MathLib.wMulDown(coeff, err) + MathLib.WAD,
+        rateAtTarget,
+      );
+
     // Non negative if avgRateAtTarget >= 0 because if err < 0, coeff <= 1.
     return {
-      avgBorrowRate: MathLib.wMulDown(
-        MathLib.wMulDown(coeff, err) + MathLib.WAD,
-        avgRateAtTarget,
-      ),
+      avgBorrowRate: _curve(avgRateAtTarget),
+      endBorrowRate: _curve(endRateAtTarget),
       endRateAtTarget,
     };
   }


### PR DESCRIPTION
Each `Market` instance corresponds to the state (hypothetical or not) of a market, including the last update timestamp

BEFORE, there were 2 issues:
- the supply rate was calculated as the borrow rate times the utilization AND THEN ONLY compounded to get the supply APY: this is incorrect as in practice lenders will accrue the interest based on the compounded borrow rate AND THEN ONLY share the interest (proof is left as an exercise to the reader)
  - COROLLARY: the supply rate is meaningless. only the supply APY makes sense
- the borrow rate was calculated as the avgBorrowRate since the last update, with `elapsed = 0`. This leads to the borrow rate being the rateAtTarget corrected by the IRM's curve coefficient, which uses the market's utilization. In practice, we do `market.accrueInterest(timestamp).borrowRate`, which means the borrow rate is calculated with the updated coefficient, using the updated utilization: but this value is not guaranteed to ever correspond to anything onchain! So what we do is instead calculate the end borrow rate on-the-fly based on the IRM calculations of a virtual accrual, using the market's previous utilization ; which DOES correspond to an exact onchain behavior!
  - CONCLUSION: from now on, `market.getSupplyApy(timestamp)` is BETTER than `market.accrueInterest(timestamp).supplyApy`

