### PR TITLE
fix(migration-sdk-viem): export MigratableBorrowPosition from borrow module

### DIFF
--- a/packages/migration-sdk-viem/src/positions/index.ts
+++ b/packages/migration-sdk-viem/src/positions/index.ts
@@ -2,6 +2,7 @@ import type { MigratableBorrowPosition } from "./borrow/MigratableBorrowPosition
 import type { MigratableSupplyPosition } from "./supply/index.js";
 
 export { MigratableSupplyPosition } from "./supply/index.js";
+export { MigratableBorrowPosition } from "./borrow/index.js";
 
 export type MigratablePosition =
   | MigratableSupplyPosition


### PR DESCRIPTION
# Motivation

The purpose of this PR is to export `MigratableBorrowPosition` in the same way that we are doing for `MigratableSupplyPosition`.