### PR TITLE
fix(bundler-sdk-viem): resolve active wallet account for signing

### DIFF
--- a/packages/bundler-sdk-viem/src/ActionBundle.ts
+++ b/packages/bundler-sdk-viem/src/ActionBundle.ts
@@ -1,6 +1,7 @@
 import type { SimulationResult } from "@morpho-org/simulation-sdk";
 import type { Account, Address, Chain, Client, Hex, Transport } from "viem";
 import { BundlerAction } from "./BundlerAction.js";
+import { getSigningAccount } from "./account.js";
 import type {
   Action,
   SignatureRequirement,
@@ -18,9 +19,13 @@ export class ActionBundleRequirements<
 
   sign(client: Client<Transport, Chain | undefined, Account>): Promise<Hex[]>;
   sign(client: Client, account: Account): Promise<Hex[]>;
-  sign(client: Client, account: Account = client.account!) {
+  async sign(client: Client, account?: Account) {
+    const signingAccount = await getSigningAccount(client, account);
+
     return Promise.all(
-      this.signatures.map((requirement) => requirement.sign(client, account)),
+      this.signatures.map((requirement) =>
+        requirement.sign(client, signingAccount),
+      ),
     );
   }
 }

--- a/packages/bundler-sdk-viem/src/account.ts
+++ b/packages/bundler-sdk-viem/src/account.ts
@@ -1,0 +1,29 @@
+import type { Account, Chain, Client, Transport } from "viem";
+import { getAddresses } from "viem/actions";
+
+export async function getSigningAccount(
+  client: Client,
+  account?: Account,
+): Promise<Account> {
+  if (account != null) return account;
+
+  const clientAccount = client.account;
+
+  if (clientAccount?.type !== "json-rpc") {
+    if (clientAccount != null) return clientAccount;
+
+    const [address] = await getAddresses(client);
+    if (address == null) throw new Error("No account available for signing");
+
+    return { address, type: "json-rpc" };
+  }
+
+  const [address] = await getAddresses(client);
+
+  return {
+    ...clientAccount,
+    address: address ?? clientAccount.address,
+  };
+}
+
+export type SigningClient = Client<Transport, Chain | undefined, Account>;

--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -40,6 +40,7 @@ import {
 } from "@morpho-org/blue-sdk-viem";
 import { signTypedData } from "viem/actions";
 import { ActionBundle, ActionBundleRequirements } from "./ActionBundle.js";
+import { getSigningAccount } from "./account.js";
 import { BundlerErrors } from "./errors.js";
 import type {
   Action,
@@ -169,7 +170,8 @@ export const encodeOperation = (
 
         requirements.signatures.push({
           action,
-          async sign(client: Client, account: Account = client.account!) {
+          async sign(client: Client, account?: Account) {
+            account = await getSigningAccount(client, account);
             let signature = action.args[1];
             if (signature != null) return signature;
 
@@ -272,7 +274,8 @@ export const encodeOperation = (
 
         requirements.signatures.push({
           action,
-          async sign(client: Client, account: Account = client.account!) {
+          async sign(client: Client, account?: Account) {
+            account = await getSigningAccount(client, account);
             let signature = action.args[4];
             if (signature != null) return signature; // action is already signed
 
@@ -378,7 +381,8 @@ export const encodeOperation = (
 
         requirements.signatures.push({
           action,
-          async sign(client: Client, account: Account = client.account!) {
+          async sign(client: Client, account?: Account) {
+            account = await getSigningAccount(client, account);
             const { details, sigDeadline } = action.args[1];
 
             let signature = action.args[2];

--- a/packages/bundler-sdk-viem/test/ActionBundle.test.ts
+++ b/packages/bundler-sdk-viem/test/ActionBundle.test.ts
@@ -1,0 +1,34 @@
+import { type Address, type Hex, createClient, custom } from "viem";
+import { describe, expect, test, vi } from "vitest";
+import { ActionBundleRequirements } from "../src/ActionBundle.js";
+
+describe("ActionBundleRequirements", () => {
+  test("uses the active JSON-RPC account when signing without an explicit account", async () => {
+    const staleAccount = {
+      address: "0x1111111111111111111111111111111111111111" as Address,
+      type: "json-rpc" as const,
+    };
+    const activeAccount = "0x2222222222222222222222222222222222222222";
+    const client = createClient({
+      account: staleAccount,
+      transport: custom({
+        async request({ method }) {
+          if (method === "eth_accounts") return [activeAccount];
+
+          throw new Error(`Unexpected RPC method: ${method}`);
+        },
+      }),
+    });
+    const sign = vi.fn(async (_client, account) => account.address as Hex);
+    const requirements = new ActionBundleRequirements(
+      [],
+      [{ action: {} as never, sign }],
+    );
+
+    await expect(requirements.sign(client)).resolves.toEqual([activeAccount]);
+    expect(sign).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({ address: activeAccount }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve the active JSON-RPC wallet account at signature time when no explicit account is supplied.
- Keep explicit accounts and local accounts unchanged, while refreshing stale WalletConnect/injected `json-rpc` accounts via `eth_accounts`.
- Route `ActionBundleRequirements.sign()` and individual signature requirements through the same account resolver.

Fixes #534.

## Validation
- `pnpm --filter @morpho-org/bundler-sdk-viem build`
- `pnpm exec vitest packages/bundler-sdk-viem/test/ActionBundle.test.ts --run` -> 1 passed
- `pnpm exec biome check packages/bundler-sdk-viem/src/account.ts packages/bundler-sdk-viem/src/ActionBundle.ts packages/bundler-sdk-viem/src/actions.ts packages/bundler-sdk-viem/test/ActionBundle.test.ts`
