### PR TITLE
refactor(operations): drop sender in callbacks, drop address for blue operations

### DIFF
--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -518,13 +518,13 @@ export const encodeOperation = (
       break;
     }
     case "Erc20_Wrap": {
-      const { amount } = operation.args;
+      const { amount, owner } = operation.args;
 
       switch (operation.address) {
         case wNative: {
           actions.push({
             type: "wrapNative",
-            args: [amount, generalAdapter1, operation.skipRevert],
+            args: [amount, owner, operation.skipRevert],
           });
 
           break;
@@ -532,7 +532,7 @@ export const encodeOperation = (
         case wstEth: {
           actions.push({
             type: "wrapStEth",
-            args: [amount, generalAdapter1, operation.skipRevert],
+            args: [amount, owner, operation.skipRevert],
           });
 
           break;
@@ -544,7 +544,7 @@ export const encodeOperation = (
               amount,
               MathLib.MAX_UINT_256,
               zeroAddress,
-              generalAdapter1,
+              owner,
               operation.skipRevert,
             ],
           });
@@ -585,7 +585,7 @@ export const encodeOperation = (
         case wNative: {
           actions.push({
             type: "unwrapNative",
-            args: [amount, generalAdapter1, operation.skipRevert],
+            args: [amount, receiver, operation.skipRevert],
           });
 
           break;
@@ -593,7 +593,7 @@ export const encodeOperation = (
         case wstEth: {
           actions.push({
             type: "unwrapStEth",
-            args: [amount, generalAdapter1, operation.skipRevert],
+            args: [amount, receiver, operation.skipRevert],
           });
 
           break;

--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -160,7 +160,11 @@ export const encodeOperation = (
       ...(callback && {
         callback: (dataBefore) => {
           callbackBundle = encodeBundle(
-            callback,
+            callback.map((callbackOperation) => ({
+              ...callbackOperation,
+              // Inside a callback, the sender is forced to be the generalAdapter1.
+              sender: generalAdapter1,
+            })),
             getCurrent(dataBefore),
             supportsSignature,
           );
@@ -179,7 +183,7 @@ export const encodeOperation = (
     requirements.signatures.push(...callbackBundle.requirements.signatures);
   }
 
-  const { sender, address } = operation;
+  const { sender } = operation;
 
   switch (operation.type) {
     case "Blue_SetAuthorization": {
@@ -221,7 +225,7 @@ export const encodeOperation = (
 
             await verifyTypedData({
               ...typedData,
-              address: sender, // Verify against the authorization's owner.
+              address: owner, // Verify against the authorization's owner.
               signature,
             });
 
@@ -251,7 +255,7 @@ export const encodeOperation = (
     }
     case "Erc20_Approve": {
       // Native token cannot be approved.
-      if (address === NATIVE_ADDRESS) break;
+      if (operation.address === NATIVE_ADDRESS) break;
 
       const { amount, spender } = operation.args;
 
@@ -259,14 +263,20 @@ export const encodeOperation = (
       if (!supportsSignature && spender === permit2) break;
 
       requirements.txs.push(
-        ...encodeErc20Approval(address, sender, spender, amount, dataBefore),
+        ...encodeErc20Approval(
+          operation.address,
+          sender,
+          spender,
+          amount,
+          dataBefore,
+        ),
       );
 
       break;
     }
     case "Erc20_Permit": {
       // Native token cannot be permitted.
-      if (address === NATIVE_ADDRESS) break;
+      if (operation.address === NATIVE_ADDRESS) break;
 
       const { amount, spender, nonce } = operation.args;
 
@@ -276,34 +286,28 @@ export const encodeOperation = (
         throw new BundlerErrors.UnexpectedSignature(spender);
 
       if (supportsSignature) {
-        const action: Action =
-          address === dai
-            ? {
-                type: "permitDai",
-                args: [
-                  sender,
-                  nonce,
-                  deadline,
-                  true,
-                  null,
-                  operation.skipRevert,
-                ],
-              }
-            : {
-                type: "permit",
-                args: [
-                  sender,
-                  address,
-                  amount,
-                  deadline,
-                  null,
-                  operation.skipRevert,
-                ],
-              };
+        const isDai = dai != null && operation.address === dai;
+
+        const action: Action = isDai
+          ? {
+              type: "permitDai",
+              args: [sender, nonce, deadline, true, null, operation.skipRevert],
+            }
+          : {
+              type: "permit",
+              args: [
+                sender,
+                operation.address,
+                amount,
+                deadline,
+                null,
+                operation.skipRevert,
+              ],
+            };
 
         actions.push(action);
 
-        const tokenData = dataBefore.getToken(address);
+        const tokenData = dataBefore.getToken(operation.address);
 
         requirements.signatures.push({
           action,
@@ -311,7 +315,7 @@ export const encodeOperation = (
             let signature = action.args[4];
             if (signature != null) return signature; // action is already signed
 
-            if (address === dai) {
+            if (isDai) {
               const typedData = getDaiPermitTypedData(
                 {
                   owner: sender,
@@ -366,14 +370,20 @@ export const encodeOperation = (
       // Simple permit is not supported, fallback to standard approval.
 
       requirements.txs.push(
-        ...encodeErc20Approval(address, sender, spender, amount, dataBefore),
+        ...encodeErc20Approval(
+          operation.address,
+          sender,
+          spender,
+          amount,
+          dataBefore,
+        ),
       );
 
       break;
     }
     case "Erc20_Permit2": {
       // Native token cannot be permitted.
-      if (address === NATIVE_ADDRESS) break;
+      if (operation.address === NATIVE_ADDRESS) break;
 
       const { amount, expiration, nonce } = operation.args;
 
@@ -384,7 +394,7 @@ export const encodeOperation = (
             sender,
             {
               details: {
-                token: address,
+                token: operation.address,
                 amount,
                 nonce: Number(nonce),
                 expiration: Number(expiration),
@@ -441,7 +451,7 @@ export const encodeOperation = (
 
       requirements.txs.push(
         ...encodeErc20Approval(
-          address,
+          operation.address,
           sender,
           generalAdapter1,
           amount,
@@ -454,7 +464,7 @@ export const encodeOperation = (
     case "Erc20_Transfer": {
       const { amount, from, to } = operation.args;
 
-      if (address === NATIVE_ADDRESS) {
+      if (operation.address === NATIVE_ADDRESS) {
         actions.push({
           type: "nativeTransfer",
           args: [from, to, amount, operation.skipRevert],
@@ -467,7 +477,13 @@ export const encodeOperation = (
       if (from === generalAdapter1) {
         actions.push({
           type: "erc20Transfer",
-          args: [address, to, amount, generalAdapter1, operation.skipRevert],
+          args: [
+            operation.address,
+            to,
+            amount,
+            generalAdapter1,
+            operation.skipRevert,
+          ],
         });
 
         break;
@@ -475,7 +491,7 @@ export const encodeOperation = (
 
       actions.push({
         type: "erc20TransferFrom",
-        args: [address, amount, to, operation.skipRevert],
+        args: [operation.address, amount, to, operation.skipRevert],
       });
 
       break;
@@ -486,7 +502,7 @@ export const encodeOperation = (
       if (supportsSignature) {
         actions.push({
           type: "transferFrom2",
-          args: [address, amount, to, operation.skipRevert],
+          args: [operation.address, amount, to, operation.skipRevert],
         });
 
         break;
@@ -496,7 +512,7 @@ export const encodeOperation = (
 
       actions.push({
         type: "erc20TransferFrom",
-        args: [address, amount, to, operation.skipRevert],
+        args: [operation.address, amount, to, operation.skipRevert],
       });
 
       break;
@@ -504,7 +520,7 @@ export const encodeOperation = (
     case "Erc20_Wrap": {
       const { amount } = operation.args;
 
-      switch (address) {
+      switch (operation.address) {
         case wNative: {
           actions.push({
             type: "wrapNative",
@@ -536,22 +552,27 @@ export const encodeOperation = (
           break;
         }
         default: {
-          if (erc20WrapperTokens[chainId]?.has(address)) {
-            const underlying = getUnwrappedToken(address, chainId);
+          if (erc20WrapperTokens[chainId]?.has(operation.address)) {
+            const underlying = getUnwrappedToken(operation.address, chainId);
             if (underlying == null)
-              throw Error(`unknown wrapped token: ${address}`);
+              throw Error(`unknown wrapped token: ${operation.address}`);
 
             actions.push({
               type: "erc20WrapperDepositFor",
-              args: [address, underlying, amount, operation.skipRevert],
+              args: [
+                operation.address,
+                underlying,
+                amount,
+                operation.skipRevert,
+              ],
             });
 
             break;
           }
 
           // Convex token wrapping is executed onchain along with supplyCollateral, via depositFor.
-          if (!convexWrapperTokens[chainId]?.has(address))
-            throw Error(`unexpected token wrap: ${address}`);
+          if (!convexWrapperTokens[chainId]?.has(operation.address))
+            throw Error(`unexpected token wrap: ${operation.address}`);
         }
       }
 
@@ -560,7 +581,7 @@ export const encodeOperation = (
     case "Erc20_Unwrap": {
       const { amount, receiver } = operation.args;
 
-      switch (address) {
+      switch (operation.address) {
         case wNative: {
           actions.push({
             type: "unwrapNative",
@@ -578,12 +599,12 @@ export const encodeOperation = (
           break;
         }
         default: {
-          if (!erc20WrapperTokens[chainId]?.has(address))
-            throw Error(`unexpected token unwrap: ${address}`);
+          if (!erc20WrapperTokens[chainId]?.has(operation.address))
+            throw Error(`unexpected token unwrap: ${operation.address}`);
 
           actions.push({
             type: "erc20WrapperWithdrawTo",
-            args: [address, receiver, amount, operation.skipRevert],
+            args: [operation.address, receiver, amount, operation.skipRevert],
           });
         }
       }
@@ -722,9 +743,9 @@ export const encodeOperation = (
       const { params } = dataBefore.getMarket(id);
 
       if (convexWrapperTokens[chainId]?.has(params.collateralToken)) {
-        const underlying = getUnwrappedToken(address, chainId);
+        const underlying = getUnwrappedToken(params.collateralToken, chainId);
         if (underlying == null)
-          throw Error(`unknown wrapped token: ${address}`);
+          throw Error(`unknown wrapped token: ${params.collateralToken}`);
 
         actions.push({
           type: "erc20WrapperDepositFor",
@@ -774,7 +795,7 @@ export const encodeOperation = (
 
       // Accrue interest to calculate the expected share price.
       const vault = dataBefore
-        .getAccrualVault(address)
+        .getAccrualVault(operation.address)
         .accrueInterest(dataBefore.block.timestamp);
       const maxSharePrice = vault.toAssets(
         MathLib.wToRay(MathLib.WAD + slippage),
@@ -783,12 +804,24 @@ export const encodeOperation = (
       if (shares === 0n)
         actions.push({
           type: "erc4626Deposit",
-          args: [address, assets, maxSharePrice, owner, operation.skipRevert],
+          args: [
+            operation.address,
+            assets,
+            maxSharePrice,
+            owner,
+            operation.skipRevert,
+          ],
         });
       else
         actions.push({
           type: "erc4626Mint",
-          args: [address, shares, maxSharePrice, owner, operation.skipRevert],
+          args: [
+            operation.address,
+            shares,
+            maxSharePrice,
+            owner,
+            operation.skipRevert,
+          ],
         });
 
       break;
@@ -804,7 +837,7 @@ export const encodeOperation = (
 
       // Accrue interest to calculate the expected share price.
       const vault = dataBefore
-        .getAccrualVault(address)
+        .getAccrualVault(operation.address)
         .accrueInterest(dataBefore.block.timestamp);
       const minSharePrice = vault.toAssets(
         MathLib.wToRay(MathLib.WAD - slippage),
@@ -814,7 +847,7 @@ export const encodeOperation = (
         actions.push({
           type: "erc4626Withdraw",
           args: [
-            address,
+            operation.address,
             assets,
             minSharePrice,
             receiver,
@@ -826,7 +859,7 @@ export const encodeOperation = (
         actions.push({
           type: "erc4626Redeem",
           args: [
-            address,
+            operation.address,
             shares,
             minSharePrice,
             receiver,
@@ -840,14 +873,15 @@ export const encodeOperation = (
     case "MetaMorpho_PublicReallocate": {
       const { withdrawals, supplyMarketId } = operation.args;
 
-      const { fee } = dataBefore.getVault(address).publicAllocatorConfig!;
+      const { fee } = dataBefore.getVault(operation.address)
+        .publicAllocatorConfig!;
 
       // Value is already accrued via another native input transfer.
 
       actions.push({
         type: "reallocateTo",
         args: [
-          address,
+          operation.address,
           fee,
           withdrawals.map(({ id, assets }) => ({
             marketParams: dataBefore.getMarket(id).params,

--- a/packages/bundler-sdk-viem/src/operations.ts
+++ b/packages/bundler-sdk-viem/src/operations.ts
@@ -220,7 +220,6 @@ export const populateSubBundle = (
 ) => {
   const { sender } = inputOperation;
   const {
-    morpho,
     bundler3: { bundler3, generalAdapter1 },
   } = getChainAddresses(data.chainId);
   const {
@@ -240,53 +239,56 @@ export const populateSubBundle = (
     !!wrappedToken &&
     !!erc20WrapperTokens[data.chainId]?.has(wrappedToken.address);
 
-  // Transform input operation to act on behalf of the sender, via the bundler.
   const mainOperation = produceImmutable(inputOperation, (draft) => {
-    draft.sender = generalAdapter1;
+    if (draft.type === "Erc20_Wrap" && isErc20Wrapper)
+      // ERC20Wrapper wrapped tokens are sent to the caller, not the bundler.
+      draft.args.owner = sender;
 
-    // Redirect MetaMorpho operation owner.
-    switch (draft.type) {
-      case "Erc20_Wrap": {
-        // ERC20Wrapper are skipped because tokens are sent to the caller, not the bundler.
-        if (isErc20Wrapper) {
-          draft.args.owner = sender;
-          break;
-        }
+    // Transform input operation to act on behalf of the sender, when sender is not the bundler.
+    if (sender !== generalAdapter1) {
+      draft.sender = generalAdapter1;
+
+      // Redirect MetaMorpho operation owner.
+      switch (draft.type) {
+        case "MetaMorpho_Deposit":
+        case "MetaMorpho_Withdraw":
+          // Only if sender is owner otherwise the owner would be lost.
+          if (draft.args.owner === sender) draft.args.owner = generalAdapter1;
       }
-      case "MetaMorpho_Deposit":
-      case "MetaMorpho_Withdraw":
-        // Only if sender is owner otherwise the owner would be lost.
-        if (draft.args.owner === sender) draft.args.owner = generalAdapter1;
-    }
 
-    // Redirect operation targets.
-    switch (draft.type) {
-      case "Blue_Borrow":
-      case "Blue_Withdraw":
-      case "Blue_WithdrawCollateral":
-        draft.args.onBehalf = sender;
-      case "MetaMorpho_Withdraw":
-        // Only if sender is receiver otherwise the receiver would be lost.
-        if (draft.args.receiver === sender)
-          draft.args.receiver = generalAdapter1;
+      // Redirect operation targets.
+      switch (draft.type) {
+        case "Blue_Borrow":
+        case "Blue_Withdraw":
+        case "Blue_WithdrawCollateral":
+          draft.args.onBehalf = sender;
+        case "MetaMorpho_Withdraw":
+          // Only if sender is receiver otherwise the receiver would be lost.
+          if (draft.args.receiver === sender)
+            draft.args.receiver = generalAdapter1;
+      }
     }
   });
 
-  const needsBundlerAuthorization =
+  if (
     mainOperation.type === "Blue_Borrow" ||
     mainOperation.type === "Blue_Withdraw" ||
-    mainOperation.type === "Blue_WithdrawCollateral";
-  if (needsBundlerAuthorization && !data.getUser(sender).isBundlerAuthorized)
-    operations.push({
-      type: "Blue_SetAuthorization",
-      sender: bundler3,
-      address: morpho,
-      args: {
-        owner: sender,
-        isAuthorized: true,
-        authorized: generalAdapter1,
-      },
-    });
+    mainOperation.type === "Blue_WithdrawCollateral"
+  ) {
+    // Either sender === generalAdapter1 or sender === onBehalf.
+    const { onBehalf } = mainOperation.args;
+
+    if (!data.getUser(onBehalf).isBundlerAuthorized)
+      operations.push({
+        type: "Blue_SetAuthorization",
+        sender: bundler3,
+        args: {
+          owner: onBehalf,
+          isAuthorized: true,
+          authorized: generalAdapter1,
+        },
+      });
+  }
 
   // Reallocate liquidity if necessary.
   if (
@@ -440,7 +442,11 @@ export const populateSubBundle = (
         callback: (data) => {
           const operations = callback.flatMap((inputOperation) => {
             const subBundleOperations = populateSubBundle(
-              inputOperation,
+              {
+                ...inputOperation,
+                // Inside a callback, the sender is forced to be the generalAdapter1.
+                sender: generalAdapter1,
+              },
               data,
               options,
             );
@@ -460,14 +466,17 @@ export const populateSubBundle = (
     },
   } as Operation;
 
-  // Operations with callbacks are populated recursively as a side-effect of the simulation, within the callback itself.
   let requiredTokenAmounts = simulateRequiredTokenAmounts(
+    // Safe cast because operations do not contain callbacks.
     (operations as Operation[]).concat([simulatedOperation]),
     data,
   );
 
+  // Safe cast because operations do not contain callbacks.
   const allOperations = (operations as BundlerOperation[]).concat([
-    mainOperation,
+    // Safe cast because mainOperation, if including a callback, was transformed to a BundlerOperation
+    // within the callback executed through the simulation `simulateRequiredTokenAmounts`.
+    mainOperation as BundlerOperation,
   ]);
 
   // Skip approvals/transfers if operation only uses available balances (via maxUint256).
@@ -968,7 +977,7 @@ export const simulateRequiredTokenAmounts = (
 };
 
 export const getSimulatedBundlerOperation = (
-  operation: BundlerOperation,
+  operation: Omit<BundlerOperation, "sender">,
   { slippage }: { slippage?: bigint } = {},
 ) => {
   const callback = getValue(operation.args, "callback");

--- a/packages/bundler-sdk-viem/src/types/operations.ts
+++ b/packages/bundler-sdk-viem/src/types/operations.ts
@@ -1,17 +1,19 @@
-import type {
-  BlueOperationArgs,
-  BlueOperationType,
+import {
+  type BlueOperationArgs,
+  type BlueOperationType,
   CALLBACK_OPERATIONS,
-  Erc20OperationArgs,
-  Erc20OperationType,
-  MetaMorphoOperationArgs,
-  MetaMorphoOperationType,
-  OperationArgs,
-  OperationType,
-  WithOperationArgs,
+  ERC20_OPERATIONS,
+  type Erc20OperationArgs,
+  type Erc20OperationType,
+  type MetaMorphoOperationArgs,
+  type MetaMorphoOperationType,
+  type OperationArgs,
+  type OperationType,
+  type WithOperationArgs,
 } from "@morpho-org/simulation-sdk";
+import type { UnionOmit } from "viem";
 
-export const BUNDLER_OPERATIONS = [
+export const BLUE_BUNDLER_OPERATIONS = [
   "Blue_SetAuthorization",
   "Blue_Borrow",
   "Blue_Repay",
@@ -19,61 +21,142 @@ export const BUNDLER_OPERATIONS = [
   "Blue_SupplyCollateral",
   "Blue_Withdraw",
   "Blue_WithdrawCollateral",
-  "MetaMorpho_Deposit",
-  "MetaMorpho_Withdraw",
-  "MetaMorpho_PublicReallocate",
-  "Erc20_Approve",
-  "Erc20_Permit",
-  "Erc20_Permit2",
-  "Erc20_Transfer",
-  "Erc20_Transfer2",
-  "Erc20_Wrap",
-  "Erc20_Unwrap",
-] as const satisfies readonly OperationType[];
+] as const satisfies readonly BlueOperationType[];
 
-export type BundlerOperationType = (typeof BUNDLER_OPERATIONS)[number];
+export type BlueBundlerOperationType = (typeof BLUE_BUNDLER_OPERATIONS)[number];
 
-export interface BundlerOperationArgs
-  extends Omit<OperationArgs, (typeof CALLBACK_OPERATIONS)[number]> {
+export interface BlueBundlerOperationArgs
+  extends Omit<BlueOperationArgs, (typeof CALLBACK_OPERATIONS)[number]> {
   Blue_SupplyCollateral: Omit<
     BlueOperationArgs["Blue_SupplyCollateral"],
     "callback"
-  > & { callback?: BundlerOperation[] };
+  > & {
+    /**
+     * Inside a callback, the sender is forced to be the generalAdapter1.
+     */
+    callback?: UnionOmit<BundlerOperation, "sender">[];
+  };
 
   Blue_Supply: Omit<BlueOperationArgs["Blue_Supply"], "callback"> & {
-    callback?: BundlerOperation[];
+    /**
+     * Inside a callback, the sender is forced to be the generalAdapter1.
+     */
+    callback?: UnionOmit<BundlerOperation, "sender">[];
   };
   Blue_Repay: Omit<BlueOperationArgs["Blue_Repay"], "callback"> & {
-    callback?: BundlerOperation[];
+    /**
+     * Inside a callback, the sender is forced to be the generalAdapter1.
+     */
+    callback?: UnionOmit<BundlerOperation, "sender">[];
   };
 }
-export type BundlerOperations = {
-  [OperationType in BundlerOperationType]: WithOperationArgs<
-    OperationType,
-    BundlerOperationArgs
+export type BlueBundlerOperations = {
+  [OperationType in BlueBundlerOperationType]: Omit<
+    WithOperationArgs<OperationType, BlueBundlerOperationArgs>,
+    "address"
   >;
 };
-export type BundlerOperation = BundlerOperations[BundlerOperationType];
+export type BlueBundlerOperation =
+  BlueBundlerOperations[BlueBundlerOperationType];
+
+export const METAMORPHO_BUNDLER_OPERATIONS = [
+  "MetaMorpho_Deposit",
+  "MetaMorpho_Withdraw",
+  "MetaMorpho_PublicReallocate",
+] as const satisfies readonly MetaMorphoOperationType[];
+
+export type MetaMorphoBundlerOperationType =
+  (typeof METAMORPHO_BUNDLER_OPERATIONS)[number];
+export type MetaMorphoBundlerOperations = {
+  [OperationType in MetaMorphoBundlerOperationType]: WithOperationArgs<
+    OperationType,
+    MetaMorphoOperationArgs
+  >;
+};
+export type MetaMorphoBundlerOperation =
+  MetaMorphoBundlerOperations[MetaMorphoBundlerOperationType];
+
+export const ERC20_BUNDLER_OPERATIONS =
+  ERC20_OPERATIONS satisfies readonly Erc20OperationType[];
+
+export type Erc20BundlerOperationType =
+  (typeof ERC20_BUNDLER_OPERATIONS)[number];
+export type Erc20BundlerOperations = {
+  [OperationType in Erc20BundlerOperationType]: WithOperationArgs<
+    OperationType,
+    Erc20OperationArgs
+  >;
+};
+export type Erc20BundlerOperation =
+  Erc20BundlerOperations[Erc20BundlerOperationType];
+
+export interface BundlerOperationArgs
+  extends BlueOperationArgs,
+    MetaMorphoOperationArgs,
+    Erc20OperationArgs {}
+
+export type BundlerOperations = BlueBundlerOperations &
+  MetaMorphoBundlerOperations &
+  Erc20BundlerOperations;
+
+export type BundlerOperationType =
+  | BlueBundlerOperationType
+  | MetaMorphoBundlerOperationType
+  | Erc20BundlerOperationType;
+
+export type BundlerOperation =
+  | BlueBundlerOperation
+  | MetaMorphoBundlerOperation
+  | Erc20BundlerOperation;
+
+export const BUNDLER_OPERATIONS = [
+  ...BLUE_BUNDLER_OPERATIONS,
+  ...METAMORPHO_BUNDLER_OPERATIONS,
+  ...ERC20_BUNDLER_OPERATIONS,
+] as const satisfies readonly OperationType[];
 
 export type CallbackBundlerOperationType = (typeof CALLBACK_OPERATIONS)[number];
-export type CallbackBundlerOperations = {
-  [OperationType in CallbackBundlerOperationType]: WithOperationArgs<
-    OperationType,
-    BundlerOperationArgs
-  >;
-};
+export type CallbackBundlerOperations = Pick<
+  BundlerOperations,
+  CallbackBundlerOperationType
+>;
 export type CallbackBundlerOperation =
   CallbackBundlerOperations[CallbackBundlerOperationType];
 
-export const BLUE_INPUT_OPERATIONS = [
-  "Blue_Borrow",
-  "Blue_Repay",
-  "Blue_Supply",
-  "Blue_SupplyCollateral",
-  "Blue_Withdraw",
-  "Blue_WithdrawCollateral",
-  "Blue_SetAuthorization",
-] as const satisfies readonly BlueOperationType[];
+export const isBlueBundlerOperation = (
+  operation: BundlerOperation,
+): operation is BlueBundlerOperation => {
+  return (BLUE_BUNDLER_OPERATIONS as readonly OperationType[]).includes(
+    operation.type,
+  );
+};
+
+export const isMetaMorphoBundlerOperation = (
+  operation: BundlerOperation,
+): operation is MetaMorphoBundlerOperation => {
+  return (METAMORPHO_BUNDLER_OPERATIONS as readonly OperationType[]).includes(
+    operation.type,
+  );
+};
+
+export const isErc20BundlerOperation = (
+  operation: BundlerOperation,
+): operation is Erc20BundlerOperation => {
+  return (ERC20_BUNDLER_OPERATIONS as readonly OperationType[]).includes(
+    operation.type,
+  );
+};
+
+export const isCallbackBundlerOperation = (
+  operation: BundlerOperation,
+): operation is CallbackBundlerOperation => {
+  return (CALLBACK_OPERATIONS as readonly OperationType[]).includes(
+    operation.type,
+  );
+};
+
+export const BLUE_INPUT_OPERATIONS =
+  BLUE_BUNDLER_OPERATIONS satisfies readonly BlueBundlerOperationType[];
 
 export type BlueInputBundlerOperationType =
   (typeof BLUE_INPUT_OPERATIONS)[number];
@@ -83,19 +166,30 @@ export interface BlueInputBundlerOperationArgs
   Blue_SupplyCollateral: Omit<
     BlueOperationArgs["Blue_SupplyCollateral"],
     "callback"
-  > & { callback?: InputBundlerOperation[] };
+  > & {
+    /**
+     * Inside a callback, the sender is forced to be the generalAdapter1.
+     */
+    callback?: UnionOmit<InputBundlerOperation, "sender">[];
+  };
 
   Blue_Supply: Omit<BlueOperationArgs["Blue_Supply"], "callback"> & {
-    callback?: InputBundlerOperation[];
+    /**
+     * Inside a callback, the sender is forced to be the generalAdapter1.
+     */
+    callback?: UnionOmit<InputBundlerOperation, "sender">[];
   };
   Blue_Repay: Omit<BlueOperationArgs["Blue_Repay"], "callback"> & {
-    callback?: InputBundlerOperation[];
+    /**
+     * Inside a callback, the sender is forced to be the generalAdapter1.
+     */
+    callback?: UnionOmit<InputBundlerOperation, "sender">[];
   };
 }
 export type BlueInputBundlerOperations = {
-  [OperationType in BlueInputBundlerOperationType]: WithOperationArgs<
-    OperationType,
-    BlueInputBundlerOperationArgs
+  [OperationType in BlueInputBundlerOperationType]: Omit<
+    WithOperationArgs<OperationType, BlueInputBundlerOperationArgs>,
+    "address"
   >;
 };
 export type BlueInputBundlerOperation =
@@ -104,22 +198,20 @@ export type BlueInputBundlerOperation =
 export const METAMORPHO_INPUT_OPERATIONS = [
   "MetaMorpho_Deposit",
   "MetaMorpho_Withdraw",
-] as const satisfies readonly MetaMorphoOperationType[];
+] as const satisfies readonly MetaMorphoBundlerOperationType[];
 
 export type MetaMorphoInputBundlerOperationType =
   (typeof METAMORPHO_INPUT_OPERATIONS)[number];
 export type MetaMorphoInputBundlerOperation =
-  BundlerOperations[MetaMorphoInputBundlerOperationType];
+  MetaMorphoBundlerOperations[MetaMorphoInputBundlerOperationType];
 
-export const ERC20_INPUT_OPERATIONS = [
-  "Erc20_Wrap",
-  "Erc20_Unwrap",
-] as const satisfies readonly Erc20OperationType[];
+export const ERC20_INPUT_OPERATIONS =
+  ERC20_BUNDLER_OPERATIONS satisfies readonly Erc20BundlerOperationType[];
 
 export type Erc20InputBundlerOperationType =
   (typeof ERC20_INPUT_OPERATIONS)[number];
 export type Erc20InputBundlerOperation =
-  BundlerOperations[Erc20InputBundlerOperationType];
+  Erc20BundlerOperations[Erc20InputBundlerOperationType];
 
 export interface InputBundlerOperationArgs
   extends BlueOperationArgs,
@@ -135,14 +227,6 @@ export type InputBundlerOperation =
   | BlueInputBundlerOperation
   | MetaMorphoInputBundlerOperation
   | Erc20InputBundlerOperation;
-
-// export const isBundlerOperation = (
-//   operation: Operation
-// ): operation is BundlerOperation => {
-//   return (BUNDLER_OPERATIONS as readonly OperationType[]).includes(
-//     operation.type
-//   );
-// };
 
 export const isBlueInputBundlerOperation = (operation: {
   type: OperationType;

--- a/packages/bundler-sdk-viem/test/populateBundle.test.ts
+++ b/packages/bundler-sdk-viem/test/populateBundle.test.ts
@@ -2360,13 +2360,13 @@ describe("populateBundle", () => {
           ).toBe(0n);
           expect(
             await client.balanceOf({ erc20: stEth, owner: generalAdapter1 }),
-          ).toBe(1n); // 1 stETH is always remaining in the bundler
+          ).toBe(0n);
           expect(
             await client.balanceOf({ erc20: wNative, owner: generalAdapter1 }),
           ).toBe(0n);
 
           expect(await client.balanceOf({ erc20: stEth })).toBe(
-            wstEthToken.toUnwrappedExactAmountIn(collateralAmount, 0n) - 3n,
+            wstEthToken.toUnwrappedExactAmountIn(collateralAmount, 0n) - 1n,
           );
           expect(await client.balanceOf({ erc20: wstEth })).toBe(0n);
           expect(await client.balanceOf({ erc20: wNative })).toBe(
@@ -4716,13 +4716,13 @@ describe("populateBundle", () => {
           ).toBe(0n);
           expect(
             await client.balanceOf({ erc20: stEth, owner: generalAdapter1 }),
-          ).toBe(1n); // 1 stETH is always remaining in the bundler
+          ).toBe(0n);
           expect(
             await client.balanceOf({ erc20: wNative, owner: generalAdapter1 }),
           ).toBe(0n);
 
           expect(await client.balanceOf({ erc20: stEth })).toBe(
-            wstEthToken.toUnwrappedExactAmountIn(collateralAmount, 0n) - 3n,
+            wstEthToken.toUnwrappedExactAmountIn(collateralAmount, 0n) - 1n,
           );
           expect(await client.balanceOf({ erc20: wstEth })).toBe(0n);
           expect(await client.balanceOf({ erc20: wNative })).toBe(
@@ -4797,18 +4797,8 @@ describe("populateBundle", () => {
               address: wNative,
               args: {
                 amount: assets,
-                owner: generalAdapter1,
+                owner: client.account.address,
                 slippage: DEFAULT_SLIPPAGE_TOLERANCE,
-              },
-            },
-            {
-              type: "Erc20_Transfer",
-              address: wNative,
-              sender: generalAdapter1,
-              args: {
-                amount: maxUint256,
-                from: generalAdapter1,
-                to: client.account.address,
               },
             },
           ]);

--- a/packages/bundler-sdk-viem/test/populateBundle.test.ts
+++ b/packages/bundler-sdk-viem/test/populateBundle.test.ts
@@ -84,7 +84,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Supply",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets,
@@ -129,7 +128,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Supply",
               sender: client.account.address,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -167,7 +165,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Supply",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -261,7 +258,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: client.account.address,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -343,7 +339,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -429,7 +424,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: client.account.address,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -448,7 +442,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -458,7 +451,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -751,7 +743,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: client.account.address,
-              address: morpho,
               args: {
                 id: marketParams.id,
                 assets: maxUint256,
@@ -813,7 +804,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: marketParams.id,
                 assets: maxUint256,
@@ -902,7 +892,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: client.account.address,
-              address: morpho,
               args: {
                 id: marketParams.id,
                 assets: shares,
@@ -964,7 +953,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: marketParams.id,
                 assets: shares,
@@ -1246,7 +1234,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_SupplyCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: collateralAssets,
@@ -1256,7 +1243,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Borrow",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   shares: loanShares,
@@ -1316,7 +1302,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: collateralAssets,
@@ -1326,7 +1311,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -1336,7 +1320,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 shares: loanShares,
@@ -1463,7 +1446,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_SupplyCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: collateralAssets,
@@ -1473,7 +1455,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Borrow",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets,
@@ -1554,7 +1535,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: collateralAssets,
@@ -1564,7 +1544,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -1574,7 +1553,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets,
@@ -1707,7 +1685,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Repay",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets / 2n,
@@ -1718,7 +1695,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_WithdrawCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: collateralAssets / 2n,
@@ -1740,7 +1716,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Repay",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets / 4n,
@@ -1833,7 +1808,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Repay",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets / 2n,
@@ -1844,7 +1818,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -1854,7 +1827,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_WithdrawCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: collateralAssets / 2n,
@@ -1876,7 +1848,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Repay",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets / 4n,
@@ -2044,7 +2015,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Borrow",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets,
@@ -2067,7 +2037,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -2119,7 +2088,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets,
@@ -2229,7 +2197,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Repay",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id: eth_wstEth.id,
                   shares: position.borrowShares,
@@ -2240,7 +2207,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_WithdrawCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id: eth_wstEth.id,
                   assets: position.collateral,
@@ -2300,7 +2266,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Repay",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: eth_wstEth.id,
                 shares: position.borrowShares,
@@ -2311,7 +2276,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -2321,7 +2285,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_WithdrawCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: eth_wstEth.id,
                 assets: position.collateral,
@@ -2454,7 +2417,6 @@ describe("populateBundle", () => {
                 {
                   type: "Blue_Supply",
                   sender: client.account.address,
-                  address: morpho,
                   args: {
                     id,
                     assets,
@@ -2532,7 +2494,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_SupplyCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets,
@@ -2621,7 +2582,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -2710,7 +2670,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Borrow",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets,
@@ -2740,7 +2699,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -2750,7 +2708,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets,
@@ -3062,7 +3019,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_SupplyCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id: marketParams.id,
                   assets: maxUint256,
@@ -3129,7 +3085,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: marketParams.id,
                 assets: maxUint256,
@@ -3221,7 +3176,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_SupplyCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id: marketParams.id,
                   assets: shares,
@@ -3285,7 +3239,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: marketParams.id,
                 assets: shares,
@@ -3568,7 +3521,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_SupplyCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: collateralAssets,
@@ -3578,7 +3530,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Borrow",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   shares: loanShares,
@@ -3650,7 +3601,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: collateralAssets,
@@ -3660,7 +3610,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -3670,7 +3619,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 shares: loanShares,
@@ -3797,7 +3745,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_SupplyCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: collateralAssets,
@@ -3807,7 +3754,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Borrow",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets,
@@ -3905,7 +3851,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SupplyCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: collateralAssets,
@@ -3915,7 +3860,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -3925,7 +3869,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets,
@@ -4058,7 +4001,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Repay",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets / 2n,
@@ -4069,7 +4011,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_WithdrawCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: collateralAssets / 2n,
@@ -4091,7 +4032,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Repay",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets / 4n,
@@ -4195,7 +4135,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Repay",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets / 2n,
@@ -4206,7 +4145,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -4216,7 +4154,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_WithdrawCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: collateralAssets / 2n,
@@ -4238,7 +4175,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Repay",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets / 4n,
@@ -4406,7 +4342,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Borrow",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id,
                   assets: loanAssets,
@@ -4439,7 +4374,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -4491,7 +4425,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Borrow",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id,
                 assets: loanAssets,
@@ -4601,7 +4534,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Repay",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id: eth_wstEth.id,
                   shares: position.borrowShares,
@@ -4612,7 +4544,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_WithdrawCollateral",
                 sender: client.account.address,
-                address: morpho,
                 args: {
                   id: eth_wstEth.id,
                   assets: position.collateral,
@@ -4677,7 +4608,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Repay",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: eth_wstEth.id,
                 shares: position.borrowShares,
@@ -4688,7 +4618,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_SetAuthorization",
               sender: bundler3,
-              address: morpho,
               args: {
                 owner: client.account.address,
                 isAuthorized: true,
@@ -4698,7 +4627,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_WithdrawCollateral",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: eth_wstEth.id,
                 assets: position.collateral,
@@ -4930,7 +4858,6 @@ describe("populateBundle", () => {
               {
                 type: "Blue_Supply",
                 sender: whitelisted,
-                address: morpho,
                 args: {
                   id: marketParams.id,
                   assets,
@@ -4998,7 +4925,6 @@ describe("populateBundle", () => {
             {
               type: "Blue_Supply",
               sender: generalAdapter1,
-              address: morpho,
               args: {
                 id: marketParams.id,
                 assets,

--- a/packages/bundler-sdk-viem/test/populateBundle.test.ts
+++ b/packages/bundler-sdk-viem/test/populateBundle.test.ts
@@ -92,7 +92,21 @@ describe("populateBundle", () => {
               },
             ]),
           ).rejects.toThrowErrorMatchingInlineSnapshot(
-            `[Error: insufficient balance of user "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" for token "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]`,
+            `
+            [Error: insufficient balance of user "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" for token "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
+            when simulating operation:
+            {
+              "type": "Erc20_Transfer2",
+              "sender": "0x4A6c312ec70E8747a587EE860a0353cd42Be0aE0",
+              "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+              "args": {
+                "amount": "15000000000000000000001",
+                "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                "to": "0x4A6c312ec70E8747a587EE860a0353cd42Be0aE0"
+              }
+            }]
+          `,
           );
         },
       );
@@ -2427,7 +2441,21 @@ describe("populateBundle", () => {
               { supportsSignature: false },
             ),
           ).rejects.toThrowErrorMatchingInlineSnapshot(
-            `[Error: insufficient balance of user "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" for token "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]`,
+            `
+            [Error: insufficient balance of user "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" for token "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
+            when simulating operation:
+            {
+              "type": "Erc20_Transfer2",
+              "sender": "0x4A6c312ec70E8747a587EE860a0353cd42Be0aE0",
+              "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+              "args": {
+                "amount": "15000000000000000000001",
+                "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                "to": "0x4A6c312ec70E8747a587EE860a0353cd42Be0aE0"
+              }
+            }]
+          `,
           );
         },
       );

--- a/packages/bundler-sdk-viem/test/sharedLiquidity.test.ts
+++ b/packages/bundler-sdk-viem/test/sharedLiquidity.test.ts
@@ -19,7 +19,6 @@ configure({ asyncUtilTimeout: 10_000 });
 
 describe("sharedLiquidity", () => {
   const {
-    morpho,
     bundler3: { bundler3, generalAdapter1 },
     publicAllocator,
     wNative,
@@ -159,7 +158,6 @@ describe("sharedLiquidity", () => {
           {
             type: "Blue_SupplyCollateral",
             sender: client.account.address,
-            address: morpho,
             args: {
               id,
               assets: collateralAssets,
@@ -169,7 +167,6 @@ describe("sharedLiquidity", () => {
           {
             type: "Blue_Borrow",
             sender: client.account.address,
-            address: morpho,
             args: {
               id,
               assets: borrowed,
@@ -217,7 +214,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_SupplyCollateral",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             id,
             assets: collateralAssets,
@@ -227,7 +223,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_SetAuthorization",
           sender: bundler3,
-          address: morpho,
           args: {
             owner: client.account.address,
             isAuthorized: true,
@@ -237,7 +232,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_Borrow",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             id,
             assets: borrowed,
@@ -353,7 +347,6 @@ describe("sharedLiquidity", () => {
           {
             type: "Blue_SupplyCollateral",
             sender: client.account.address,
-            address: morpho,
             args: {
               id,
               assets: collateralAssets,
@@ -363,7 +356,6 @@ describe("sharedLiquidity", () => {
           {
             type: "Blue_Borrow",
             sender: client.account.address,
-            address: morpho,
             args: {
               id,
               assets: maxFriendlyReallocationAmount,
@@ -411,7 +403,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_SupplyCollateral",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             id,
             assets: collateralAssets,
@@ -421,7 +412,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_SetAuthorization",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             owner: client.account.address,
             isAuthorized: true,
@@ -445,7 +435,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_Borrow",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             id,
             assets: maxFriendlyReallocationAmount,
@@ -562,7 +551,6 @@ describe("sharedLiquidity", () => {
           {
             type: "Blue_SupplyCollateral",
             sender: client.account.address,
-            address: morpho,
             args: {
               id,
               assets: collateralAssets,
@@ -572,7 +560,6 @@ describe("sharedLiquidity", () => {
           {
             type: "Blue_Borrow",
             sender: client.account.address,
-            address: morpho,
             args: {
               id,
               assets: borrowed,
@@ -620,7 +607,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_SupplyCollateral",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             id,
             assets: collateralAssets,
@@ -630,7 +616,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_SetAuthorization",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             owner: client.account.address,
             isAuthorized: true,
@@ -654,7 +639,6 @@ describe("sharedLiquidity", () => {
         {
           type: "Blue_Borrow",
           sender: generalAdapter1,
-          address: morpho,
           args: {
             id,
             assets: borrowed,

--- a/packages/migration-sdk-viem/src/positions/borrow/blue.borrow.ts
+++ b/packages/migration-sdk-viem/src/positions/borrow/blue.borrow.ts
@@ -107,7 +107,6 @@ export class MigratableBorrowPosition_Blue
 
     return {
       type: "Blue_SupplyCollateral",
-      address: "0x",
       sender: this.position.user,
       args: {
         id: marketTo,
@@ -118,8 +117,6 @@ export class MigratableBorrowPosition_Blue
             ? ([
                 {
                   type: "Blue_Borrow",
-                  address: "0x",
-                  sender: this.position.user,
                   args: {
                     id: marketTo,
                     assets:
@@ -136,8 +133,6 @@ export class MigratableBorrowPosition_Blue
                 },
                 {
                   type: "Blue_Repay",
-                  address: "0x",
-                  sender: this.position.user,
                   args: {
                     id: this.market.id,
                     slippage: slippageFrom,
@@ -153,8 +148,6 @@ export class MigratableBorrowPosition_Blue
             : []),
           {
             type: "Blue_WithdrawCollateral",
-            address: "0x",
-            sender: this.position.user,
             args: {
               id: this.market.id,
               assets: collateralAssets,

--- a/packages/migration-sdk-viem/test/e2e/blue/borrow.test.ts
+++ b/packages/migration-sdk-viem/test/e2e/blue/borrow.test.ts
@@ -102,7 +102,9 @@ const fetchSimulationState = async (
     holdings,
     bundlerHoldings,
     positions,
+    bundlerPositions,
     userData,
+    bundlerData,
   ] = await Promise.all([
     client.getBlock({ blockTag: "latest" }),
     Promise.all(
@@ -134,7 +136,14 @@ const fetchSimulationState = async (
         async (id) => [id, await fetchPosition(user, id, client)] as const,
       ),
     ),
+    Promise.all(
+      marketIds.map(
+        async (id) =>
+          [id, await fetchPosition(generalAdapter1, id, client)] as const,
+      ),
+    ),
     fetchUser(user, client),
+    fetchUser(generalAdapter1, client),
   ]);
   return new SimulationState({
     chainId,
@@ -146,8 +155,11 @@ const fetchSimulationState = async (
       [user]: fromEntries(holdings),
       [generalAdapter1]: fromEntries(bundlerHoldings),
     },
-    positions: { [user]: fromEntries(positions) },
-    users: { [user]: userData },
+    positions: {
+      [user]: fromEntries(positions),
+      [generalAdapter1]: fromEntries(bundlerPositions),
+    },
+    users: { [user]: userData, [generalAdapter1]: bundlerData },
   });
 };
 
@@ -259,7 +271,6 @@ describe("Borrow position on blue", () => {
 
         expect(operation).toEqual({
           type: "Blue_SupplyCollateral",
-          address: "0x",
           sender: client.account.address,
           args: {
             id: marketTo.id,
@@ -268,8 +279,6 @@ describe("Borrow position on blue", () => {
             callback: [
               {
                 type: "Blue_Borrow",
-                address: "0x",
-                sender: client.account.address,
                 args: {
                   id: marketTo.id,
                   assets: borrowToMigrate,
@@ -280,8 +289,6 @@ describe("Borrow position on blue", () => {
               },
               {
                 type: "Blue_Repay",
-                address: "0x",
-                sender: client.account.address,
                 args: {
                   id: marketFrom.id,
                   assets: borrowToMigrate,
@@ -291,8 +298,6 @@ describe("Borrow position on blue", () => {
               },
               {
                 type: "Blue_WithdrawCollateral",
-                address: "0x",
-                sender: client.account.address,
                 args: {
                   id: marketFrom.id,
                   assets: collateralToMigrate,
@@ -312,7 +317,6 @@ describe("Borrow position on blue", () => {
         expect(finalizedBundle).toEqual([
           {
             type: "Blue_SupplyCollateral",
-            address: "0x",
             sender: generalAdapter1,
             args: {
               id: marketTo.id,
@@ -322,7 +326,6 @@ describe("Borrow position on blue", () => {
                 {
                   type: "Blue_SetAuthorization",
                   sender: bundler3,
-                  address: morpho,
                   args: {
                     owner: client.account.address,
                     isAuthorized: true,
@@ -331,7 +334,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_Borrow",
-                  address: "0x",
                   sender: generalAdapter1,
                   args: {
                     id: marketTo.id,
@@ -343,7 +345,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_Repay",
-                  address: "0x",
                   sender: generalAdapter1,
                   args: {
                     id: marketFrom.id,
@@ -354,7 +355,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_WithdrawCollateral",
-                  address: "0x",
                   sender: generalAdapter1,
                   args: {
                     id: marketFrom.id,
@@ -437,7 +437,6 @@ describe("Borrow position on blue", () => {
 
           expect(operation).toEqual({
             type: "Blue_SupplyCollateral",
-            address: "0x",
             sender: client.account.address,
             args: {
               id: marketTo.id,
@@ -446,8 +445,6 @@ describe("Borrow position on blue", () => {
               callback: [
                 {
                   type: "Blue_Borrow",
-                  address: "0x",
-                  sender: client.account.address,
                   args: {
                     id: marketTo.id,
                     assets: MathLib.wMulUp(
@@ -461,8 +458,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_Repay",
-                  address: "0x",
-                  sender: client.account.address,
                   args: {
                     id: marketFrom.id,
                     shares: sharesToMigrate,
@@ -472,8 +467,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_WithdrawCollateral",
-                  address: "0x",
-                  sender: client.account.address,
                   args: {
                     id: marketFrom.id,
                     assets: collateralToMigrate,
@@ -493,7 +486,6 @@ describe("Borrow position on blue", () => {
           expect(finalizedBundle).toEqual([
             {
               type: "Blue_SupplyCollateral",
-              address: "0x",
               sender: generalAdapter1,
               args: {
                 id: marketTo.id,
@@ -503,7 +495,6 @@ describe("Borrow position on blue", () => {
                   {
                     type: "Blue_SetAuthorization",
                     sender: bundler3,
-                    address: morpho,
                     args: {
                       owner: client.account.address,
                       isAuthorized: true,
@@ -512,7 +503,6 @@ describe("Borrow position on blue", () => {
                   },
                   {
                     type: "Blue_Borrow",
-                    address: "0x",
                     sender: generalAdapter1,
                     args: {
                       id: marketTo.id,
@@ -527,7 +517,6 @@ describe("Borrow position on blue", () => {
                   },
                   {
                     type: "Blue_Repay",
-                    address: "0x",
                     sender: generalAdapter1,
                     args: {
                       id: marketFrom.id,
@@ -538,7 +527,6 @@ describe("Borrow position on blue", () => {
                   },
                   {
                     type: "Blue_WithdrawCollateral",
-                    address: "0x",
                     sender: generalAdapter1,
                     args: {
                       id: marketFrom.id,
@@ -627,7 +615,6 @@ describe("Borrow position on blue", () => {
         );
         expect(operation).toEqual({
           type: "Blue_SupplyCollateral",
-          address: "0x",
           sender: client.account.address,
           args: {
             id: marketTo.id,
@@ -636,8 +623,6 @@ describe("Borrow position on blue", () => {
             callback: [
               {
                 type: "Blue_Borrow",
-                address: "0x",
-                sender: client.account.address,
                 args: {
                   id: marketTo.id,
                   assets: MathLib.wMulUp(
@@ -651,8 +636,6 @@ describe("Borrow position on blue", () => {
               },
               {
                 type: "Blue_Repay",
-                address: "0x",
-                sender: client.account.address,
                 args: {
                   id: marketFrom.id,
                   shares: initialPositionFrom.borrowShares,
@@ -662,8 +645,6 @@ describe("Borrow position on blue", () => {
               },
               {
                 type: "Blue_WithdrawCollateral",
-                address: "0x",
-                sender: client.account.address,
                 args: {
                   id: marketFrom.id,
                   assets: collateralAmount,
@@ -683,7 +664,6 @@ describe("Borrow position on blue", () => {
         expect(finalizedBundle).toEqual([
           {
             type: "Blue_SupplyCollateral",
-            address: "0x",
             sender: generalAdapter1,
             args: {
               id: marketTo.id,
@@ -693,7 +673,6 @@ describe("Borrow position on blue", () => {
                 {
                   type: "Blue_SetAuthorization",
                   sender: bundler3,
-                  address: morpho,
                   args: {
                     owner: client.account.address,
                     isAuthorized: true,
@@ -702,7 +681,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_Borrow",
-                  address: "0x",
                   sender: generalAdapter1,
                   args: {
                     id: marketTo.id,
@@ -717,7 +695,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_Repay",
-                  address: "0x",
                   sender: generalAdapter1,
                   args: {
                     id: marketFrom.id,
@@ -728,7 +705,6 @@ describe("Borrow position on blue", () => {
                 },
                 {
                   type: "Blue_WithdrawCollateral",
-                  address: "0x",
                   sender: generalAdapter1,
                   args: {
                     id: marketFrom.id,

--- a/packages/simulation-sdk-wagmi/test/hooks/useSimulationState.test.ts
+++ b/packages/simulation-sdk-wagmi/test/hooks/useSimulationState.test.ts
@@ -320,7 +320,21 @@ describe("useSimulationState", () => {
         result.current.data!,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" for token "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"]`,
+      `
+      [Error: insufficient balance of user "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" for token "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Transfer",
+        "sender": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "args": {
+          "amount": "1000000",
+          "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "to": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+        }
+      }]
+    `,
     );
   });
 
@@ -367,7 +381,21 @@ describe("useSimulationState", () => {
         result.current.data!,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient allowance for token "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" from owner "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" to spender "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"]`,
+      `
+      [Error: insufficient allowance for token "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" from owner "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" to spender "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Transfer",
+        "sender": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "args": {
+          "amount": "1000000",
+          "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "to": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+        }
+      }]
+    `,
     );
   });
 

--- a/packages/simulation-sdk/src/errors.ts
+++ b/packages/simulation-sdk/src/errors.ts
@@ -192,7 +192,12 @@ export namespace SimulationErrors {
       public readonly index: number,
       public readonly operation: T,
     ) {
-      super(error.message);
+      super(
+        `${error.message}
+
+${error instanceof Simulation ? "in the callback of" : "when simulating operation"}:
+${JSON.stringify(operation, (_, value) => (typeof value === "bigint" ? `${value.toString()}n` : value), 2)}`,
+      );
 
       this.stack = error.stack;
     }

--- a/packages/simulation-sdk/src/operations.ts
+++ b/packages/simulation-sdk/src/operations.ts
@@ -285,24 +285,32 @@ export type CallbackOperations = {
 };
 export type CallbackOperation = CallbackOperations[CallbackOperationType];
 
-export const isBlueOperation = (operation: {
-  type: OperationType;
-}): operation is BlueOperation => {
+export const isBlueOperation = (
+  operation: Operation,
+): operation is BlueOperation => {
   return (BLUE_OPERATIONS as readonly OperationType[]).includes(operation.type);
 };
 
-export const isMetaMorphoOperation = (operation: {
-  type: OperationType;
-}): operation is MetaMorphoOperation => {
+export const isMetaMorphoOperation = (
+  operation: Operation,
+): operation is MetaMorphoOperation => {
   return (METAMORPHO_OPERATIONS as readonly OperationType[]).includes(
     operation.type,
   );
 };
 
-export const isErc20Operation = (operation: {
-  type: OperationType;
-}): operation is Erc20Operation => {
+export const isErc20Operation = (
+  operation: Operation,
+): operation is Erc20Operation => {
   return (ERC20_OPERATIONS as readonly OperationType[]).includes(
+    operation.type,
+  );
+};
+
+export const isCallbackOperation = (
+  operation: Operation,
+): operation is CallbackOperation => {
+  return (CALLBACK_OPERATIONS as readonly OperationType[]).includes(
     operation.type,
   );
 };

--- a/packages/simulation-sdk/test/handlers/blue/accrueInterest.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/accrueInterest.test.ts
@@ -61,7 +61,18 @@ describe(type, () => {
         dataFixtureCopy,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: invalid interest accrual on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd: accrual timestamp 12344 can't be prior to last update 12345]`,
+      `
+      [Error: invalid interest accrual on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd: accrual timestamp 12344 can't be prior to last update 12345
+
+      when simulating operation:
+      {
+        "type": "Blue_AccrueInterest",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/blue/borrow.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/borrow.test.ts
@@ -76,7 +76,21 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: assets=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: assets=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Borrow",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "-1n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `);
   });
 
   test("should throw if shares is negative", () => {
@@ -94,7 +108,21 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: shares=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: shares=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Borrow",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "shares": "-1n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `);
   });
 
   test("should throw if insufficient liquidity", () => {
@@ -113,7 +141,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient liquidity on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient liquidity on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_Borrow",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10750000000n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -133,7 +175,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient collateral for user 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient collateral for user 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_Borrow",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/blue/repay.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/repay.test.ts
@@ -89,7 +89,20 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: assets=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: assets=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Repay",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "-1n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `);
   });
 
   test("should throw if shares is negative", () => {
@@ -106,7 +119,20 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: shares=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: shares=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Repay",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "shares": "-1n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `);
   });
 
   test("should throw if insufficient debt", () => {
@@ -124,7 +150,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient position for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient position for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_Repay",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "shares": "10000000000001n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 
@@ -143,7 +182,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Blue_Repay",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10000000n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 
@@ -216,7 +268,33 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: unauthorized bundler for user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"]`,
+      `
+      [Error: unauthorized bundler for user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+
+      when simulating operation:
+      {
+        "type": "Blue_Borrow",
+        "sender": "0x4A6c312ec70E8747a587EE860a0353cd42Be0aE0",
+        "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }
+
+      in the callback of:
+      {
+        "type": "Blue_Repay",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10000000n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/blue/setAuthorization.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/setAuthorization.test.ts
@@ -64,7 +64,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      "[Error: isBundlerAuthorized is already set to false]",
+      `
+      [Error: isBundlerAuthorized is already set to false
+
+      when simulating operation:
+      {
+        "type": "Blue_SetAuthorization",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "owner": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "isAuthorized": false,
+          "authorized": "0x4A6c312ec70E8747a587EE860a0353cd42Be0aE0"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/blue/supply.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/supply.test.ts
@@ -84,7 +84,20 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: assets=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: assets=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Supply",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "-1n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `);
   });
 
   test("should throw if shares is negative", () => {
@@ -101,7 +114,20 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: shares=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: shares=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Supply",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "shares": "-1n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `);
   });
 
   test("should throw if insufficient wallet balance", () => {
@@ -119,7 +145,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Blue_Supply",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -192,7 +231,33 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient position for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient position for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_Withdraw",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10000000n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }
+
+      in the callback of:
+      {
+        "type": "Blue_Supply",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/blue/supplyCollateral.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/supplyCollateral.test.ts
@@ -57,7 +57,20 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: assets=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: assets=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_SupplyCollateral",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "-1n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `);
   });
 
   test("should throw if insufficient wallet balance", () => {
@@ -75,7 +88,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0xBF3FCDD92C14a1EF02C787C379c0aA941d239Af2"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0xBF3FCDD92C14a1EF02C787C379c0aA941d239Af2"
+
+      when simulating operation:
+      {
+        "type": "Blue_SupplyCollateral",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "1000000000000000000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -151,7 +177,33 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient liquidity on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient liquidity on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_Borrow",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "address": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "1000000000000000000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }
+
+      in the callback of:
+      {
+        "type": "Blue_SupplyCollateral",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "1000000000000000000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/blue/withdraw.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/withdraw.test.ts
@@ -77,7 +77,21 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: assets=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: assets=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Withdraw",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "-1n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `);
   });
 
   test("should throw if shares is negative", () => {
@@ -95,7 +109,21 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: shares=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: shares=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_Withdraw",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "shares": "-1n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `);
   });
 
   test("should throw if insufficient liquidity", () => {
@@ -114,7 +142,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient liquidity on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient liquidity on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_Withdraw",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "10750000000n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 
@@ -134,7 +176,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient position for user 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient position for user 0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_Withdraw",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "shares": "10000000000001n",
+          "onBehalf": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/blue/withdrawCollateral.test.ts
+++ b/packages/simulation-sdk/test/handlers/blue/withdrawCollateral.test.ts
@@ -49,7 +49,21 @@ describe(type, () => {
         },
         dataFixture,
       ),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: invalid input: assets=-1]`);
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: invalid input: assets=-1
+
+      when simulating operation:
+      {
+        "type": "Blue_WithdrawCollateral",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "-1n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `);
   });
 
   test("should throw if insufficient balance", () => {
@@ -68,7 +82,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient position for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient position for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_WithdrawCollateral",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "50000000000000000000001n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -88,7 +116,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient collateral for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd]`,
+      `
+      [Error: insufficient collateral for user 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB on market 0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd
+
+      when simulating operation:
+      {
+        "type": "Blue_WithdrawCollateral",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "args": {
+          "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+          "assets": "50000000000000000000000n",
+          "onBehalf": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/erc20/approve.test.ts
+++ b/packages/simulation-sdk/test/handlers/erc20/approve.test.ts
@@ -119,7 +119,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: unknown allowance for token "0x1111111111111111111111111111111111111111" from owner "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" to spender "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: unknown allowance for token "0x1111111111111111111111111111111111111111" from owner "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" to spender "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Approve",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0x1111111111111111111111111111111111111111",
+        "args": {
+          "spender": "0x1111111111111111111111111111111111111111",
+          "amount": "1n"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/erc20/permit.test.ts
+++ b/packages/simulation-sdk/test/handlers/erc20/permit.test.ts
@@ -102,7 +102,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: unknown EIP-2612 data for token "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" of owner "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"]`,
+      `
+      [Error: unknown EIP-2612 data for token "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" of owner "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Permit",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        "args": {
+          "spender": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+          "amount": "1n",
+          "nonce": "0n"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/erc20/transfer.test.ts
+++ b/packages/simulation-sdk/test/handlers/erc20/transfer.test.ts
@@ -126,7 +126,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient allowance for token "0x000000000000000000000000000000000000000A" from owner "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" to spender "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"]`,
+      `
+      [Error: insufficient allowance for token "0x000000000000000000000000000000000000000A" from owner "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" to spender "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Transfer",
+        "sender": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": {
+          "amount": "1000000000000000000n",
+          "from": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "to": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -146,7 +160,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Transfer",
+        "sender": "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+        "address": "0x1111111111111111111111111111111111111111",
+        "args": {
+          "amount": "1000000n",
+          "from": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "to": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/erc20/transfer2.test.ts
+++ b/packages/simulation-sdk/test/handlers/erc20/transfer2.test.ts
@@ -55,7 +55,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient permit2 allowance for token "0x2222222222222222222222222222222222222222" from owner "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"]`,
+      `
+      [Error: insufficient permit2 allowance for token "0x2222222222222222222222222222222222222222" from owner "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Transfer2",
+        "sender": "0x4A6c312ec70E8747a587EE860a0353cd42Be0aE0",
+        "address": "0x2222222222222222222222222222222222222222",
+        "args": {
+          "amount": "1000000n",
+          "from": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "to": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 
@@ -75,7 +89,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Transfer2",
+        "sender": "0x6566194141eefa99Af43Bb5Aa71460Ca2Dc90245",
+        "address": "0x1111111111111111111111111111111111111111",
+        "args": {
+          "amount": "1000000n",
+          "from": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "to": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/erc20/unwrap.test.ts
+++ b/packages/simulation-sdk/test/handlers/erc20/unwrap.test.ts
@@ -46,7 +46,20 @@ describe(type, () => {
         wrapFixtures,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: unknown wrapped token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: unknown wrapped token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Unwrap",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0x1111111111111111111111111111111111111111",
+        "args": {
+          "amount": "1000000000000000000n",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -65,7 +78,20 @@ describe(type, () => {
         wrapFixtures,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x2222222222222222222222222222222222222222"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x2222222222222222222222222222222222222222"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Unwrap",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "address": "0x2222222222222222222222222222222222222222",
+        "args": {
+          "amount": "1000000000000000000n",
+          "receiver": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/erc20/wrap.test.ts
+++ b/packages/simulation-sdk/test/handlers/erc20/wrap.test.ts
@@ -46,7 +46,20 @@ describe(type, () => {
         wrapFixtures,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: unknown wrapped token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: unknown wrapped token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Wrap",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0x1111111111111111111111111111111111111111",
+        "args": {
+          "amount": "1000000n",
+          "owner": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -65,7 +78,20 @@ describe(type, () => {
         wrapFixtures,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "Erc20_Wrap",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "address": "0x2222222222222222222222222222222222222222",
+        "args": {
+          "amount": "1000000n",
+          "owner": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/metamorpho/deposit.test.ts
+++ b/packages/simulation-sdk/test/handlers/metamorpho/deposit.test.ts
@@ -201,7 +201,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x1111111111111111111111111111111111111111"
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_Deposit",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": {
+          "assets": "115792089237316195423570985008687907853269984665640564039457584007913129639935n",
+          "owner": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 
@@ -220,7 +233,20 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: all caps reached on vault "0x000000000000000000000000000000000000000A" (remaining requested: 890000000)]`,
+      `
+      [Error: all caps reached on vault "0x000000000000000000000000000000000000000A" (remaining requested: 890000000)
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_Deposit",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": {
+          "assets": "1000000000n",
+          "owner": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/metamorpho/publicReallocate.test.ts
+++ b/packages/simulation-sdk/test/handlers/metamorpho/publicReallocate.test.ts
@@ -95,7 +95,25 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: max outflow exceeded for vault "0x000000000000000000000000000000000000000A" on market "0x82b7572458381128c105a67bc944e36b6318aa3c8095074efe9da6274b8e236a"]`,
+      `
+      [Error: max outflow exceeded for vault "0x000000000000000000000000000000000000000A" on market "0x82b7572458381128c105a67bc944e36b6318aa3c8095074efe9da6274b8e236a"
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_PublicReallocate",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": {
+          "withdrawals": [
+            {
+              "id": "0x82b7572458381128c105a67bc944e36b6318aa3c8095074efe9da6274b8e236a",
+              "assets": "10000000n"
+            }
+          ],
+          "supplyMarketId": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd"
+        }
+      }]
+    `,
     );
   });
 
@@ -119,7 +137,25 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: max inflow exceeded for vault "0x000000000000000000000000000000000000000A" on market "0x82b7572458381128c105a67bc944e36b6318aa3c8095074efe9da6274b8e236a"]`,
+      `
+      [Error: max inflow exceeded for vault "0x000000000000000000000000000000000000000A" on market "0x82b7572458381128c105a67bc944e36b6318aa3c8095074efe9da6274b8e236a"
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_PublicReallocate",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": {
+          "withdrawals": [
+            {
+              "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+              "assets": "50000000n"
+            }
+          ],
+          "supplyMarketId": "0x82b7572458381128c105a67bc944e36b6318aa3c8095074efe9da6274b8e236a"
+        }
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/metamorpho/reallocate.test.ts
+++ b/packages/simulation-sdk/test/handlers/metamorpho/reallocate.test.ts
@@ -80,7 +80,26 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: inconsistent reallocation for vault "0x000000000000000000000000000000000000000A": total supplied (30000000) != total withdrawn (50000000)]`,
+      `
+      [Error: inconsistent reallocation for vault "0x000000000000000000000000000000000000000A": total supplied (30000000) != total withdrawn (50000000)
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_Reallocate",
+        "sender": "0x1DCE4B3eE7e3d194adDc02ceead91D0c9403a9df",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": [
+          {
+            "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+            "assets": "950000000n"
+          },
+          {
+            "id": "0x82b7572458381128c105a67bc944e36b6318aa3c8095074efe9da6274b8e236a",
+            "assets": "430000000n"
+          }
+        ]
+      }]
+    `,
     );
   });
 
@@ -105,7 +124,26 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: unknown config for vault "0x000000000000000000000000000000000000000A" on market "0x6ac1b39121c55504e845c0a07000bee40d85b9d432992ee34b00fa03b5d19b95"]`,
+      `
+      [Error: unknown config for vault "0x000000000000000000000000000000000000000A" on market "0x6ac1b39121c55504e845c0a07000bee40d85b9d432992ee34b00fa03b5d19b95"
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_Reallocate",
+        "sender": "0x1DCE4B3eE7e3d194adDc02ceead91D0c9403a9df",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": [
+          {
+            "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+            "assets": "950000000n"
+          },
+          {
+            "id": "0x6ac1b39121c55504e845c0a07000bee40d85b9d432992ee34b00fa03b5d19b95",
+            "assets": "115792089237316195423570985008687907853269984665640564039457584007913129639935n"
+          }
+        ]
+      }]
+    `,
     );
   });
 
@@ -130,7 +168,26 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: account 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB not allocator of vault "0x000000000000000000000000000000000000000b"]`,
+      `
+      [Error: account 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB not allocator of vault "0x000000000000000000000000000000000000000b"
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_Reallocate",
+        "sender": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+        "address": "0x000000000000000000000000000000000000000b",
+        "args": [
+          {
+            "id": "0x042487b563685b432d4d2341934985eca3993647799cb5468fb366fad26b4fdd",
+            "assets": "950000000n"
+          },
+          {
+            "id": "0x6ac1b39121c55504e845c0a07000bee40d85b9d432992ee34b00fa03b5d19b95",
+            "assets": "115792089237316195423570985008687907853269984665640564039457584007913129639935n"
+          }
+        ]
+      }]
+    `,
     );
   });
 });

--- a/packages/simulation-sdk/test/handlers/metamorpho/withdraw.test.ts
+++ b/packages/simulation-sdk/test/handlers/metamorpho/withdraw.test.ts
@@ -196,7 +196,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x000000000000000000000000000000000000000A"]`,
+      `
+      [Error: insufficient balance of user "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" for token "0x000000000000000000000000000000000000000A"
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_Withdraw",
+        "sender": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+        "address": "0x000000000000000000000000000000000000000A",
+        "args": {
+          "assets": "115792089237316195423570985008687907853269984665640564039457584007913129639935n",
+          "owner": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 
@@ -216,7 +230,21 @@ describe(type, () => {
         dataFixture,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: not enough liquidity on vault "0x000000000000000000000000000000000000000C" (remaining requested: 14000000000)]`,
+      `
+      [Error: not enough liquidity on vault "0x000000000000000000000000000000000000000C" (remaining requested: 14000000000)
+
+      when simulating operation:
+      {
+        "type": "MetaMorpho_Withdraw",
+        "sender": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+        "address": "0x000000000000000000000000000000000000000C",
+        "args": {
+          "assets": "15000000000n",
+          "owner": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+          "receiver": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+        }
+      }]
+    `,
     );
   });
 });


### PR DESCRIPTION
This PR introduces a breaking change because former operations that contained a valid "address: morpho" and operations in callbacks that contained a valid "sender: ..." will now raise typescript errors and the dev will have to remove them

I think it's ok to introduce such a breaking change in a minor version, because the fix is dead simple: remove whatever the dev input in these places