### PR TITLE
fix: reuse existing marketparams

### DIFF
--- a/packages/blue-sdk/src/market/Market.ts
+++ b/packages/blue-sdk/src/market/Market.ts
@@ -108,7 +108,8 @@ export class Market implements IMarket {
     price,
     rateAtTarget,
   }: IMarket) {
-    this.params = new MarketParams(params);
+    this.params =
+      params instanceof MarketParams ? params : new MarketParams(params);
     this.totalSupplyAssets = totalSupplyAssets;
     this.totalBorrowAssets = totalBorrowAssets;
     this.totalSupplyShares = totalSupplyShares;

--- a/packages/blue-sdk/test/unit/Market.test.ts
+++ b/packages/blue-sdk/test/unit/Market.test.ts
@@ -1,7 +1,7 @@
 import { Time } from "@morpho-org/morpho-ts";
 import { randomAddress } from "@morpho-org/test/fixtures";
 import { describe, expect, test } from "vitest";
-import { Market } from "../../src/index.js";
+import { Market, MarketParams } from "../../src/index.js";
 
 describe("Market", () => {
   test("should have consistent APRs and APYs", () => {
@@ -52,5 +52,27 @@ describe("Market", () => {
     );
     expect(market2.getAvgSupplyApy(timestamp)).toBe(0.964032975905364);
     expect(market2.getAvgBorrowApy(timestamp)).toBe(1.718281828393502);
+  });
+
+  test("precalculated market params should be fast", { timeout: 250 }, () => {
+    const params = new MarketParams({
+      collateralToken: randomAddress(),
+      loanToken: randomAddress(),
+      oracle: randomAddress(),
+      irm: randomAddress(),
+      lltv: 86_0000000000000000n,
+    });
+    for (let i = 0; i < 100000; i++) {
+      new Market({
+        params,
+        totalSupplyAssets: 100n,
+        totalBorrowAssets: 90n,
+        totalSupplyShares: 10000000n,
+        totalBorrowShares: 9000000n,
+        rateAtTarget: 10_0000000000000000n / Time.s.from.y(1n),
+        lastUpdate: Time.timestamp(),
+        fee: 25_0000000000000000n,
+      });
+    }
   });
 });


### PR DESCRIPTION
#448 

the test is a bit aggressive, but it does fail on old code for my node. my desktop  (14900) in node can do somewhere between ~5000-20,000 hashes per second (dependent on a lot of stuff)

browser sha3 running in sandboxed vm combined with people with slower single core speed, therefore, (and i see it even on my pc) only a few hundred hashes can cause 100+ms delay on main thread, especially if thread is doing busy react renders. 

there is a possible argument to not pass params this way and reconstruct a new marketparams with an alternative constructor. happy to do that if that would be preferred. 