### PR TITLE
fix: re-enable zero-amount approvals for non-DAI ERC20 tokens

### DIFF
--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -329,9 +329,8 @@ export const encodeOperation = (
 
       // Simple permit is not supported, fallback to standard approval.
 
-      // Ignore zero permits used to reset allowances at the end of a bundle
+      // Ignore DAI-specific zero permits used to reset allowances at the end of a bundle
       // when the signer does not support signatures, as they cannot be bundled.
-      // Currently only used by DAI-specific permit which does not support specific amounts.
       if (amount > 0n || !isDai)
         requirements.txs.push(
           ...encodeErc20Approval(


### PR DESCRIPTION
A regression was identified affecting USDT and flow transactions using classic approvals. 
The previous logic was incorrectly filtering out zero-amount approvals for all tokens.