### PR TITLE
fix(vault-v2): bound maxWithdraw by idle balance when no liquidity adapter

### DIFF
--- a/packages/blue-sdk-viem/test/VaultV2Adapter.test.ts
+++ b/packages/blue-sdk-viem/test/VaultV2Adapter.test.ts
@@ -431,7 +431,7 @@ describe("LiquidityAdapter zero address", () => {
   );
 
   vaultV2Test(
-    "should withdraw full amount when liquidityAdapter is zero address",
+    "should be bounded by assetBalance when liquidityAdapter is zero address",
     async ({ client }) => {
       // Set liquidity adapter to zero address
       await client.writeContract({
@@ -445,12 +445,20 @@ describe("LiquidityAdapter zero address", () => {
       const accrualVaultV2 = await fetchAccrualVaultV2(vaultV2Address, client);
 
       const shares = parseUnits("100", 18);
+      const assets = accrualVaultV2.toAssets(shares);
       const result = accrualVaultV2.maxWithdraw(shares);
 
-      expect(result).toStrictEqual({
-        value: accrualVaultV2.toAssets(shares),
-        limiter: CapacityLimitReason.balance,
-      });
+      if (assets > accrualVaultV2.assetBalance) {
+        expect(result).toStrictEqual({
+          value: accrualVaultV2.assetBalance,
+          limiter: CapacityLimitReason.liquidity,
+        });
+      } else {
+        expect(result).toStrictEqual({
+          value: assets,
+          limiter: CapacityLimitReason.balance,
+        });
+      }
     },
   );
 });

--- a/packages/blue-sdk-viem/test/VaultV2Adapter.test.ts
+++ b/packages/blue-sdk-viem/test/VaultV2Adapter.test.ts
@@ -444,21 +444,13 @@ describe("LiquidityAdapter zero address", () => {
 
       const accrualVaultV2 = await fetchAccrualVaultV2(vaultV2Address, client);
 
-      const shares = parseUnits("100", 18);
-      const assets = accrualVaultV2.toAssets(shares);
+      const shares = parseUnits("10000000000", 18);
       const result = accrualVaultV2.maxWithdraw(shares);
 
-      if (assets > accrualVaultV2.assetBalance) {
-        expect(result).toStrictEqual({
-          value: accrualVaultV2.assetBalance,
-          limiter: CapacityLimitReason.liquidity,
-        });
-      } else {
-        expect(result).toStrictEqual({
-          value: assets,
-          limiter: CapacityLimitReason.balance,
-        });
-      }
+      expect(result).toStrictEqual({
+        value: accrualVaultV2.assetBalance,
+        limiter: CapacityLimitReason.liquidity,
+      });
     },
   );
 });

--- a/packages/blue-sdk/src/vault/v2/VaultV2.ts
+++ b/packages/blue-sdk/src/vault/v2/VaultV2.ts
@@ -196,11 +196,12 @@ export class AccrualVaultV2 extends VaultV2 implements IAccrualVaultV2 {
    */
   public maxWithdraw(shares: BigIntish): CapacityLimit {
     const assets = this.toAssets(shares);
-    if (this.liquidityAdapter === zeroAddress)
-      return { value: BigInt(assets), limiter: CapacityLimitReason.balance };
 
     let liquidity = this.assetBalance;
-    if (this.accrualLiquidityAdapter != null)
+    if (
+      this.liquidityAdapter !== zeroAddress &&
+      this.accrualLiquidityAdapter != null
+    )
       liquidity += this.accrualLiquidityAdapter.maxWithdraw(
         this.liquidityData,
       ).value;


### PR DESCRIPTION
## Summary

Fixes a bug in `AccrualVaultV2.maxWithdraw` where the returned value was unbounded when `liquidityAdapter == zeroAddress`. In that branch the method returned `toAssets(shares)` regardless of what the vault could actually pay out, which for vaults holding assets in non-liquidity adapters (e.g. Morpho Market V1 adapters) reported an arbitrarily large withdrawable amount that an on-chain `redeem`/`withdraw` would revert for.

[Bug report](https://morpholabs.slack.com/archives/C07G53ZCV5K/p1776716380766199)

## Context

On-chain, [`VaultV2.exit`](https://github.com/morpho-org/vault-v2/blob/main/src/VaultV2.sol#L804-L823) serves a withdrawal from `IERC20(asset).balanceOf(vault)` (idle) and only pulls the delta from the liquidity adapter if one is configured:

```solidity
uint256 idleAssets = IERC20(asset).balanceOf(address(this));
if (assets > idleAssets && liquidityAdapter != address(0)) {
    deallocateInternal(liquidityAdapter, liquidityData, assets - idleAssets);
}
...
SafeERC20Lib.safeTransfer(asset, receiver, assets);
```

If `liquidityAdapter == 0x0`, the deallocation is skipped and the final `safeTransfer` reverts when `assets > idle`. Therefore the true ceiling of a normal withdraw is:

```
maxWithdraw = idle + maxDeallocatable(liquidityAdapter, liquidityData)
```

with the second term being `0` when no liquidity adapter is set.