### PR TITLE
fix: make internal getters generic and type-safe in mergeArrayByField

### DIFF
--- a/packages/blue-api-sdk/src/cache.ts
+++ b/packages/blue-api-sdk/src/cache.ts
@@ -51,26 +51,26 @@ export const mergeArrayByField = <
       mergeObjects: MergeObjectsFunction;
     },
   ) => {
-    const _get = (
-      // biome-ignore lint/suspicious/noExplicitAny: recursion breaks type
-      data: any,
+    const _get = <T>(
+      data: T,
       path: string[],
     ): PropertyKey | null | undefined => {
-      if (path.length === 0) return data;
+      if (path.length === 0) return data as PropertyKey | null | undefined;
 
       const [key, ...rest] = path;
 
-      return _get(readField(key!, data), rest);
+      return _get(readField(key! as keyof T, data), rest);
     };
 
-    const getFirstValueAtPath = (
-      // biome-ignore lint/suspicious/noExplicitAny: recursion breaks type
-      data: any,
+    const getFirstValueAtPath = <T>(
+      data: T,
       i = splittedPaths.length - 1,
     ): PropertyKey | null | undefined => {
       if (i < 0) return;
 
-      return _get(data, splittedPaths[i]!) ?? getFirstValueAtPath(data, i - 1);
+      return (
+        _get<T>(data, splittedPaths[i]!) ?? getFirstValueAtPath<T>(data, i - 1)
+      );
     };
 
     const merged = existing ? existing.slice(0) : [];


### PR DESCRIPTION
- Convert `_get` and `getFirstValueAtPath` to generics for safer recursion  
- Use typed `readField` access and propagate generics through merge helpers  
- No runtime behavior change; improves TypeScript correctness in cache merging