### PR TITLE
fix(bundler): hardcode skipRevert: false on cleanup calls

### DIFF
--- a/packages/bundler-sdk-viem/src/BundlerAction.ts
+++ b/packages/bundler-sdk-viem/src/BundlerAction.ts
@@ -828,7 +828,7 @@ export namespace BundlerAction {
           args: [underlying, generalAdapter1, maxUint256],
         }),
         value: 0n,
-        skipRevert,
+        skipRevert: false,
         callbackHash: zeroHash,
       },
     ];
@@ -890,7 +890,7 @@ export namespace BundlerAction {
           args: [wrapper, generalAdapter1, maxUint256],
         }),
         value: 0n,
-        skipRevert,
+        skipRevert: false,
         callbackHash: zeroHash,
       },
     ];

--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -1009,13 +1009,7 @@ export const encodeOperation = (
         },
         {
           type: "erc20Transfer",
-          args: [
-            srcToken,
-            generalAdapter1,
-            maxUint256,
-            paraswapAdapter,
-            operation.skipRevert,
-          ],
+          args: [srcToken, generalAdapter1, maxUint256, paraswapAdapter, false],
         },
       );
 
@@ -1074,7 +1068,7 @@ export const encodeOperation = (
             generalAdapter1,
             maxUint256,
             paraswapAdapter,
-            operation.skipRevert,
+            false,
           ],
         });
 
@@ -1117,13 +1111,7 @@ export const encodeOperation = (
         },
         {
           type: "erc20Transfer",
-          args: [
-            srcToken,
-            generalAdapter1,
-            maxUint256,
-            paraswapAdapter,
-            operation.skipRevert,
-          ],
+          args: [srcToken, generalAdapter1, maxUint256, paraswapAdapter, false],
         },
       );
 


### PR DESCRIPTION
## Summary
- Cleanup calls (sweep-back transfers) in multi-call adapter sequences now always use `skipRevert: false`, preventing tokens from being stranded on permissionless adapters when `skipRevert=true` is set by the integrator
- Applies to ERC20Wrapper `wrap`/`unwrap` and Paraswap `buy`/`sell`/`buyDebt` flows

Resolves [SDK-93](https://linear.app/morpho-labs/issue/SDK-93/hardcode-skiprevert-false-on-cleanup-calls-in-multi-call-adapter)

## Test plan
- [x] Build passes (`pnpm build` in bundler-sdk-viem)
- [ ] Verify wrap/unwrap and paraswap bundle encoding in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)