### PR TITLE
fix: bigint type policy for vault position state assets and shares

### DIFF
--- a/packages/blue-api-sdk/src/cache.ts
+++ b/packages/blue-api-sdk/src/cache.ts
@@ -560,6 +560,12 @@ export const typePolicies = {
       supplyShares: {
         read: readMaybeBigInt,
       },
+      assets: {
+        read: readMaybeBigInt,
+      },
+      shares: {
+        read: readMaybeBigInt,
+      },
       position: {
         merge: true,
       },


### PR DESCRIPTION
There was a missing bigint type conversion for apollo cache. Probably when the `shares` and `assets` fields were moved from the root of VaultPosition to VaultPositionState. How can we make sure that we don't forget to update this typePolicy file in the future? It can create bugs that are hard to predict.