### PR TITLE
fix(bundler-sdk): rename slippageAmount to correct parameter names

### DIFF
--- a/packages/bundler-sdk-viem/src/BundlerAction.ts
+++ b/packages/bundler-sdk-viem/src/BundlerAction.ts
@@ -1091,7 +1091,7 @@ export namespace BundlerAction {
    * @param market The market params to supply to.
    * @param assets The amount of assets to supply.
    * @param shares The amount of supply shares to mint.
-   * @param slippageAmount The maximum (resp. minimum) amount of assets (resp. supply shares) to supply (resp. mint) (protects the sender from unexpected slippage).
+   * @param maxSharePriceE27 The maximum amount of assets supplied per supply share minted, scaled by 1e27 (protects the sender from unexpected slippage).
    * @param onBehalf The address to supply on behalf of.
    * @param callbackCalls The array of calls to execute inside Morpho Blue's `onMorphoSupply` callback.
    * @param skipRevert Whether to allow the transfer to revert without making the whole bundler revert. Defaults to false.
@@ -1101,7 +1101,7 @@ export namespace BundlerAction {
     market: InputMarketParams,
     assets: bigint,
     shares: bigint,
-    slippageAmount: bigint,
+    maxSharePriceE27: bigint,
     onBehalf: Address,
     callbackCalls: BundlerCall[],
     skipRevert = false,
@@ -1121,7 +1121,7 @@ export namespace BundlerAction {
         data: encodeFunctionData({
           abi: generalAdapter1Abi,
           functionName: "morphoSupply",
-          args: [market, assets, shares, slippageAmount, onBehalf, reenterData],
+          args: [market, assets, shares, maxSharePriceE27, onBehalf, reenterData],
         }),
         value: 0n,
         skipRevert,
@@ -1177,7 +1177,7 @@ export namespace BundlerAction {
    * @param market The market params to borrow from.
    * @param assets The amount of assets to borrow.
    * @param shares The amount of borrow shares to mint.
-   * @param slippageAmount The minimum (resp. maximum) amount of assets (resp. borrow shares) to borrow (resp. mint) (protects the sender from unexpected slippage).
+   * @param minSharePriceE27 The minimum amount of assets borrowed per borrow share minted, scaled by 1e27 (protects the sender from unexpected slippage).
    * @param receiver The address to send borrowed tokens to.
    * @param skipRevert Whether to allow the transfer to revert without making the whole bundler revert. Defaults to false.
    */
@@ -1186,7 +1186,7 @@ export namespace BundlerAction {
     market: InputMarketParams,
     assets: bigint,
     shares: bigint,
-    slippageAmount: bigint,
+    minSharePriceE27: bigint,
     receiver: Address,
     skipRevert = false,
   ): BundlerCall[] {
@@ -1200,7 +1200,7 @@ export namespace BundlerAction {
         data: encodeFunctionData({
           abi: generalAdapter1Abi,
           functionName: "morphoBorrow",
-          args: [market, assets, shares, slippageAmount, receiver],
+          args: [market, assets, shares, minSharePriceE27, receiver],
         }),
         value: 0n,
         skipRevert,
@@ -1215,7 +1215,7 @@ export namespace BundlerAction {
    * @param market The market params to repay to.
    * @param assets The amount of assets to repay.
    * @param shares The amount of borrow shares to redeem.
-   * @param slippageAmount The maximum (resp. minimum) amount of assets (resp. borrow shares) to repay (resp. redeem) (protects the sender from unexpected slippage).
+   * @param maxSharePriceE27 The maximum amount of assets repaid per borrow share burned, scaled by 1e27 (protects the sender from unexpected slippage).
    * @param onBehalf The address to repay on behalf of.
    * @param callbackCalls The array of calls to execute inside Morpho Blue's `onMorphoSupply` callback.
    * @param skipRevert Whether to allow the transfer to revert without making the whole bundler revert. Defaults to false.
@@ -1225,7 +1225,7 @@ export namespace BundlerAction {
     market: InputMarketParams,
     assets: bigint,
     shares: bigint,
-    slippageAmount: bigint,
+    maxSharePriceE27: bigint,
     onBehalf: Address,
     callbackCalls: BundlerCall[],
     skipRevert = false,
@@ -1245,7 +1245,7 @@ export namespace BundlerAction {
         data: encodeFunctionData({
           abi: generalAdapter1Abi,
           functionName: "morphoRepay",
-          args: [market, assets, shares, slippageAmount, onBehalf, reenterData],
+          args: [market, assets, shares, maxSharePriceE27, onBehalf, reenterData],
         }),
         value: 0n,
         skipRevert,
@@ -1260,7 +1260,7 @@ export namespace BundlerAction {
    * @param market The market params to withdraw from.
    * @param assets The amount of assets to withdraw.
    * @param shares The amount of supply shares to redeem.
-   * @param slippageAmount The minimum (resp. maximum) amount of assets (resp. supply shares) to withdraw (resp. redeem) (protects the sender from unexpected slippage).
+   * @param minSharePriceE27 The minimum amount of assets withdrawn per supply share redeemed, scaled by 1e27 (protects the sender from unexpected slippage).
    * @param receiver The address to send withdrawn tokens to.
    * @param skipRevert Whether to allow the transfer to revert without making the whole bundler revert. Defaults to false.
    */
@@ -1269,7 +1269,7 @@ export namespace BundlerAction {
     market: InputMarketParams,
     assets: bigint,
     shares: bigint,
-    slippageAmount: bigint,
+    minSharePriceE27: bigint,
     receiver: Address,
     skipRevert = false,
   ): BundlerCall[] {
@@ -1283,7 +1283,7 @@ export namespace BundlerAction {
         data: encodeFunctionData({
           abi: generalAdapter1Abi,
           functionName: "morphoWithdraw",
-          args: [market, assets, shares, slippageAmount, receiver],
+          args: [market, assets, shares, minSharePriceE27, receiver],
         }),
         value: 0n,
         skipRevert,


### PR DESCRIPTION
This PR fixes #470 by renaming the `slippageAmount` parameter in the Bundler SDK to the correct parameter names that match the Solidity contract.

## Changes

Updated the following functions in `BundlerAction.ts`:

- `morphoSupply`: `slippageAmount` → `maxSharePriceE27`
- `morphoBorrow`: `slippageAmount` → `minSharePriceE27`  
- `morphoRepay`: `slippageAmount` → `maxSharePriceE27`
- `morphoWithdraw`: `slippageAmount` → `minSharePriceE27`

Also updated the JSDoc comments to clarify that these parameters represent share prices scaled by 1e27, not slippage amounts.

This makes the SDK API consistent with the underlying Solidity contract and helps developers understand the actual meaning of these parameters.