### PR TITLE
[codex] add agent convention guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,6 @@
 - Reuse SDK types for protocol values: `Address`, `MarketId`, `ChainId`, `BigIntish`.
 - Public package APIs are explicit re-exports from `src/index.ts`; do not expose deep files accidentally.
 - Never edit build output in `lib/`; source and tests live under `packages/*/src` and `packages/*/test`.
+- Prefer `as const` and `satisfies` for protocol lists and ABI literals, e.g. `BLUE_OPERATIONS as const`.
+- Change generated inputs, not generated files, e.g. edit `graphql/*.gql` before `src/api/sdk.ts`.
+- Domain failures are typed `Error` classes with readonly inputs, e.g. `new UnknownTokenError(address)`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Monorepo Conventions
+
+- Use pnpm with Node >=22; root checks are `pnpm lint` and `pnpm test`.
+- Keep TypeScript strict and NodeNext-friendly; relative imports include `.js`, e.g. `export * from "./market/index.js";`.
+- Prefer type-only imports where possible: `import type { Address } from "viem";`.
+- Let Biome own style: 2-space indentation, organized imports, no unused imports or variables.
+- Use `bigint` for onchain quantities and WAD-scaled rates, e.g. `92_0000000000000000n`.
+- Reuse SDK types for protocol values: `Address`, `MarketId`, `ChainId`, `BigIntish`.
+- Public package APIs are explicit re-exports from `src/index.ts`; do not expose deep files accidentally.
+- Never edit build output in `lib/`; source and tests live under `packages/*/src` and `packages/*/test`.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -6,3 +6,6 @@
 - Build scripts follow `tsc --noEmit && pnpm build:cjs && pnpm build:esm`; keep new packages aligned.
 - Add tests in the owning package, e.g. `packages/blue-sdk/test/unit/Market.test.ts`.
 - Fork or Wagmi tests import their fixture setup: `import { test } from "./setup.js";`.
+- Keep publish exports in `publishConfig.exports`; mirror `types`, `import`, and `require`.
+- Put host libraries in `peerDependencies`, with local test versions in `devDependencies`.
+- Subpath exports need both package exports and TS path support, e.g. `./vitest`.

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,0 +1,8 @@
+# Package Conventions
+
+- Packages are ESM at source (`"type": "module"`) and publish dual builds from `lib/esm` and `lib/cjs`.
+- Keep `main` pointed at source for local work, e.g. `"main": "src/index.ts"`.
+- Internal dependencies use workspace ranges, e.g. `"@morpho-org/blue-sdk": "workspace:^"`.
+- Build scripts follow `tsc --noEmit && pnpm build:cjs && pnpm build:esm`; keep new packages aligned.
+- Add tests in the owning package, e.g. `packages/blue-sdk/test/unit/Market.test.ts`.
+- Fork or Wagmi tests import their fixture setup: `import { test } from "./setup.js";`.

--- a/packages/blue-sdk-viem/AGENTS.md
+++ b/packages/blue-sdk-viem/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/blue-sdk-viem/CLAUDE.md
+++ b/packages/blue-sdk-viem/CLAUDE.md
@@ -1,0 +1,8 @@
+# blue-sdk-viem Conventions
+
+- Fetchers accept a `viem` `Client` and return `blue-sdk` classes, e.g. `fetchMarket(id, client)`.
+- Default deployless reads to `true`; fall back to multicall unless `deployless === "force"`.
+- Set missing chain IDs from the client: `parameters.chainId ??= await getChainId(client)`.
+- Keep generated deployless query artifacts as `abi` and `code` constants under `src/queries`.
+- Augment classes only in `src/augment`, e.g. `Market.fetch = fetchMarket`.
+- Use `readContractRestructured` when tuple fields should map to named object properties.

--- a/packages/blue-sdk-viem/CLAUDE.md
+++ b/packages/blue-sdk-viem/CLAUDE.md
@@ -6,3 +6,6 @@
 - Keep generated deployless query artifacts as `abi` and `code` constants under `src/queries`.
 - Augment classes only in `src/augment`, e.g. `Market.fetch = fetchMarket`.
 - Use `readContractRestructured` when tuple fields should map to named object properties.
+- Fetch params pass through viem call fields: `account`, `blockNumber`, `blockTag`, `stateOverride`.
+- Normalize unsafe user addresses with `safeGetAddress`, not lowercasing alone.
+- Typed-data helpers return `TypedDataDefinition`, e.g. `getPermitTypedData(...)`.

