### PR TITLE
fix(migration-sdk-viem): fix aave pricing

### DIFF
--- a/packages/migration-sdk-viem/src/fetchers/aaveV3/aaveV3.fetchers.ts
+++ b/packages/migration-sdk-viem/src/fetchers/aaveV3/aaveV3.fetchers.ts
@@ -7,7 +7,7 @@ import {
   fetchToken,
 } from "@morpho-org/blue-sdk-viem";
 
-import { type Client, erc20Abi, parseUnits } from "viem";
+import { type Client, erc20Abi, parseUnits, zeroAddress } from "viem";
 import { getChainId, readContract } from "viem/actions";
 import {
   aTokenV3Abi,
@@ -217,13 +217,15 @@ export async function fetchAaveV3Positions(
             }),
           ]);
 
-        const ethPrice = await readContract(client, {
+        const usdPrice = await readContract(client, {
           ...parameters,
           abi: aaveV3OracleAbi,
           address: oracleAddress,
           functionName: "getAssetPrice",
           args: [
-            eModeId === 0n ? underlyingAddress : eModeCategoryData.priceSource,
+            eModeId === 0n || eModeCategoryData.priceSource === zeroAddress
+              ? underlyingAddress
+              : eModeCategoryData.priceSource,
           ],
         });
 
@@ -242,7 +244,7 @@ export async function fetchAaveV3Positions(
             currentLiquidityRate,
             aTokenData,
             nonce,
-            ethPrice,
+            usdPrice,
           },
           borrow: {
             liquidationThreshold:
@@ -252,7 +254,7 @@ export async function fetchAaveV3Positions(
             currentVariableBorrowRate,
             totalBorrow,
             isActive,
-            ethPrice,
+            usdPrice,
             morphoNonce,
             isBundlerManaging,
           },
@@ -403,8 +405,8 @@ export async function fetchAaveV3Positions(
         user,
         maxRepay: maxBorrow,
         maxWithdraw: maxCollateral,
-        collateralPriceEth: collateralData.ethPrice,
-        loanPriceEth: loanData.ethPrice,
+        collateralPrice: collateralData.usdPrice,
+        loanPrice: loanData.usdPrice,
         morphoNonce: loanData.morphoNonce,
         isBundlerManaging: loanData.isBundlerManaging,
       }),

--- a/packages/migration-sdk-viem/src/positions/borrow/aaveV3.borrow.ts
+++ b/packages/migration-sdk-viem/src/positions/borrow/aaveV3.borrow.ts
@@ -37,8 +37,8 @@ interface IMigratableBorrowPosition_AaveV3
   extends Omit<IMigratableBorrowPosition, "protocol"> {
   nonce: bigint;
   aToken: Token;
-  collateralPriceEth: bigint;
-  loanPriceEth: bigint;
+  collateralPrice: bigint;
+  loanPrice: bigint;
 }
 
 export class MigratableBorrowPosition_AaveV3
@@ -47,15 +47,15 @@ export class MigratableBorrowPosition_AaveV3
 {
   private _nonce;
   public readonly aToken;
-  public readonly collateralPriceEth;
-  public readonly loanPriceEth;
+  public readonly collateralPrice;
+  public readonly loanPrice;
 
   constructor(config: IMigratableBorrowPosition_AaveV3) {
     super({ ...config, protocol: MigratableProtocol.aaveV3 });
     this.aToken = config.aToken;
     this._nonce = config.nonce;
-    this.collateralPriceEth = config.collateralPriceEth;
-    this.loanPriceEth = config.loanPriceEth;
+    this.collateralPrice = config.collateralPrice;
+    this.loanPrice = config.loanPrice;
   }
 
   getLtv({
@@ -63,11 +63,11 @@ export class MigratableBorrowPosition_AaveV3
     repaid = 0n,
   }: { withdrawn?: bigint; repaid?: bigint } = {}): bigint | null {
     const totalCollateralEth =
-      ((this.collateral - withdrawn) * this.collateralPriceEth) /
+      ((this.collateral - withdrawn) * this.collateralPrice) /
       parseUnits("1", this.collateralToken.decimals);
 
     const totalBorrowEth =
-      ((this.borrow - repaid) * this.loanPriceEth) /
+      ((this.borrow - repaid) * this.loanPrice) /
       parseUnits("1", this.loanToken.decimals);
 
     if (totalBorrowEth <= 0n) return null;


### PR DESCRIPTION
changes: 
- rename variables as price is in USD and not in ETH on aaveV3
- priceSource should be set to market address if not defined (equal to `0x0000...`)