### PR TITLE
fix(market-utils): update apy calculation

### DIFF
--- a/packages/blue-sdk-viem/src/utils.ts
+++ b/packages/blue-sdk-viem/src/utils.ts
@@ -12,38 +12,12 @@ import {
   type Transport,
   getAbiItem,
   getAddress,
-  parseUnits,
 } from "viem";
 import { readContract } from "viem/actions";
-
-// Alternative to Number.toFixed that doesn't use scientific notation for excessively small or large numbers.
-const toFixed = (x: number, decimals: number) =>
-  new Intl.NumberFormat("en-US", {
-    style: "decimal",
-    useGrouping: false,
-    maximumFractionDigits: decimals,
-    minimumFractionDigits: decimals,
-  }).format(x);
+export { safeParseNumber, safeParseUnits } from "@morpho-org/blue-sdk";
 
 export const safeGetAddress = (address: string) =>
   getAddress(address.toLowerCase());
-
-export const safeParseNumber = (value: number, decimals = 18) =>
-  safeParseUnits(toFixed(value, decimals), decimals);
-
-export const safeParseUnits = (strValue: string, decimals = 18) => {
-  if (!/[-+]?[0-9]*\.?[0-9]+/.test(strValue))
-    throw Error(`invalid number: ${strValue}`);
-
-  let [whole, dec = ""] = strValue.split(".");
-
-  dec = dec.slice(0, decimals);
-
-  return parseUnits(
-    [whole || "0", dec].filter((v) => v.length > 0).join("."),
-    decimals,
-  );
-};
 
 type ZipToObject<
   T extends readonly { name?: string }[],

--- a/packages/blue-sdk/src/index.ts
+++ b/packages/blue-sdk/src/index.ts
@@ -11,3 +11,4 @@ export * from "./holding/index.js";
 export * from "./position/index.js";
 export * from "./vault/index.js";
 export * from "./preLiquidation.js";
+export * from "./utils.js";