--- a/packages/blue-sdk-wagmi/AGENTS.md
+++ b/packages/blue-sdk-wagmi/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/blue-sdk-wagmi/CLAUDE.md
+++ b/packages/blue-sdk-wagmi/CLAUDE.md
@@ -6,3 +6,6 @@
 - Exclude `blockNumber` and `blockTag` from cache keys unless a multi-block cache is intentional.
 - Gate queries on required inputs, e.g. `enabled: parameters.marketId != null && query.enabled`.
 - Use `replaceDeepEqual` as the default structural sharing for entity hooks.
+- Multi-entity hooks dedupe inputs before `useQueries`, e.g. `new Set(marketIds)`.
+- Return indexed records with `data`, `error`, `isFetching`, and `isFetchingAny`.
+- Keep `throwOnError`, `queryFn`, and query key fields owned by query option helpers.

--- a/packages/blue-sdk-wagmi/CLAUDE.md
+++ b/packages/blue-sdk-wagmi/CLAUDE.md
@@ -1,0 +1,8 @@
+# blue-sdk-wagmi Conventions
+
+- Hooks wrap query option helpers: `useMarket` calls `fetchMarketQueryOptions`.
+- Hook parameters compose fetch params, `ConfigParameter`, and `QueryParameter`.
+- Keep query keys prefixed with `BLUE_SDK_QUERY_KEY_PREFIX` and use `hashFn` for bigint support.
+- Exclude `blockNumber` and `blockTag` from cache keys unless a multi-block cache is intentional.
+- Gate queries on required inputs, e.g. `enabled: parameters.marketId != null && query.enabled`.
+- Use `replaceDeepEqual` as the default structural sharing for entity hooks.

--- a/packages/blue-sdk/AGENTS.md
+++ b/packages/blue-sdk/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/blue-sdk/CLAUDE.md
+++ b/packages/blue-sdk/CLAUDE.md
@@ -6,3 +6,5 @@
 - Use getters for derived state, e.g. `get utilization()`, and methods for parameterized math.
 - Keep all protocol amounts as `bigint`; accept `BigIntish` only at API edges.
 - Address registries are immutable and additive; custom addresses must not override existing values.
+- Use `MathLib` rounding helpers; spell rounding as `"Up"` or `"Down"`.
+- Use `_try(accessor, UnknownError)` for optional domain lookups, not broad `catch`.

--- a/packages/blue-sdk/CLAUDE.md
+++ b/packages/blue-sdk/CLAUDE.md
@@ -1,0 +1,8 @@
+# blue-sdk Conventions
+
+- Keep this package framework-agnostic; do not import `viem`, `wagmi`, React, or test helpers in `src`.
+- Model protocol state as `I*` interfaces plus classes, e.g. `interface IMarket` and `class Market`.
+- Constructors accept plain inputs and normalize nested classes, e.g. `new MarketParams(params)`.
+- Use getters for derived state, e.g. `get utilization()`, and methods for parameterized math.
+- Keep all protocol amounts as `bigint`; accept `BigIntish` only at API edges.
+- Address registries are immutable and additive; custom addresses must not override existing values.

--- a/packages/bundler-sdk-viem/AGENTS.md
+++ b/packages/bundler-sdk-viem/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/bundler-sdk-viem/CLAUDE.md
+++ b/packages/bundler-sdk-viem/CLAUDE.md
@@ -1,0 +1,8 @@
+# bundler-sdk-viem Conventions
+
+- Convert simulation operations into bundler actions before encoding transactions.
+- Keep action encoders pure where possible: `BundlerAction.encode(chainId, action)`.
+- Throw `BundlerErrors.MissingSignature` when a signature-required action lacks a signature.
+- Track native value only for transfers into bundler adapter addresses.
+- Prefer infinite approvals used elsewhere, e.g. `MathLib.MAX_UINT_160`, when Permit2 flow requires it.
+- Return both planned operations and the encoded bundle from setup helpers.

--- a/packages/bundler-sdk-viem/CLAUDE.md
+++ b/packages/bundler-sdk-viem/CLAUDE.md
@@ -6,3 +6,6 @@
 - Track native value only for transfers into bundler adapter addresses.
 - Prefer infinite approvals used elsewhere, e.g. `MathLib.MAX_UINT_160`, when Permit2 flow requires it.
 - Return both planned operations and the encoded bundle from setup helpers.
+- Validate signatures after signing with `verifyTypedData` before caching them on actions.
+- Never sign for independent consumers; only adapters like `generalAdapter1` should receive permits.
+- Recursive callbacks force `sender: generalAdapter1` before encoding nested operations.

