### PR TITLE
fix(liquidation-sdk-viem): add pagination and where clause splitting

### DIFF
--- a/packages/liquidation-sdk-viem/graphql/GetAssetByAddress.query.gql
+++ b/packages/liquidation-sdk-viem/graphql/GetAssetByAddress.query.gql
@@ -1,0 +1,5 @@
+query getAssetByAddress($chainId: Int!, $address: String!) {
+  assetByAddress(chainId: $chainId, address: $address) {
+    priceUsd
+  }
+}

--- a/packages/liquidation-sdk-viem/graphql/GetLiquidatablePositions.query.gql
+++ b/packages/liquidation-sdk-viem/graphql/GetLiquidatablePositions.query.gql
@@ -1,23 +1,41 @@
 query getLiquidatablePositions(
   $chainId: Int!
-  $wNative: String!
   $marketIds: [String!]
-  $first: Int = 1000
+  $skip: Int
+  $first: Int = 100
+  $orderBy: MarketPositionOrderBy
+  $orderDirection: OrderDirection
 ) {
-  assetByAddress(chainId: $chainId, address: $wNative) {
-    priceUsd
-  }
-
   marketPositions(
+    skip: $skip
     first: $first
     where: {
       chainId_in: [$chainId]
       marketUniqueKey_in: $marketIds
       healthFactor_lte: 1
     }
+    orderBy: $orderBy
+    orderDirection: $orderDirection
   ) {
+    pageInfo {
+      count
+      countTotal
+      limit
+      skip
+    }
     items {
-      ...MarketPosition
+      healthFactor
+      user {
+        address
+      }
+      market {
+        uniqueKey
+      }
+      state {
+        borrowShares
+        collateral
+        supplyShares
+      }
     }
   }
 }