--- a/packages/blue-sdk/src/market/Market.ts
+++ b/packages/blue-sdk/src/market/Market.ts
@@ -156,7 +156,7 @@ export class Market implements IMarket {
   get apyAtTarget() {
     if (this.rateAtTarget == null) return;
 
-    return MarketUtils.compoundRate(this.rateAtTarget);
+    return MarketUtils.rateToApy(this.rateAtTarget);
   }
 
   /**
@@ -303,7 +303,7 @@ export class Market implements IMarket {
   public getBorrowApy(timestamp: BigIntish = Time.timestamp()) {
     const borrowRate = this.getEndBorrowRate(timestamp);
 
-    return MarketUtils.compoundRate(borrowRate);
+    return MarketUtils.rateToApy(borrowRate);
   }
 
   /**
@@ -332,7 +332,7 @@ export class Market implements IMarket {
   public getAvgBorrowApy(timestamp: BigIntish = Time.timestamp()) {
     const borrowRate = this.getAvgBorrowRate(timestamp);
 
-    return MarketUtils.compoundRate(borrowRate);
+    return MarketUtils.rateToApy(borrowRate);
   }
 
   /**

--- a/packages/blue-sdk/src/market/MarketUtils.ts
+++ b/packages/blue-sdk/src/market/MarketUtils.ts
@@ -94,20 +94,27 @@ export namespace MarketUtils {
   }
 
   /**
-   * Returns the per-second rate continuously compounded over the given period (scaled by WAD),
-   * as calculated in Morpho Blue assuming the market is frequently accrued onchain.
-   * If the period is 1 year, the compounded rate correspond to the Annual Percentage Yield (APY).
+   * Returns the per-second rate continuously compounded over the given period, as calculated in Morpho Blue (scaled by WAD).
    * @param rate The per-second rate to compound (scaled by WAD).
    * @param period The period to compound the rate over (in seconds). Defaults to 1 year.
-   * @deprecated The compounded rate is inaccurate if period is small (use `wTaylorCompounded` instead).
+   * @deprecated The compounded rate is inaccurate if rate * period >> 0. If interested in the APY, use `rateToApy` instead.
    */
-  // TODO: force period = SECONDS_PER_YER and always return a Number for APYs.
   export function compoundRate(
     rate: BigIntish,
     period: BigIntish = SECONDS_PER_YEAR,
   ) {
+    return MathLib.wTaylorCompounded(rate, period);
+  }
+
+  /**
+   * Returns the per-second rate continuously compounded over a year (scaled by WAD),
+   * as calculated in Morpho Blue assuming the market is frequently accrued onchain.
+   * @param rate The per-second rate to compound annually (scaled by WAD).
+   */
+  // TODO: return a Number for APYs.
+  export function rateToApy(rate: BigIntish) {
     return safeParseNumber(
-      Math.expm1(+formatEther(BigInt(rate) * BigInt(period))),
+      Math.expm1(+formatEther(BigInt(rate) * SECONDS_PER_YEAR)),
     );
   }
 

--- a/packages/blue-sdk/src/market/MarketUtils.ts
+++ b/packages/blue-sdk/src/market/MarketUtils.ts
@@ -1,5 +1,7 @@
+import { safeParseNumber } from "@morpho-org/blue-sdk-viem";
 import { keccak_256 } from "@noble/hashes/sha3";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import { formatEther } from "viem";
 import {
   LIQUIDATION_CURSOR,
   MAX_LIQUIDATION_INCENTIVE_FACTOR,
@@ -92,16 +94,21 @@ export namespace MarketUtils {
   }
 
   /**
-   * Returns the per-second rate continuously compounded over the given period, as calculated in Morpho Blue (scaled by WAD).
-   * If the period is 1 year, the compounded rate correspond to the Annual Percentage Yield (APY)
+   * Returns the per-second rate continuously compounded over the given period (scaled by WAD),
+   * as calculated in Morpho Blue assuming the market is frequently accrued onchain.
+   * If the period is 1 year, the compounded rate correspond to the Annual Percentage Yield (APY).
    * @param rate The per-second rate to compound (scaled by WAD).
    * @param period The period to compound the rate over (in seconds). Defaults to 1 year.
+   * @deprecated The compounded rate is inaccurate if period is small (use `wTaylorCompounded` instead).
    */
+  // TODO: force period = SECONDS_PER_YER.
   export function compoundRate(
     rate: BigIntish,
     period: BigIntish = SECONDS_PER_YEAR,
   ) {
-    return MathLib.wTaylorCompounded(rate, period);
+    return safeParseNumber(
+      Math.expm1(+formatEther(BigInt(rate) * BigInt(period))),
+    );
   }
 
   /**

--- a/packages/blue-sdk/src/market/MarketUtils.ts
+++ b/packages/blue-sdk/src/market/MarketUtils.ts
@@ -1,4 +1,3 @@
-import { safeParseNumber } from "@morpho-org/blue-sdk-viem";
 import { keccak_256 } from "@noble/hashes/sha3";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
 import { formatEther } from "viem";
@@ -10,6 +9,7 @@ import {
 } from "../constants.js";
 import { MathLib, type RoundingDirection, SharesMath } from "../math/index.js";
 import type { BigIntish, MarketId } from "../types.js";
+import { safeParseNumber } from "../utils.js";
 import type { IMarketParams } from "./MarketParams.js";
 
 /**
@@ -101,7 +101,7 @@ export namespace MarketUtils {
    * @param period The period to compound the rate over (in seconds). Defaults to 1 year.
    * @deprecated The compounded rate is inaccurate if period is small (use `wTaylorCompounded` instead).
    */
-  // TODO: force period = SECONDS_PER_YER.
+  // TODO: force period = SECONDS_PER_YER and always return a Number for APYs.
   export function compoundRate(
     rate: BigIntish,
     period: BigIntish = SECONDS_PER_YEAR,

--- a/packages/blue-sdk/src/utils.ts
+++ b/packages/blue-sdk/src/utils.ts
@@ -1,0 +1,76 @@
+// Alternative to Number.toFixed that doesn't use scientific notation for excessively small or large numbers.
+const toFixed = (x: number, decimals: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "decimal",
+    useGrouping: false,
+    maximumFractionDigits: decimals,
+    minimumFractionDigits: decimals,
+  }).format(x);
+
+export const safeParseNumber = (value: number, decimals = 18) =>
+  safeParseUnits(toFixed(value, decimals), decimals);
+
+export const safeParseUnits = (strValue: string, decimals = 18) => {
+  if (!/[-+]?[0-9]*\.?[0-9]+/.test(strValue))
+    throw Error(`invalid number: ${strValue}`);
+
+  let [whole, dec = ""] = strValue.split(".");
+
+  dec = dec.slice(0, decimals);
+
+  return parseUnits(
+    [whole || "0", dec].filter((v) => v.length > 0).join("."),
+    decimals,
+  );
+};
+
+/**
+ * Multiplies a string representation of a number by a given exponent of base 10 (10exponent).
+ *
+ * - Docs: https://viem.sh/docs/utilities/parseUnits
+ *
+ * @example
+ * import { parseUnits } from 'viem'
+ *
+ * parseUnits('420', 9)
+ * // 420000000000n
+ */
+// TODO: get rid of this copy.
+function parseUnits(value: string, decimals: number) {
+  let [integer, fraction = "0"] = value.split(".");
+
+  const negative = integer!.startsWith("-");
+  if (negative) integer = integer!.slice(1);
+
+  // trim trailing zeros.
+  fraction = fraction.replace(/(0+)$/, "");
+
+  // round off if the fraction is larger than the number of decimals.
+  if (decimals === 0) {
+    if (Math.round(Number(`.${fraction}`)) === 1)
+      integer = `${BigInt(integer!) + 1n}`;
+    fraction = "";
+  } else if (fraction.length > decimals) {
+    const [left, unit, right] = [
+      fraction.slice(0, decimals - 1),
+      fraction.slice(decimals - 1, decimals),
+      fraction.slice(decimals),
+    ];
+
+    const rounded = Math.round(Number(`${unit}.${right}`));
+    if (rounded > 9)
+      fraction = `${BigInt(left) + BigInt(1)}0`.padStart(left.length + 1, "0");
+    else fraction = `${left}${rounded}`;
+
+    if (fraction.length > decimals) {
+      fraction = fraction.slice(1);
+      integer = `${BigInt(integer!) + 1n}`;
+    }
+
+    fraction = fraction.slice(0, decimals);
+  } else {
+    fraction = fraction.padEnd(decimals, "0");
+  }
+
+  return BigInt(`${negative ? "-" : ""}${integer}${fraction}`);
+}

--- a/packages/blue-sdk/test/unit/MarketUtils.test.ts
+++ b/packages/blue-sdk/test/unit/MarketUtils.test.ts
@@ -1,8 +1,6 @@
 import { parseUnits } from "viem";
-import { MarketUtils, MathLib, SECONDS_PER_YEAR } from "../../src/index.js";
-
-import { Time } from "@morpho-org/morpho-ts";
 import { describe, expect, test } from "vitest";
+import { MarketUtils, MathLib, SECONDS_PER_YEAR } from "../../src/index.js";
 
 const market = {
   loanToken: "0x0000000000000000000000000000000000000001",
@@ -112,21 +110,15 @@ describe("MarketUtils", () => {
 
   test("should continuously compound rates", () => {
     expect(
-      MarketUtils.compoundRate(parseUnits("3", 16) / SECONDS_PER_YEAR),
+      MarketUtils.rateToApy(parseUnits("3", 16) / SECONDS_PER_YEAR),
     ).toEqual(3_0454533936848223n);
 
     expect(
-      MarketUtils.compoundRate(
-        parseUnits("40", 16) / SECONDS_PER_YEAR,
-        Time.s.from.mo(1),
-      ),
-    ).toEqual(3_4556262331251440n);
+      MarketUtils.rateToApy(parseUnits("40", 16) / SECONDS_PER_YEAR),
+    ).toEqual(49_1824697617472700n);
 
     expect(
-      MarketUtils.compoundRate(
-        parseUnits("500", 16) / SECONDS_PER_YEAR,
-        Time.s.from.mo(8),
-      ),
-    ).toEqual(288_82118976199070000n);
+      MarketUtils.rateToApy(parseUnits("500", 16) / SECONDS_PER_YEAR),
+    ).toEqual(14741_3159098725030000n);
   });
 });

--- a/packages/blue-sdk/test/unit/MarketUtils.test.ts
+++ b/packages/blue-sdk/test/unit/MarketUtils.test.ts
@@ -113,20 +113,20 @@ describe("MarketUtils", () => {
   test("should continuously compound rates", () => {
     expect(
       MarketUtils.compoundRate(parseUnits("3", 16) / SECONDS_PER_YEAR),
-    ).toEqual(3_0454499983331440n);
+    ).toEqual(3_0454533936848223n);
 
     expect(
       MarketUtils.compoundRate(
         parseUnits("40", 16) / SECONDS_PER_YEAR,
         Time.s.from.mo(1),
       ),
-    ).toEqual(3_4556206450587179n);
+    ).toEqual(3_4556262331251440n);
 
     expect(
       MarketUtils.compoundRate(
         parseUnits("500", 16) / SECONDS_PER_YEAR,
         Time.s.from.mo(8),
       ),
-    ).toEqual(157_02792765518178794n);
+    ).toEqual(288_82118976199070000n);
   });
 });


### PR DESCRIPTION
Fixes INFRA-1293

Here's a summary of the issue: when `avgBorrowRate * elapsed` is large, the approximation error of `wTaylorCompounded(avgBorrowRate, elapsed) ~ exp(avgBorrowRate * elapsed) - 1` is huge, so we should never use `wTaylorCompounded` to calculate an APY (because `elapsed = SECONDS_PER_YEAR`)