--- a/packages/liquidation-sdk-viem/AGENTS.md
+++ b/packages/liquidation-sdk-viem/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/liquidation-sdk-viem/CLAUDE.md
+++ b/packages/liquidation-sdk-viem/CLAUDE.md
@@ -6,3 +6,6 @@
 - Token integrations are grouped under `src/tokens`, e.g. `Pendle`, `Spectra`, `Usual`.
 - Fetch market and position data in parallel, then build `AccrualPosition` or `PreLiquidationPosition`.
 - External swap integrations return typed swap data; validate ambiguous results before encoding calls.
+- Use shared pagination helpers for API lists; first page gives `countTotal`.
+- Chunk market ID queries when API calls can grow large.
+- Treat API bigint strings defensively in tests, e.g. `BigInt(position.state?.borrowShares ?? "0")`.

--- a/packages/liquidation-sdk-viem/CLAUDE.md
+++ b/packages/liquidation-sdk-viem/CLAUDE.md
@@ -1,0 +1,8 @@
+# liquidation-sdk-viem Conventions
+
+- GraphQL queries live in `graphql/*.gql`; regenerate API types with this package's `codegen` script.
+- Do not hand-edit generated `src/api/sdk.ts`; update queries or `codegen.ts` instead.
+- Keep liquidation execution helpers on `LiquidationEncoder`, extending `ExecutorEncoder`.
+- Token integrations are grouped under `src/tokens`, e.g. `Pendle`, `Spectra`, `Usual`.
+- Fetch market and position data in parallel, then build `AccrualPosition` or `PreLiquidationPosition`.
+- External swap integrations return typed swap data; validate ambiguous results before encoding calls.

--- a/packages/liquidity-sdk-viem/AGENTS.md
+++ b/packages/liquidity-sdk-viem/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/liquidity-sdk-viem/CLAUDE.md
+++ b/packages/liquidity-sdk-viem/CLAUDE.md
@@ -1,0 +1,8 @@
+# liquidity-sdk-viem Conventions
+
+- GraphQL queries live in `graphql/*.gql`; regenerate API types with this package's `codegen` script.
+- Do not hand-edit generated `src/api/sdk.ts`; update queries or `codegen.ts` instead.
+- Loader code batches by market ID through `DataLoader`.
+- Snapshot onchain state at one block before simulation, e.g. pass `{ blockNumber: block.number }`.
+- Convert API maps through `fromEntries` and filter with `isDefined`.
+- Public liquidity options use WAD-scaled `bigint` thresholds.

--- a/packages/liquidity-sdk-viem/CLAUDE.md
+++ b/packages/liquidity-sdk-viem/CLAUDE.md
@@ -6,3 +6,6 @@
 - Snapshot onchain state at one block before simulation, e.g. pass `{ blockNumber: block.number }`.
 - Convert API maps through `fromEntries` and filter with `isDefined`.
 - Public liquidity options use WAD-scaled `bigint` thresholds.
+- `apiSdk` is a singleton `GraphQLClient` bound to `BLUE_API_GRAPHQL_URL`.
+- Batch expensive market requests by chunking IDs before paginating.
+- Keep loader output deterministic: return `withdrawals`, `startState`, `endState`, and utilization.

--- a/packages/migration-sdk-viem/AGENTS.md
+++ b/packages/migration-sdk-viem/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/migration-sdk-viem/CLAUDE.md
+++ b/packages/migration-sdk-viem/CLAUDE.md
@@ -1,0 +1,8 @@
+# migration-sdk-viem Conventions
+
+- Keep per-protocol fetchers under `src/fetchers/<protocol>/<protocol>.fetchers.ts`.
+- Fetchers return `MigratablePosition[]` and return `[]` when a protocol is unsupported on the chain.
+- Read chain IDs from viem clients when absent: `parameters.chainId ??= await getChainId(client)`.
+- Migration address config is additive and frozen with `deepFreeze`.
+- Position classes expose validated `getMigrationTx(...)` and keep protocol-specific encoding in subclasses.
+- Use protocol enums in public types, e.g. `MigratableProtocol.aaveV3`.

--- a/packages/migration-sdk-viem/CLAUDE.md
+++ b/packages/migration-sdk-viem/CLAUDE.md
@@ -6,3 +6,6 @@
 - Migration address config is additive and frozen with `deepFreeze`.
 - Position classes expose validated `getMigrationTx(...)` and keep protocol-specific encoding in subclasses.
 - Use protocol enums in public types, e.g. `MigratableProtocol.aaveV3`.
+- Keep protocol ABIs grouped by source protocol under `src/abis`.
+- Use `rateToApy(rate, period, decimals, isApr)` for external protocol rates.
+- Validate target Morpho markets before building migration bundles.