--- a/packages/liquidation-sdk-viem/graphql/GetMarketsAssets.query.gql
+++ b/packages/liquidation-sdk-viem/graphql/GetMarketsAssets.query.gql
@@ -1,5 +1,24 @@
-query getMarketsAssets($chainId: Int!, $marketIds: [String!]!) {
-  markets(where: { chainId_in: [$chainId], uniqueKey_in: $marketIds }) {
+query getMarketsAssets(
+  $chainId: Int!
+  $marketIds: [String!]!
+  $skip: Int
+  $first: Int = 100
+  $orderBy: MarketOrderBy
+  $orderDirection: OrderDirection
+) {
+  markets(
+    skip: $skip
+    first: $first
+    where: { chainId_in: [$chainId], uniqueKey_in: $marketIds }
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+  ) {
+    pageInfo {
+      count
+      countTotal
+      limit
+      skip
+    }
     items {
       uniqueKey
       collateralAsset {

--- a/packages/liquidation-sdk-viem/src/api/index.ts
+++ b/packages/liquidation-sdk-viem/src/api/index.ts
@@ -2,6 +2,8 @@ import { GraphQLClient } from "graphql-request";
 
 import { BLUE_API_GRAPHQL_URL } from "@morpho-org/morpho-ts";
 
+import type { InputMaybe, OrderDirection } from "@morpho-org/blue-api-sdk";
+import type { MarketId } from "@morpho-org/blue-sdk";
 import { getSdk } from "./sdk.js";
 
 export * from "./sdk.js";
@@ -10,3 +12,127 @@ export * from "./types.js";
 export const apiSdk: ReturnType<typeof getSdk> = getSdk(
   new GraphQLClient(BLUE_API_GRAPHQL_URL),
 );
+
+type QueryVariables = Record<string, unknown>;
+
+export type PaginationVariables<V extends QueryVariables> = V & {
+  first?: number;
+  skip?: number;
+  orderDirection?: InputMaybe<OrderDirection>;
+};
+
+export interface PageInfo {
+  count: number;
+  countTotal: number;
+  limit: number;
+  skip: number;
+}
+
+export interface PageResult<T> {
+  items: T[] | null;
+  pageInfo: PageInfo | null;
+}
+
+export async function paginatedQuery<T, V extends QueryVariables = {}>(
+  fetchPage: (vars: PaginationVariables<V>) => Promise<PageResult<T>>,
+  {
+    pageSize,
+    orderBy,
+    orderDirection,
+    args,
+  }: {
+    pageSize: number;
+    orderBy?: string;
+    orderDirection?: InputMaybe<OrderDirection>;
+    args: PaginationVariables<V>;
+  },
+): Promise<T[]> {
+  // 1) Fetch the first page serially to get total count
+  const firstVars: PaginationVariables<V> = {
+    ...args,
+    first: pageSize,
+    ...(orderBy != null ? { orderBy } : {}),
+    ...(orderDirection != null ? { orderDirection } : {}),
+    skip: 0,
+  };
+  const firstPage = await fetchPage(firstVars);
+  const countTotal = firstPage.pageInfo?.countTotal ?? 0;
+
+  if (firstPage.items == null) {
+    console.warn(`paginatedQuery: received null items on first page`);
+  }
+  if (firstPage.pageInfo == null) {
+    console.warn(`paginatedQuery: received null pageInfo on first page`);
+  }
+
+  const allItems: T[] = firstPage.items ?? [];
+
+  // 2) Calculate how many additional pages we need
+  const totalPages = Math.ceil(countTotal / pageSize);
+  if (totalPages <= 1) {
+    return allItems;
+  }
+
+  // 3) Kick off all remaining page fetches in parallel
+  const pagePromises: Promise<PageResult<T>>[] = [];
+  for (let pageIndex = 1; pageIndex < totalPages; pageIndex++) {
+    pagePromises.push(fetchPage({ ...firstVars, skip: pageIndex * pageSize }));
+  }
+
+  // 4) Wait for them all
+  const otherPages = await Promise.all(pagePromises);
+
+  // 5) Flatten, warning on nulls
+  otherPages.forEach((page, idx) => {
+    const { items } = page;
+    const pageNum = idx + 2; // human-friendly page number
+    if (items == null) {
+      console.warn(
+        `paginateGraphQLConcurrent: received null items on page ${pageNum}`,
+      );
+    } else {
+      allItems.push(...items);
+    }
+  });
+
+  // 6) Return full list + last pageInfo (from the last fetch)
+  return allItems;
+}
+
+export async function paginatedQueryWithChunkedMarketIds<
+  T,
+  V extends QueryVariables & { marketIds: MarketId[] },
+>(
+  fetchPage: (vars: PaginationVariables<V>) => Promise<PageResult<T>>,
+  {
+    maxMarketIds,
+    pageSize,
+    orderBy,
+    orderDirection,
+    args,
+  }: {
+    maxMarketIds: number;
+    pageSize: number;
+    orderBy?: string;
+    orderDirection?: InputMaybe<OrderDirection>;
+    args: PaginationVariables<V>;
+  },
+): Promise<T[]> {
+  const chunks: MarketId[][] = [];
+  for (let i = 0; i < args.marketIds.length; i += maxMarketIds) {
+    chunks.push(args.marketIds.slice(i, i + maxMarketIds));
+  }
+
+  const results = await Promise.all(
+    chunks.map((chunk) =>
+      paginatedQuery<T, V>((vars) => fetchPage({ ...vars, marketIds: chunk }), {
+        pageSize,
+        orderBy,
+        orderDirection,
+        args,
+      }),
+    ),
+  );
+
+  return results.flat();
+}

--- a/packages/liquidation-sdk-viem/src/api/types.ts
+++ b/packages/liquidation-sdk-viem/src/api/types.ts
@@ -1,21 +1,40 @@
 import type * as Types from "@morpho-org/blue-api-sdk";
 
+export type GetAssetByAddressQueryVariables = Types.Exact<{
+  chainId: Types.Scalars["Int"]["input"];
+  address: Types.Scalars["String"]["input"];
+}>;
+
+export type GetAssetByAddressQuery = {
+  __typename?: "Query";
+  assetByAddress: { __typename?: "Asset"; priceUsd: number | null };
+};
+
 export type GetLiquidatablePositionsQueryVariables = Types.Exact<{
   chainId: Types.Scalars["Int"]["input"];
-  wNative: Types.Scalars["String"]["input"];
   marketIds?: Types.InputMaybe<
     Array<Types.Scalars["String"]["input"]> | Types.Scalars["String"]["input"]
   >;
+  skip?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
   first?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  orderBy?: Types.InputMaybe<Types.MarketPositionOrderBy>;
+  orderDirection?: Types.InputMaybe<Types.OrderDirection>;
 }>;
 
 export type GetLiquidatablePositionsQuery = {
   __typename?: "Query";
-  assetByAddress: { __typename?: "Asset"; priceUsd: number | null };
   marketPositions: {
     __typename?: "PaginatedMarketPositions";
+    pageInfo: {
+      __typename?: "PageInfo";
+      count: number;
+      countTotal: number;
+      limit: number;
+      skip: number;
+    } | null;
     items: Array<{
       __typename?: "MarketPosition";
+      healthFactor: number | null;
       user: {
         __typename?: "User";
         address: Types.Scalars["Address"]["output"];
@@ -23,23 +42,13 @@ export type GetLiquidatablePositionsQuery = {
       market: {
         __typename?: "Market";
         uniqueKey: Types.Scalars["MarketId"]["output"];
-        collateralAsset: {
-          __typename?: "Asset";
-          address: Types.Scalars["Address"]["output"];
-          decimals: number;
-          symbol: string;
-          priceUsd: number | null;
-          spotPriceEth: number | null;
-        } | null;
-        loanAsset: {
-          __typename?: "Asset";
-          address: Types.Scalars["Address"]["output"];
-          decimals: number;
-          symbol: string;
-          priceUsd: number | null;
-          spotPriceEth: number | null;
-        };
       };
+      state: {
+        __typename?: "MarketPositionState";
+        borrowShares: Types.Scalars["BigInt"]["output"];
+        collateral: Types.Scalars["BigInt"]["output"];
+        supplyShares: Types.Scalars["BigInt"]["output"];
+      } | null;
     }> | null;
   };
 };
@@ -49,12 +58,23 @@ export type GetMarketsAssetsQueryVariables = Types.Exact<{
   marketIds:
     | Array<Types.Scalars["String"]["input"]>
     | Types.Scalars["String"]["input"];
+  skip?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  first?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  orderBy?: Types.InputMaybe<Types.MarketOrderBy>;
+  orderDirection?: Types.InputMaybe<Types.OrderDirection>;
 }>;
 
 export type GetMarketsAssetsQuery = {
   __typename?: "Query";
   markets: {
     __typename?: "PaginatedMarkets";
+    pageInfo: {
+      __typename?: "PageInfo";
+      count: number;
+      countTotal: number;
+      limit: number;
+      skip: number;
+    } | null;
     items: Array<{
       __typename?: "Market";
       uniqueKey: Types.Scalars["MarketId"]["output"];

--- a/packages/liquidation-sdk-viem/test/examples/helpers.ts
+++ b/packages/liquidation-sdk-viem/test/examples/helpers.ts
@@ -1,0 +1,103 @@
+import type { IPosition } from "@morpho-org/blue-sdk";
+import { BLUE_API_BASE_URL } from "@morpho-org/morpho-ts";
+import nock from "nock";
+import type { Address } from "viem";
+
+export function nockBlueApi(
+  {
+    ethPriceUsd,
+    collateralToken,
+    loanToken,
+    collateralPriceUsd,
+    loanPriceUsd,
+    position,
+  }: {
+    ethPriceUsd: number;
+    collateralToken: { address: Address; decimals: number };
+    loanToken: { address: Address; decimals: number };
+    collateralPriceUsd: number;
+    loanPriceUsd: number;
+    position: IPosition;
+  },
+  forPreLiquidations = false,
+) {
+  const marketAssetsData = {
+    markets: {
+      pageInfo: {
+        count: 1,
+        countTotal: 1,
+        limit: 100,
+        skip: 0,
+      },
+      items: [
+        {
+          uniqueKey: position.marketId,
+          collateralAsset: {
+            address: collateralToken.address,
+            decimals: collateralToken.decimals,
+            priceUsd: collateralPriceUsd,
+            spotPriceEth: collateralPriceUsd / ethPriceUsd,
+          },
+          loanAsset: {
+            address: loanToken.address,
+            decimals: loanToken.decimals,
+            priceUsd: loanPriceUsd,
+            spotPriceEth: loanPriceUsd / ethPriceUsd,
+          },
+        },
+      ],
+    },
+  };
+
+  const basicMocks = nock(BLUE_API_BASE_URL)
+    // request for whitelisted marketIds
+    .post("/graphql")
+    .reply(200, {
+      data: { markets: { items: [{ uniqueKey: position.marketId }] } },
+    })
+    // request for wNative price
+    .post("/graphql")
+    .reply(200, {
+      data: {
+        assetByAddress: {
+          priceUsd: ethPriceUsd,
+          spotPriceEth: 1,
+        },
+      },
+    })
+    // request for market assets
+    .post("/graphql")
+    .reply(200, { data: marketAssetsData })
+    // request for liquidatable positions
+    .post("/graphql")
+    .reply(200, {
+      data: {
+        marketPositions: {
+          pageInfo: {
+            count: 1,
+            countTotal: 1,
+            limit: 100,
+            skip: 0,
+          },
+          items: forPreLiquidations
+            ? []
+            : [
+                {
+                  user: { address: position.user },
+                  market: {
+                    uniqueKey: position.marketId,
+                  },
+                  state: {
+                    supplyShares: position.supplyShares,
+                    borrowShares: position.borrowShares,
+                    collateral: position.collateral,
+                  },
+                },
+              ],
+        },
+      },
+    });
+
+  // extra request for market assets (for preliquidations)
+  return basicMocks.post("/graphql").reply(200, { data: marketAssetsData });
+}

--- a/packages/liquidation-sdk-viem/test/examples/helpers.ts
+++ b/packages/liquidation-sdk-viem/test/examples/helpers.ts
@@ -49,7 +49,7 @@ export function nockBlueApi(
     },
   };
 
-  const basicMocks = nock(BLUE_API_BASE_URL)
+  nock(BLUE_API_BASE_URL)
     // request for whitelisted marketIds
     .post("/graphql")
     .reply(200, {
@@ -79,25 +79,26 @@ export function nockBlueApi(
             limit: 100,
             skip: 0,
           },
-          items: forPreLiquidations
-            ? []
-            : [
-                {
-                  user: { address: position.user },
-                  market: {
-                    uniqueKey: position.marketId,
-                  },
-                  state: {
-                    supplyShares: position.supplyShares,
-                    borrowShares: position.borrowShares,
-                    collateral: position.collateral,
-                  },
-                },
-              ],
+          items: [
+            {
+              user: { address: position.user },
+              market: {
+                uniqueKey: position.marketId,
+              },
+              state: {
+                supplyShares: position.supplyShares,
+                borrowShares: position.borrowShares,
+                collateral: position.collateral,
+              },
+            },
+          ],
         },
       },
     });
 
-  // extra request for market assets (for preliquidations)
-  return basicMocks.post("/graphql").reply(200, { data: marketAssetsData });
+  if (forPreLiquidations) {
+    nock(BLUE_API_BASE_URL)
+      .post("/graphql")
+      .reply(200, { data: marketAssetsData });
+  }
 }


### PR DESCRIPTION
afaict, the new infra has a constraint on both the number of `marketIds` you can have in a single `where` clause, and a response size limit. This broke the liquidation SDK.

This change fixes it by introducing full pagination support at the response level, and request chunking at the marketId level.

Closes INTEG-2621