### PR TITLE
fix(bundler-sdk-viem): handle undefined client.account in sign functions

### DIFF
--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -172,9 +172,7 @@ export const encodeOperation = (
           async sign(client: Client, account?: Account) {
             if (account == null) {
               if (client.account == null) {
-                throw new Error(
-                  "Account must be provided either as argument or on client",
-                );
+                throw new BundlerErrors.UnknownAccount();
               }
               account = client.account;
             }
@@ -283,9 +281,7 @@ export const encodeOperation = (
           async sign(client: Client, account?: Account) {
             if (account == null) {
               if (client.account == null) {
-                throw new Error(
-                  "Account must be provided either as argument or on client",
-                );
+                throw new BundlerErrors.UnknownAccount();
               }
               account = client.account;
             }
@@ -397,9 +393,7 @@ export const encodeOperation = (
           async sign(client: Client, account?: Account) {
             if (account == null) {
               if (client.account == null) {
-                throw new Error(
-                  "Account must be provided either as argument or on client",
-                );
+                throw new BundlerErrors.UnknownAccount();
               }
               account = client.account;
             }

--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -169,7 +169,15 @@ export const encodeOperation = (
 
         requirements.signatures.push({
           action,
-          async sign(client: Client, account: Account = client.account!) {
+          async sign(client: Client, account?: Account) {
+            if (account == null) {
+              if (client.account == null) {
+                throw new Error(
+                  "Account must be provided either as argument or on client",
+                );
+              }
+              account = client.account;
+            }
             let signature = action.args[1];
             if (signature != null) return signature;
 
@@ -272,7 +280,15 @@ export const encodeOperation = (
 
         requirements.signatures.push({
           action,
-          async sign(client: Client, account: Account = client.account!) {
+          async sign(client: Client, account?: Account) {
+            if (account == null) {
+              if (client.account == null) {
+                throw new Error(
+                  "Account must be provided either as argument or on client",
+                );
+              }
+              account = client.account;
+            }
             let signature = action.args[4];
             if (signature != null) return signature; // action is already signed
 
@@ -378,7 +394,15 @@ export const encodeOperation = (
 
         requirements.signatures.push({
           action,
-          async sign(client: Client, account: Account = client.account!) {
+          async sign(client: Client, account?: Account) {
+            if (account == null) {
+              if (client.account == null) {
+                throw new Error(
+                  "Account must be provided either as argument or on client",
+                );
+              }
+              account = client.account;
+            }
             const { details, sigDeadline } = action.args[1];
 
             let signature = action.args[2];

--- a/packages/bundler-sdk-viem/src/errors.ts
+++ b/packages/bundler-sdk-viem/src/errors.ts
@@ -55,4 +55,12 @@ export namespace BundlerErrors {
       super(`missing final skim for token "${token}"`);
     }
   }
+
+  export class UnknownAccount extends Error {
+    constructor() {
+      super(
+        "Account must be provided either as argument or on client",
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Problem

The `sign` functions in three places in `actions.ts` use a default parameter value with a non-null assertion:

```typescript
async sign(client: Client, account: Account = client.account!) {
```

This is problematic because:
1. If `client.account` is `undefined`, the `!` assertion hides this from TypeScript
2. At runtime, `account` becomes `undefined`, which violates the `Account` type
3. This leads to confusing errors when signing operations without an account configured

## Solution

Replace the unsafe default with a runtime check that:
1. Makes `account` an optional parameter (`account?: Account`)
2. Checks if account is provided or available on client
3. Throws a descriptive error if neither is available
4. Properly satisfies the `SignatureRequirementFunction` overloaded type

## Changes

- Modified 3 `sign` functions in `packages/bundler-sdk-viem/src/actions.ts`
- Each now validates account availability at runtime
- Clear error message guides users to provide an account

## Type Safety

The change maintains type compatibility with the existing `SignatureRequirementFunction` type which supports both:
- `(client: Client<Transport, Chain | undefined, Account>): Promise<Hex>`
- `(client: Client, account: Account): Promise<Hex>`

## Testing

- TypeScript compilation passes for the modified file
- The fix prevents runtime errors when `client.account` is undefined
- Error message clearly indicates the required action