--- a/packages/morpho-test/AGENTS.md
+++ b/packages/morpho-test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/morpho-test/CLAUDE.md
+++ b/packages/morpho-test/CLAUDE.md
@@ -4,3 +4,6 @@
 - Export fixture groups from `src/fixtures/index.ts` through `src/index.ts`.
 - Use concrete chain keys, e.g. `markets[ChainId.EthMainnet]`.
 - Keep fixture data typed with `blue-sdk` models and IDs.
+- Use `parseUnits("94.5", 16)` for LLTV percentages in market fixtures.
+- Prefer deterministic fixture helpers, e.g. `randomMarket({ loanToken })`.
+- Keep token capability sets explicit, e.g. `withSimplePermit[ChainId.EthMainnet]`.

--- a/packages/morpho-test/CLAUDE.md
+++ b/packages/morpho-test/CLAUDE.md
@@ -1,0 +1,6 @@
+# morpho-test Conventions
+
+- Keep fixtures framework-agnostic; test runners should consume them, not live here.
+- Export fixture groups from `src/fixtures/index.ts` through `src/index.ts`.
+- Use concrete chain keys, e.g. `markets[ChainId.EthMainnet]`.
+- Keep fixture data typed with `blue-sdk` models and IDs.

--- a/packages/morpho-ts/AGENTS.md
+++ b/packages/morpho-ts/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/morpho-ts/CLAUDE.md
+++ b/packages/morpho-ts/CLAUDE.md
@@ -5,3 +5,6 @@
 - Use type guards for filtering, e.g. `array.filter(isDefined)`.
 - Prefer typed wrappers over raw object helpers, e.g. `entries(obj)` instead of `Object.entries(obj)`.
 - Export new utilities from `src/index.ts` through the nearest folder index.
+- Preserve numeric input kind in time converters, e.g. `Time.s.from.h(2n)` returns `bigint`.
+- Match fixed time assumptions: `mo` is 31 days and `y` is 365 days.
+- Formatters stay chainable and end with `.of(...)` or `.createOf()`.

--- a/packages/morpho-ts/CLAUDE.md
+++ b/packages/morpho-ts/CLAUDE.md
@@ -1,0 +1,7 @@
+# morpho-ts Conventions
+
+- Keep this package framework-free; export generic time, format, URL, and object helpers only.
+- Preserve nullability through helpers, e.g. `transformValue(value, fn)` returns nullish input unchanged.
+- Use type guards for filtering, e.g. `array.filter(isDefined)`.
+- Prefer typed wrappers over raw object helpers, e.g. `entries(obj)` instead of `Object.entries(obj)`.
+- Export new utilities from `src/index.ts` through the nearest folder index.

--- a/packages/simulation-sdk-wagmi/AGENTS.md
+++ b/packages/simulation-sdk-wagmi/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/simulation-sdk-wagmi/CLAUDE.md
+++ b/packages/simulation-sdk-wagmi/CLAUDE.md
@@ -1,0 +1,7 @@
+# simulation-sdk-wagmi Conventions
+
+- Compose state from `blue-sdk-wagmi` hooks; do not duplicate entity fetch logic here.
+- Entity queries require a known block before enabling: `enabled: block != null && query.enabled`.
+- Invalidate Blue SDK queries when `block.number` changes so query closures refetch at the new block.
+- Return discriminated pending/data states with `isPending`.
+- Keep `blockTag` and `blockNumber` out of public fetch params except the single `block` object.

--- a/packages/simulation-sdk-wagmi/CLAUDE.md
+++ b/packages/simulation-sdk-wagmi/CLAUDE.md
@@ -5,3 +5,6 @@
 - Invalidate Blue SDK queries when `block.number` changes so query closures refetch at the new block.
 - Return discriminated pending/data states with `isPending`.
 - Keep `blockTag` and `blockNumber` out of public fetch params except the single `block` object.
+- Preserve per-entity query overrides under `entityQuery`, e.g. `entityQuery.markets`.
+- Memoize derived query inputs that depend on iterables, e.g. `useMemo(() => Array.from(users), [users])`.
+- Apply optional accrual through query `select`, e.g. `market.accrueInterest(block.timestamp)`.

