### PR TITLE
feat(simulationState): avoid frequent refetching of static data

### DIFF
--- a/packages/blue-sdk-wagmi/src/queries/fetchToken.ts
+++ b/packages/blue-sdk-wagmi/src/queries/fetchToken.ts
@@ -44,8 +44,6 @@ export function fetchTokenQueryOptions<config extends Config>(
 export function fetchTokenQueryKey({
   token,
   chainId,
-  blockTag,
-  blockNumber,
   deployless,
   account,
   stateOverride,
@@ -56,8 +54,6 @@ export function fetchTokenQueryKey({
     {
       token,
       chainId,
-      blockTag,
-      blockNumber,
       deployless,
       account,
       stateOverride,

--- a/packages/blue-sdk-wagmi/src/queries/fetchToken.ts
+++ b/packages/blue-sdk-wagmi/src/queries/fetchToken.ts
@@ -44,6 +44,8 @@ export function fetchTokenQueryOptions<config extends Config>(
 export function fetchTokenQueryKey({
   token,
   chainId,
+  blockTag,
+  blockNumber,
   deployless,
   account,
   stateOverride,
@@ -54,6 +56,8 @@ export function fetchTokenQueryKey({
     {
       token,
       chainId,
+      blockTag,
+      blockNumber,
       deployless,
       account,
       stateOverride,

--- a/packages/simulation-sdk-wagmi/src/hooks/useSimulationState.ts
+++ b/packages/simulation-sdk-wagmi/src/hooks/useSimulationState.ts
@@ -143,7 +143,6 @@ export function useSimulationState<
 
   const feeRecipient = useReadContract({
     ...parameters,
-    blockNumber: block?.number,
     address: morpho,
     abi: blueAbi,
     functionName: "feeRecipient",
@@ -194,7 +193,6 @@ export function useSimulationState<
 
   const tokens = useTokens({
     ...parameters,
-    blockNumber: block?.number,
     query: {
       ...parameters.query,
       enabled: block != null && parameters.query?.enabled,


### PR DESCRIPTION
Some data can be considered static and does not need to be fetched at a specific block on a regular basis.

Quick win: This PR introduces a small optimization by treating token metadata and the feeRecipient address as static, avoiding unnecessary refetching every 5 seconds.