### PR TITLE
fix(approval): allow allowance reset for usdt-like tokens

### DIFF
--- a/packages/simulation-sdk/src/handlers/erc20/approve.ts
+++ b/packages/simulation-sdk/src/handlers/erc20/approve.ts
@@ -28,7 +28,8 @@ export const handleErc20ApproveOperation: OperationHandler<
   if (contract != null) {
     if (
       APPROVE_ONLY_ONCE_TOKENS[data.chainId]?.includes(address) &&
-      senderTokenData.erc20Allowances[contract] > 0n
+      senderTokenData.erc20Allowances[contract] > 0n &&
+      amount > 0n
     )
       throw new NonZeroAllowanceError(address, sender, contract, amount);
 


### PR DESCRIPTION
Fixes: INFRA-900

The check was preventing the allowance from being reset to 0.