--- a/packages/simulation-sdk/AGENTS.md
+++ b/packages/simulation-sdk/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/simulation-sdk/CLAUDE.md
+++ b/packages/simulation-sdk/CLAUDE.md
@@ -1,0 +1,8 @@
+# simulation-sdk Conventions
+
+- Keep this package framework-agnostic; simulation logic should not depend on `viem` clients or React.
+- Define operation names as `as const` arrays, e.g. `BLUE_OPERATIONS`, then derive union types.
+- Use mutually exclusive args with `never`, e.g. `{ assets: bigint; shares?: never }`.
+- Store state in `SimulationState`; getters throw `Unknown*Error`, while `tryGet*` returns nullish.
+- Mutating simulation handlers should operate on drafts; exported APIs return immutable results.
+- Keep operation strings protocol-scoped, e.g. `Blue_Borrow` and `MetaMorpho_Deposit`.

--- a/packages/simulation-sdk/CLAUDE.md
+++ b/packages/simulation-sdk/CLAUDE.md
@@ -6,3 +6,6 @@
 - Store state in `SimulationState`; getters throw `Unknown*Error`, while `tryGet*` returns nullish.
 - Mutating simulation handlers should operate on drafts; exported APIs return immutable results.
 - Keep operation strings protocol-scoped, e.g. `Blue_Borrow` and `MetaMorpho_Deposit`.
+- Wrap handler failures in `SimulationErrors.Simulation(error, index, operation)`.
+- Use `produceImmutable` for public simulation, and `handleOperation` for in-place draft updates.
+- Encode slippage as WAD-scaled `bigint`, e.g. `MathLib.WAD + slippage`.

--- a/packages/test-wagmi/AGENTS.md
+++ b/packages/test-wagmi/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/test-wagmi/CLAUDE.md
+++ b/packages/test-wagmi/CLAUDE.md
@@ -1,0 +1,7 @@
+# test-wagmi Conventions
+
+- Build Wagmi fixtures on top of `@morpho-org/test`; do not spawn Anvil directly here.
+- `createWagmiTest` extends `createViemTest` with a Wagmi `config` fixture.
+- Use Wagmi's `mock` connector with `testAccount()` addresses.
+- React helpers wrap renders with `WagmiProvider` and `QueryClientProvider`.
+- Clear caller-provided query clients before render helpers reuse them.

--- a/packages/test-wagmi/CLAUDE.md
+++ b/packages/test-wagmi/CLAUDE.md
@@ -5,3 +5,6 @@
 - Use Wagmi's `mock` connector with `testAccount()` addresses.
 - React helpers wrap renders with `WagmiProvider` and `QueryClientProvider`.
 - Clear caller-provided query clients before render helpers reuse them.
+- Disable Wagmi reconnects in tests: `reconnectOnMount: false`.
+- Default React Query tests to `retry: false` and infinite `gcTime`.
+- Extend async waits through the wrapper `waitFor`, not raw Testing Library defaults.

--- a/packages/test/AGENTS.md
+++ b/packages/test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/test/CLAUDE.md
+++ b/packages/test/CLAUDE.md
@@ -5,3 +5,6 @@
 - Extend viem clients through `createAnvilTestClient`; keep helpers like `balanceOf` and `approve` on the test client.
 - BigInts are JSON-serialized in the Vitest setup by adding `BigInt.prototype.toJSON`.
 - Export public entrypoints explicitly: `@morpho-org/test/vitest`, `/fixtures`, and `/playwright`.
+- Deterministic accounts come from the standard test mnemonic via `testAccount(index)`.
+- Use `checksumAddress` for generated addresses, e.g. `randomAddress(chainId)`.
+- Trace assertions use `getFunctionCalls` over Anvil `ots_traceTransaction`.

--- a/packages/test/CLAUDE.md
+++ b/packages/test/CLAUDE.md
@@ -1,0 +1,7 @@
+# test Conventions
+
+- This package owns Anvil, viem, Vitest, and Playwright test utilities.
+- `createViemTest(chain, parameters)` should set deterministic defaults such as zero gas and timestamp interval.
+- Extend viem clients through `createAnvilTestClient`; keep helpers like `balanceOf` and `approve` on the test client.
+- BigInts are JSON-serialized in the Vitest setup by adding `BigInt.prototype.toJSON`.
+- Export public entrypoints explicitly: `@morpho-org/test/vitest`, `/fixtures`, and `/playwright`.


### PR DESCRIPTION
## Summary

Adds concise `CLAUDE.md` convention guides inferred from the monorepo source code.

The guides are placed at the repository root, the shared `packages/` level, and each package root. Each guide has a same-folder `AGENTS.md` symlink pointing to `CLAUDE.md`.

Fixes: SDK-174

## Impact

Future coding agents get package-specific conventions without duplicating lower-level guidance or adding files below package roots.

## Validation

- `pnpm lint`
- Verified 15 `CLAUDE.md` files and 15 symlinked `AGENTS.md` files
- Verified no `CLAUDE.md` files below package root depth