### PR TITLE
fix(simulation): replace infinite balance with dynamic tracking

### DIFF
--- a/packages/blue-sdk/src/holding/Holding.ts
+++ b/packages/blue-sdk/src/holding/Holding.ts
@@ -48,11 +48,6 @@ export class Holding implements IHolding {
   public readonly token: Address;
 
   /**
-   * The balance of the user for this token.
-   */
-  public balance: bigint;
-
-  /**
    * Whether the user is allowed to transfer this holding's balance.
    */
   public canTransfer?: boolean;
@@ -75,6 +70,11 @@ export class Holding implements IHolding {
    */
   public erc2612Nonce?: bigint;
 
+  /**
+   * Allows to customize the setter behavior in child classes.
+   */
+  protected _balance: bigint;
+
   constructor({
     user,
     token,
@@ -86,7 +86,7 @@ export class Holding implements IHolding {
   }: IHolding) {
     this.user = user;
     this.token = token;
-    this.balance = balance;
+    this._balance = balance;
     this.canTransfer = canTransfer;
     this.erc20Allowances = fromEntries(
       entries(erc20Allowances).map(([address, allowance]) => [
@@ -101,5 +101,15 @@ export class Holding implements IHolding {
     };
 
     if (erc2612Nonce != null) this.erc2612Nonce = erc2612Nonce;
+  }
+
+  /**
+   * The balance of the user for this token.
+   */
+  get balance() {
+    return this._balance;
+  }
+  set balance(value: bigint) {
+    this._balance = value;
   }
 }

--- a/packages/bundler-sdk-viem/src/operations.ts
+++ b/packages/bundler-sdk-viem/src/operations.ts
@@ -922,7 +922,7 @@ class VirtualHolding extends Holding {
   }
   set balance(value: bigint) {
     if (value < 0n) {
-      this.required = (this.required ?? 0n) + value;
+      this.required += -value;
 
       this._balance = 0n;
     } else this._balance = value;
@@ -955,7 +955,7 @@ export const simulateRequiredTokenAmounts = (
     .map(([token, holding]) => ({
       token,
       // Safe cast because the holding was transformed to a VirtualHolding.
-      required: -(holding as VirtualHolding).required,
+      required: (holding as VirtualHolding).required,
     }))
     .filter(({ required }) => required > 0n);
 };

--- a/packages/bundler-sdk-viem/src/operations.ts
+++ b/packages/bundler-sdk-viem/src/operations.ts
@@ -1,6 +1,7 @@
 import {
   type Address,
   DEFAULT_SLIPPAGE_TOLERANCE,
+  Holding,
   type MarketId,
   MarketUtils,
   MathLib,
@@ -11,13 +12,7 @@ import {
   permissionedBackedTokens,
   permissionedWrapperTokens,
 } from "@morpho-org/blue-sdk";
-import {
-  bigIntComparator,
-  entries,
-  getLast,
-  getValue,
-  keys,
-} from "@morpho-org/morpho-ts";
+import { entries, getLast, getValue, keys } from "@morpho-org/morpho-ts";
 import {
   type Erc20Operations,
   type MaybeDraft,
@@ -919,6 +914,21 @@ export const populateBundle = (
   return { operations, steps };
 };
 
+class VirtualHolding extends Holding {
+  public required = 0n;
+
+  get balance() {
+    return this._balance;
+  }
+  set balance(value: bigint) {
+    if (value < 0n) {
+      this.required = (this.required ?? 0n) + value;
+
+      this._balance = 0n;
+    } else this._balance = value;
+  }
+}
+
 export const simulateRequiredTokenAmounts = (
   operations: Operation[],
   data: MaybeDraft<SimulationState>,
@@ -928,43 +938,26 @@ export const simulateRequiredTokenAmounts = (
   } = getChainAddresses(data.chainId);
 
   const virtualBundlerData = produceImmutable(data, (draft) => {
-    Object.values(draft.holdings[generalAdapter1] ?? {}).forEach(
-      (bundlerTokenData) => {
-        if (bundlerTokenData == null) return;
+    const bundlerHoldings = draft.holdings[generalAdapter1];
+    if (bundlerHoldings == null) return;
 
-        // Virtual balance to calculate the amount required.
-        bundlerTokenData.balance += MathLib.MAX_UINT_160;
-      },
-    );
+    entries(bundlerHoldings).map(([token, holding]) => {
+      if (holding == null) return;
+
+      bundlerHoldings[token] = new VirtualHolding(holding);
+    });
   });
 
+  // Simulate the operations to calculate the required token amounts.
   const steps = simulateOperations(operations, virtualBundlerData);
 
-  const bundlerTokenDiffs = keys(
-    virtualBundlerData.holdings[generalAdapter1],
-  ).map((token) => ({
-    token,
-    required: steps
-      .map(
-        (step) =>
-          // When recursively simulated, this will cause tokens to be required at the highest recursion level.
-          // For example: supplyCollateral(x, supplyCollateral(y, borrow(z)))   [provided x, y, z < MAX_UINT_160]
-          //              |                   |                   |=> MAX_UINT_160 - (3 * MAX_UINT_160 + z) < 0
-          //              |                   |=> MAX_UINT_160 - (2 * MAX_UINT_160 - y) < 0
-          //              |=> MAX_UINT_160 - (MAX_UINT_160 - y - x) > 0
-          MathLib.MAX_UINT_160 -
-          (step.holdings[generalAdapter1]?.[token]?.balance ?? 0n),
-      )
-      .sort(
-        bigIntComparator(
-          (required) => required,
-          // Take the highest required amount among all operations.
-          "desc",
-        ),
-      )[0]!,
-  }));
-
-  return bundlerTokenDiffs.filter(({ required }) => required > 0n);
+  return entries(getLast(steps).holdings[generalAdapter1] ?? {})
+    .map(([token, holding]) => ({
+      token,
+      // Safe cast because the holding was transformed to a VirtualHolding.
+      required: -(holding as VirtualHolding).required,
+    }))
+    .filter(({ required }) => required > 0n);
 };
 
 export const getSimulatedBundlerOperation = (

--- a/packages/simulation-sdk-wagmi/test/hooks/useSimulationState.test.ts
+++ b/packages/simulation-sdk-wagmi/test/hooks/useSimulationState.test.ts
@@ -289,6 +289,13 @@ describe("useSimulationState", () => {
     client,
     expect,
   }) => {
+    const amount = 1_000000n;
+
+    await client.approve({
+      address: usdc,
+      args: [morpho, amount],
+    });
+
     const block = await client.getBlock();
 
     const { result } = await renderHook(config, () =>
@@ -311,7 +318,7 @@ describe("useSimulationState", () => {
             sender: morpho,
             address: usdc,
             args: {
-              amount: 1_000000n,
+              amount,
               from: client.account.address,
               to: morpho,
             },

--- a/packages/simulation-sdk/src/handlers/dispatchers.ts
+++ b/packages/simulation-sdk/src/handlers/dispatchers.ts
@@ -89,9 +89,4 @@ export const simulateOperation = (
 export const simulateOperations = (
   operations: Operation[],
   startData: MaybeDraft<SimulationState>,
-) =>
-  handleOperations(
-    operations,
-    produceImmutable(startData, () => {}),
-    simulateOperation,
-  );
+) => handleOperations(operations, startData, simulateOperation);

--- a/packages/simulation-sdk/src/handlers/erc20/transfer.ts
+++ b/packages/simulation-sdk/src/handlers/erc20/transfer.ts
@@ -28,9 +28,6 @@ export const handleErc20TransferOperation: OperationHandler<
     )
       amount = MathLib.min(amount, fromHolding.balance);
 
-    if (fromHolding.balance < amount)
-      throw new Erc20Errors.InsufficientBalance(address, from);
-
     if (sender !== from && from !== generalAdapter1) {
       // Check allowance for approval recipients (except for the bundler which doesn't need it).
       const contract =
@@ -62,6 +59,9 @@ export const handleErc20TransferOperation: OperationHandler<
     }
 
     fromHolding.balance -= amount;
+
+    if (fromHolding.balance < 0n)
+      throw new Erc20Errors.InsufficientBalance(address, from);
   }
 
   const toHolding = data.tryGetHolding(to, address);


### PR DESCRIPTION
Inside callbacks, we were not able to tell how much the GeneralAdapter1 had (all of its holdings were faked to be at least maxUint160) which is inconvenient when you want to use `maxUint256` edge cases of the GeneralAdapter1

This PR changes the way we simulate these balances by simply keeping track of whenever the balances of the adapter falls short and by how much, in another variable that is reported at the end