### PR TITLE
Fix wExp in AdaptiveCurveIrmLib.ts

### DIFF
--- a/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.ts
+++ b/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.ts
@@ -58,7 +58,7 @@ export namespace AdaptiveCurveIrmLib {
     const expR = MathLib.WAD + r + (r * r) / MathLib.WAD / 2n;
 
     // Return e^x = 2^q * e^r.
-    if (q === 0n) return expR << q;
+    if (q >= 0n) return expR << q;
     return expR >> -q;
   }
 


### PR DESCRIPTION
This implementation is confusing. When q is tested to be *equal* to zero, a left shift by 0 does nothing.

I suppose this is a port to javascript / typescript of this solidity code in https://github.com/morpho-org/morpho-blue-irm/blob/0e99e647c9bd6d3207f450144b6053cf807fa8c4/src/adaptive-curve-irm/libraries/ExpLib.sol#L45
```
// Return e^x = 2^q * e^r.
if (q >= 0) return expR << uint256(q);
else return expR >> uint256(-q);
```

Note the test is q >= 0, not q == 0.

In the current implementation, the right shift will be used, even if q is positive, i.e. -q is negative. This (probably) works because BigInt in javascript supports negative shifts.

However this is confusing when reading the code, and make it unobvious that this behaves like the original solidity code. Changing the test to the same form as the original solidity code fixes that.