### PR TITLE
fix: narrow ErrorClass constructor to unknown-args tuple for safer instanceof checks

### DIFF
--- a/packages/blue-sdk/src/errors.ts
+++ b/packages/blue-sdk/src/errors.ts
@@ -109,9 +109,10 @@ export namespace BlueErrors {
   }
 }
 
+type UnknownConstructorArgs = [] | [unknown, ...unknown[]];
+
 export interface ErrorClass<E extends Error> {
-  // biome-ignore lint/suspicious/noExplicitAny: match any type of arg
-  new (...args: any[]): E;
+  new (...args: UnknownConstructorArgs): E;
 }
 
 export function _try<T, E extends Error>(


### PR DESCRIPTION
- Introduce `UnknownConstructorArgs` to model permissive error constructor signatures  
- Update `ErrorClass` to `new (...args: UnknownConstructorArgs)` to improve type safety in `_try` without overusing `any`