### PR TITLE
feat(blue-sdk-viem): provide utility for restructuring viem arrays->objs

### DIFF
--- a/packages/blue-sdk-viem/src/fetch/MarketParams.ts
+++ b/packages/blue-sdk-viem/src/fetch/MarketParams.ts
@@ -9,6 +9,7 @@ import type { Client } from "viem";
 import { getChainId, readContract } from "viem/actions";
 import { blueAbi } from "../abis";
 import type { FetchParameters } from "../types";
+import { restructure } from "../utils";
 
 export async function fetchMarketParams(
   id: MarketId,
@@ -22,25 +23,19 @@ export async function fetchMarketParams(
 
     const { morpho } = getChainAddresses(chainId);
 
-    const [loanToken, collateralToken, oracle, irm, lltv] = await readContract(
-      client,
-      {
-        address: morpho,
-        abi: blueAbi,
-        functionName: "idToMarketParams",
-        args: [id],
-        // Always fetch at latest block because config is immutable.
-        blockTag: "latest",
-      },
+    config = new MarketParams(
+      restructure(
+        await readContract(client, {
+          address: morpho,
+          abi: blueAbi,
+          functionName: "idToMarketParams",
+          args: [id],
+          // Always fetch at latest block because config is immutable.
+          blockTag: "latest",
+        }),
+        { abi: blueAbi, name: "idToMarketParams", args: ["0x"] },
+      ),
     );
-
-    config = new MarketParams({
-      loanToken,
-      collateralToken,
-      oracle,
-      irm,
-      lltv,
-    });
   }
 
   return config;

--- a/packages/blue-sdk-viem/src/fetch/Position.ts
+++ b/packages/blue-sdk-viem/src/fetch/Position.ts
@@ -7,6 +7,7 @@ import {
   getChainAddresses,
 } from "@morpho-org/blue-sdk";
 
+import { restructure } from "src/utils";
 import type { Address, Client } from "viem";
 import { getChainId, readContract } from "viem/actions";
 import { blueAbi, blueOracleAbi, preLiquidationAbi } from "../abis";
@@ -22,20 +23,21 @@ export async function fetchPosition(
   parameters.chainId ??= await getChainId(client);
 
   const { morpho } = getChainAddresses(parameters.chainId);
-  const [supplyShares, borrowShares, collateral] = await readContract(client, {
-    ...parameters,
-    address: morpho,
-    abi: blueAbi,
-    functionName: "position",
-    args: [marketId, user],
-  });
+  const position = restructure(
+    await readContract(client, {
+      ...parameters,
+      address: morpho,
+      abi: blueAbi,
+      functionName: "position",
+      args: [marketId, user],
+    }),
+    { abi: blueAbi, name: "position", args: ["0x", "0x"] },
+  );
 
   return new Position({
     user,
     marketId,
-    supplyShares,
-    borrowShares,
-    collateral,
+    ...position,
   });
 }
 

--- a/packages/blue-sdk-viem/src/utils.ts
+++ b/packages/blue-sdk-viem/src/utils.ts
@@ -1,4 +1,14 @@
-import { getAddress, parseUnits } from "viem";
+import {
+  type Abi,
+  type AbiItemName,
+  type ContractFunctionArgs,
+  type ContractFunctionName,
+  type ExtractAbiFunctionForArgs,
+  type GetAbiItemParameters,
+  getAbiItem,
+  getAddress,
+  parseUnits,
+} from "viem";
 
 // Alternative to Number.toFixed that doesn't use scientific notation for excessively small or large numbers.
 const toFixed = (x: number, decimals: number) =>
@@ -28,3 +38,127 @@ export const safeParseUnits = (strValue: string, decimals = 18) => {
     decimals,
   );
 };
+
+type ZipToObject<
+  T extends readonly { name?: string }[],
+  V extends readonly unknown[],
+> = T extends readonly [infer Head, ...infer RestT]
+  ? V extends readonly [infer HeadValue, ...infer RestV]
+    ? Head extends { name?: infer N }
+      ? N extends string
+        ? { [K in N]: HeadValue } & ZipToObject<
+            RestT extends readonly { name?: string }[] ? RestT : [],
+            RestV extends readonly unknown[] ? RestV : []
+          >
+        : ZipToObject<
+            RestT extends readonly { name?: string }[] ? RestT : [],
+            RestV extends readonly unknown[] ? RestV : []
+          >
+      : ZipToObject<
+          RestT extends readonly { name?: string }[] ? RestT : [],
+          RestV extends readonly unknown[] ? RestV : []
+        >
+    : object
+  : object;
+
+function zipParams<
+  T extends readonly { readonly name?: string }[],
+  V extends readonly unknown[],
+>(params: T, values: V): ZipToObject<T, V> {
+  return params.reduce(
+    (acc, param, index) => {
+      return typeof param.name === "string"
+        ? // biome-ignore lint/performance/noAccumulatingSpread: This keeps type system happy with negligible performance impact
+          { ...acc, [param.name]: values[index] }
+        : acc;
+    },
+    {} as ZipToObject<T, V>,
+  );
+}
+
+/**
+ * When reading contracts, viem converts onchain tuples into arrays -- even when tuple values are named in the ABI.
+ * [They argue](https://viem.sh/docs/faq#why-is-a-contract-function-return-type-returning-an-array-instead-of-an-object)
+ * this information loss is justified, as it eliminates the ambiguity between tuple return types and struct return
+ * types. This utility can be used to convert viem's arrays back to objects, _as if_ the onchain method returned a
+ * struct.
+ *
+ * @example
+ *
+ * ```
+ * // Use with viem...
+ * const params = restructure(
+ *   await readContract(client, {
+ *     ...parameters,
+ *     address: morpho,
+ *     abi: blueAbi,
+ *     functionName: "idToMarketParams",
+ *     args: [id],
+ *   }),
+ *   // These `args` should be placeholders; just match the type of the actual `args` above
+ *   { abi: blueAbi, name: "idToMarketParams", args: ["0x"] },
+ * )
+ * ```
+ *
+ * @example
+ *
+ * ```
+ * // Use with wagmi hook...
+ * const { data: marketsData } = useReadContracts({
+ *   contracts: marketIds.map(
+ *     (marketId) =>
+ *       ({
+ *         chainId,
+ *         address: morphoAddress,
+ *         abi: morphoAbi,
+ *         functionName: "market",
+ *         args: [marketId],
+ *       }) as const,
+ *   ),
+ *   allowFailure: false,
+ *   query: {
+ *     select(data) {
+ *       // These `args` should be placeholders; just match the type of the actual `args` above
+ *       return data.map((x) => restructure(x, { abi: morphoAbi, name: "market", args: ["0x"] }));
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function restructure<
+  abi extends Abi,
+  name extends ContractFunctionName<abi, "view" | "pure">,
+  args extends ContractFunctionArgs<abi, "view" | "pure", name>,
+  outputs extends readonly unknown[],
+>(
+  outputs: outputs,
+  parameters: GetAbiItemParameters<
+    abi,
+    name extends AbiItemName<abi> ? name : never,
+    args
+  >,
+) {
+  const x = getAbiItem(parameters);
+  switch (x?.type) {
+    case "function": {
+      if (x.outputs.some((output) => output.name === undefined)) {
+        throw new Error(
+          `Attempted to restructure return values lacking names in ABI ${parameters.args!} ${x.outputs}`,
+        );
+      }
+      return zipParams(
+        x.outputs as ExtractAbiFunctionForArgs<
+          abi,
+          "view" | "pure",
+          name,
+          args
+        >["outputs"],
+        outputs,
+      );
+    }
+    default:
+      throw new Error(
+        `Attempted to restructure return values for non-function type ${x}`,
+      );
+  }
+}


### PR DESCRIPTION
Provide a utility that converts viem's array-style outputs back to objects by referencing the ABI. Works whenever Solidity tuples are named, which is the case for most (all?) Morpho contracts.

One thing that may be unexpected a priori is that you have to pass placeholder args to the restructuring function, i.e. "0x" for an `address` param -- this is so that the type system can disambiguate between overloaded methods.

I've adapted some of the SDK code to use the new utility, so we have TypeScript-level correctness guarantees going forward (no chance of accidentally ordering array destructuring elements incorrectly).