### PR TITLE
Add security ownership for publish workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/CODEOWNERS @morpho-org/security
+/.github/workflows/publish.yml @morpho-org/security

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           # Fetch all history so that we can determine the version to release.
           fetch-depth: 0
 
@@ -78,4 +79,3 @@ jobs:
 
       - run: echo "- [RELEASE] ${{ steps.release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
         if: steps.release.outputs.version
-


### PR DESCRIPTION
## Summary
- add a CODEOWNERS file for the workflow and the CODEOWNERS file itself
- assign  as the owner for both paths
- make the publish workflow checkout step explicitly use 

## Testing
- not run (workflow/config only)