### PR TITLE
chore: share /extract-plan, /pr-review, /pr-fix via .agents/commands

### DIFF
--- a/.agents/commands/extract-plan.md
+++ b/.agents/commands/extract-plan.md
@@ -1,0 +1,279 @@
+# extract-plan
+
+Read a technical document (TIB, RFC, design doc, etc.) and generate a Linear project plan
+with milestones and implementation issues from it.
+
+## Arguments
+
+- `$ARGUMENTS` should contain: `<doc-file-path> [linear-project-name-or-id]`
+- Example: `/extract-plan docs/tibs/TIB-2026-03-11-observability-package.md "Observability Package"`
+
+## Instructions
+
+You are converting a technical document into an actionable Linear project plan with milestones and
+issues. The goal is to bridge the gap between a written decision or design and trackable
+implementation work.
+
+The input document may be a TIB, RFC, design doc, or any structured technical document that
+describes a decision, approach, and/or implementation plan.
+
+Refer to `/create-issue` for how to structure issue descriptions and titles. Refer to `/plan` for how to
+structure project descriptions and workstream breakdowns.
+
+---
+
+### Step 1: Parse Arguments
+
+Check `$ARGUMENTS`:
+
+- If **two arguments** are provided, treat the first as the document file path and the second as the
+  Linear project name or ID.
+- If **one argument** is provided, treat it as the document file path and ask the user for the
+  target Linear project.
+- If **no arguments** are provided, ask:
+  1. _"Which document should I convert? (file path)"_
+  2. _"Which Linear project should the issues be created in? (project name or ID, or 'new' to create one)"_
+
+If the user says "new", you will create the project in Step 5.
+
+### Step 2: Read and Parse the Document
+
+Read the document and extract structured information. Adapt to whatever sections and format are
+present — the following are common patterns, not requirements:
+
+| Common Section               | What to extract                                                    |
+| ---------------------------- | ------------------------------------------------------------------ |
+| **Metadata**                 | Status, Date, Author, Scope                                        |
+| **Context / Background**     | Problem statement and motivation — becomes project description     |
+| **Decision Drivers / Goals** | Constraints and priorities — informs issue prioritization          |
+| **Decision / Approach**      | The chosen approach and its subsections — primary source for tasks |
+| **Implementation Phases**    | Phase breakdown — maps directly to milestones                      |
+| **Consequences / Tradeoffs** | Positive/Negative/Neutral — informs acceptance criteria            |
+| **Future Considerations**    | Items explicitly deferred — may become backlog issues              |
+| **References**               | Links and prior art — attached to relevant issues                  |
+
+If the document doesn't follow any of these patterns, use your judgment to identify the decision,
+approach, and actionable work items.
+
+**Scope detection:** Use the document's scope field (if present) and file path to determine the
+target team:
+
+- `apps/curator-*` or Scope mentions Curator → **Curator** team
+  (`c07ff95f-03b7-4bee-aa17-c7e04fda8845`)
+- `apps/markets-v2-app` or Scope mentions Markets → **Markets v2** team
+  (`f9764a7e-c555-4979-b386-c21a1cabba6a`)
+- `packages/*`, `@repo/*`, repo-wide, or cross-cutting → **Apps** team
+  (`cc8fe27e-f516-45e8-921e-69b0562c7792`)
+
+If ambiguous, ask the user.
+
+### Step 3: Generate the Plan
+
+Build the following structure from the parsed document:
+
+#### 3a: Milestones
+
+If the document contains explicit phases (e.g., "Implementation Phases", "Rollout Plan",
+"Milestones"):
+
+- Each phase becomes a **Linear milestone** within the project.
+- Milestone name: `Phase N: <phase title>` (e.g., `Phase 1: Foundation + Next.js pilot`)
+- Milestone description: The phase's description from the document, verbatim or lightly cleaned up.
+- Milestones are ordered sequentially.
+
+If the document does **not** have explicit phases, derive logical milestones from the approach
+section's subsections or propose a sensible breakdown (e.g., "Foundation", "Core Implementation",
+"Migration", "Polish"). Ask the user to confirm derived milestones.
+
+#### 3b: Issues
+
+Break the document into actionable implementation issues. Sources for issues:
+
+1. **Approach/Decision subsections** — Each subsection typically maps to one or more issues.
+2. **Implementation Phases** — Tasks described within each phase.
+3. **Negative consequences/tradeoffs** — May warrant mitigation issues.
+4. **Future Considerations** — Items worth tracking as low-priority issues.
+
+**Granularity principle:** Prefer coarser issues that represent a single PR's worth of work. Don't
+split tightly coupled work into separate issues — for example, writing tests for a feature belongs
+in the same issue as implementing that feature, not as a separate issue blocked by it. A good
+heuristic: if two tasks would naturally be done in the same PR by the same person, they should be
+one issue.
+
+For each issue, determine:
+
+- **Title**: Follow the title convention
+- **Description**: Follow the `/create-issue` 3-section template:
+
+  ```markdown
+  ## Context
+  [What this task accomplishes and why, referencing the source document]
+
+  ## References
+  - Source: <doc-file-path> (Section X.Y)
+  - [file paths, related issues, or links from the document's References section]
+
+  ## Possible solution
+  > ⚠️ AI-generated — treat as a starting point, not a prescription.
+
+  [Implementation approach derived from the document's details]
+  ```
+
+- **Milestone**: Which milestone (phase) this issue belongs to.
+- **Dependencies**: Which other issues must be completed first (`blockedBy`) and which issues this
+  unblocks (`blocks`). Derive from:
+  - Phase ordering (Phase 1 issues block Phase 2 issues where a real dependency exists)
+  - Logical dependencies within a phase (e.g., "create package" blocks "add logging module")
+  - Explicit dependency mentions in the document
+  - Do **not** create artificial cross-milestone blocking for every issue pair — only where a real
+    dependency exists.
+- **Priority**: Infer from the document:
+  - Critical path / blockers → 1 (Urgent)
+  - Core decision items / Phase 1 → 2 (High)
+  - Later phases → 3 (Normal)
+  - Future considerations → 4 (Low)
+- **Estimate** (optional, in points):
+  - 1 = Small (single file, straightforward)
+  - 2 = Medium (multiple files, some complexity)
+  - 3 = Large (cross-cutting, new abstractions)
+  - 5 = XL (major effort, consider breaking down further)
+- **Labels**: Infer from issue type (label names as an array, e.g. `["Feature"]`)
+
+#### 3c: Dependency Graph
+
+Build an explicit ordering of issues. Within a milestone, issues should be ordered by their
+dependency chain. Across milestones, only set blocking relationships where a real dependency exists.
+
+### Step 4: Present the Plan for Review
+
+Before creating anything in Linear, present the full plan to the user:
+
+```
+## Document → Linear Plan
+
+**Source**: <doc-file-path>
+**Project**: <project-name> (existing | new)
+**Team**: <team-name> (<team-key>)
+**Total milestones**: N
+**Total issues**: N
+
+---
+
+### Milestone 1: <name>
+| #  | Title                                           | Priority | Estimate | Blocked By | Blocks |
+| -- | ----------------------------------------------- | -------- | -------- | ---------- | ------ |
+| 1  | feat(observability): scaffold package structure  | High     | 2        | —          | #2, #3 |
+| 2  | feat(observability): implement logger factory    | High     | 2        | #1         | #4     |
+
+### Milestone 2: <name>
+| #  | Title                                            | Priority | Estimate | Blocked By | Blocks |
+| -- | ------------------------------------------------ | -------- | -------- | ---------- | ------ |
+| 5  | feat(cv2): migrate to @repo/observability         | Normal   | 2        | #4         | #6     |
+
+### Dependency Graph
+#1 → #2 → #4 → #5 → ...
+#1 → #3 ─┐
+          └→ #6
+```
+
+Then ask:
+
+> **Does this plan look good?** You can:
+>
+> - Say **"create all"** to create the project, milestones, and all issues
+> - Say **"create milestones 1-2 only"** to create a subset
+> - **Edit** any item (e.g., "change #3 title to ...", "move #5 to milestone 1", "remove #8")
+> - **Add** items (e.g., "add an issue for writing migration docs")
+> - Say **"skip"** to cancel without creating anything
+
+### Step 5: Create in Linear
+
+Once the user approves, create items in this order:
+
+#### 5a: Project (if new)
+
+If the user said "new" or no existing project was specified, create the project using
+`mcp__linear__create_project`:
+
+- `name`: Project name
+- `description`: Include Vision (from document context), Motivation (from decision drivers/goals),
+  Scope, and a link to the source document path
+- `addTeams`: `[<team-id>]`
+
+If the document status is "Proposed" or "Draft", note in the description that the underlying
+decision may still change.
+
+#### 5b: Milestones
+
+Create milestones in order using `mcp__linear__create_milestone`:
+
+- `name`: `Phase N: <title>`
+- `description`: Phase description from the document
+- `project`: The project ID
+
+#### 5c: Issues (two-pass)
+
+**Pass 1 — Create issues** in dependency order (issues with no `blockedBy` first) using
+`mcp__linear__create_issue`:
+
+- `title`: Title following the title convention
+- `description`: 3-section template (Context / References / Possible solution)
+- `team`: Team ID (from scope detection)
+- `project`: Project ID
+- `milestone`: Milestone name or ID
+- `priority`: 1-4
+- `estimate`: 1, 2, 3, or 5
+- `labels`: Label names as an array, e.g. `["Feature"]`
+- `state`: Default all issues to **Backlog** state unless explicitly overridden by the user
+
+Store each returned issue ID.
+
+**Pass 2 — Set dependencies** by updating each issue that has relationships:
+
+- `id`: The created issue identifier
+- `blockedBy`: Array of blocking issue identifiers
+- `blocks`: Array of blocked issue identifiers
+
+This two-pass approach avoids forward-reference problems where issue B depends on issue C that
+hasn't been created yet.
+
+### Step 6: Confirm Completion
+
+Present a summary:
+
+```
+## Created from <doc-file-name>
+
+**Project**: <project-name>
+<project-linear-url>
+
+### Milestones
+1. Phase 1: <title> — N issues
+2. Phase 2: <title> — N issues
+
+### Issues Created (N total)
+| ID        | Title                                            | Milestone | Blocked By |
+| --------- | ------------------------------------------------ | --------- | ---------- |
+| APPS-101 | feat(observability): scaffold package structure  | Phase 1   | —          |
+| APPS-102 | feat(observability): implement logger factory    | Phase 1   | APPS-101  |
+
+### Dependency Chain
+APPS-101 → APPS-102 → APPS-104 → APPS-105 → ...
+```
+
+---
+
+## Notes
+
+- Always resolve project names to IDs before creating artifacts — use `mcp__linear__list_projects`
+  to find the ID if only a name is provided
+- Issue descriptions must follow the `/create-issue` 3-section template (Context / References / Possible
+  solution)
+- Issue titles must follow the title convention
+- Refer to the Team IDs table in CLAUDE.md to select the appropriate team based on scope
+- Create issues in dependency order so that `blockedBy` references are valid
+- If the document has no explicit phases, derive milestones from logical groupings and confirm with
+  the user
+- Do NOT create a git branch — this command creates Linear artifacts only
+
+$ARGUMENTS

--- a/.agents/commands/extract-plan.md
+++ b/.agents/commands/extract-plan.md
@@ -6,7 +6,7 @@ with milestones and implementation issues from it.
 ## Arguments
 
 - `$ARGUMENTS` should contain: `<doc-file-path> [linear-project-name-or-id]`
-- Example: `/extract-plan docs/tibs/TIB-2026-03-11-observability-package.md "Observability Package"`
+- Example: `/extract-plan TIB/TIB-2026-04-30-blue-sdk-observability.md "Blue SDK Observability"`
 
 ## Instructions
 
@@ -16,9 +16,6 @@ implementation work.
 
 The input document may be a TIB, RFC, design doc, or any structured technical document that
 describes a decision, approach, and/or implementation plan.
-
-Refer to `/create-issue` for how to structure issue descriptions and titles. Refer to `/plan` for how to
-structure project descriptions and workstream breakdowns.
 
 ---
 
@@ -55,17 +52,16 @@ present — the following are common patterns, not requirements:
 If the document doesn't follow any of these patterns, use your judgment to identify the decision,
 approach, and actionable work items.
 
-**Scope detection:** Use the document's scope field (if present) and file path to determine the
-target team:
+**Scope detection:** Use the document's scope field (if present) and file path to suggest a target
+team:
 
-- `apps/curator-*` or Scope mentions Curator → **Curator** team
-  (`c07ff95f-03b7-4bee-aa17-c7e04fda8845`)
-- `apps/markets-v2-app` or Scope mentions Markets → **Markets v2** team
-  (`f9764a7e-c555-4979-b386-c21a1cabba6a`)
-- `packages/*`, `@repo/*`, repo-wide, or cross-cutting → **Apps** team
-  (`cc8fe27e-f516-45e8-921e-69b0562c7792`)
+- `packages/blue-sdk*`, `packages/morpho-sdk`, `packages/simulation-sdk*` → core SDK
+- `packages/*-viem` or `packages/*-wagmi` → integration packages
+- `scripts/`, root configs, `tsconfig.json`, `pnpm-workspace.yaml`, cross-package → repo-wide
 
-If ambiguous, ask the user.
+If `CLAUDE.md` contains a Team IDs table, use that to resolve to a Linear team ID. Otherwise ask
+the user which Linear team to file under, and offer to record the answer in `CLAUDE.md` for future
+runs.
 
 ### Step 3: Generate the Plan
 
@@ -77,7 +73,7 @@ If the document contains explicit phases (e.g., "Implementation Phases", "Rollou
 "Milestones"):
 
 - Each phase becomes a **Linear milestone** within the project.
-- Milestone name: `Phase N: <phase title>` (e.g., `Phase 1: Foundation + Next.js pilot`)
+- Milestone name: `Phase N: <phase title>` (e.g., `Phase 1: Foundation + first SDK package`)
 - Milestone description: The phase's description from the document, verbatim or lightly cleaned up.
 - Milestones are ordered sequentially.
 
@@ -103,7 +99,7 @@ one issue.
 For each issue, determine:
 
 - **Title**: Follow the title convention
-- **Description**: Follow the `/create-issue` 3-section template:
+- **Description**: Use the 3-section template below:
 
   ```markdown
   ## Context
@@ -160,15 +156,15 @@ Before creating anything in Linear, present the full plan to the user:
 ---
 
 ### Milestone 1: <name>
-| #  | Title                                           | Priority | Estimate | Blocked By | Blocks |
-| -- | ----------------------------------------------- | -------- | -------- | ---------- | ------ |
-| 1  | feat(observability): scaffold package structure  | High     | 2        | —          | #2, #3 |
-| 2  | feat(observability): implement logger factory    | High     | 2        | #1         | #4     |
+| #  | Title                                              | Priority | Estimate | Blocked By | Blocks |
+| -- | -------------------------------------------------- | -------- | -------- | ---------- | ------ |
+| 1  | feat(blue-sdk): scaffold observability hooks       | High     | 2        | —          | #2, #3 |
+| 2  | feat(blue-sdk): implement logger factory           | High     | 2        | #1         | #4     |
 
 ### Milestone 2: <name>
-| #  | Title                                            | Priority | Estimate | Blocked By | Blocks |
-| -- | ------------------------------------------------ | -------- | -------- | ---------- | ------ |
-| 5  | feat(cv2): migrate to @repo/observability         | Normal   | 2        | #4         | #6     |
+| #  | Title                                              | Priority | Estimate | Blocked By | Blocks |
+| -- | -------------------------------------------------- | -------- | -------- | ---------- | ------ |
+| 5  | feat(simulation-sdk): adopt @morpho-org/observability | Normal   | 2        | #4         | #6     |
 
 ### Dependency Graph
 #1 → #2 → #4 → #5 → ...
@@ -252,13 +248,13 @@ Present a summary:
 2. Phase 2: <title> — N issues
 
 ### Issues Created (N total)
-| ID        | Title                                            | Milestone | Blocked By |
-| --------- | ------------------------------------------------ | --------- | ---------- |
-| APPS-101 | feat(observability): scaffold package structure  | Phase 1   | —          |
-| APPS-102 | feat(observability): implement logger factory    | Phase 1   | APPS-101  |
+| ID            | Title                                            | Milestone | Blocked By  |
+| ------------- | ------------------------------------------------ | --------- | ----------- |
+| <TEAM>-101    | feat(blue-sdk): scaffold observability hooks     | Phase 1   | —           |
+| <TEAM>-102    | feat(blue-sdk): implement logger factory         | Phase 1   | <TEAM>-101  |
 
 ### Dependency Chain
-APPS-101 → APPS-102 → APPS-104 → APPS-105 → ...
+<TEAM>-101 → <TEAM>-102 → <TEAM>-104 → <TEAM>-105 → ...
 ```
 
 ---
@@ -267,10 +263,10 @@ APPS-101 → APPS-102 → APPS-104 → APPS-105 → ...
 
 - Always resolve project names to IDs before creating artifacts — use `mcp__linear__list_projects`
   to find the ID if only a name is provided
-- Issue descriptions must follow the `/create-issue` 3-section template (Context / References / Possible
-  solution)
+- Issue descriptions must follow the 3-section template (Context / References / Possible solution)
 - Issue titles must follow the title convention
-- Refer to the Team IDs table in CLAUDE.md to select the appropriate team based on scope
+- If team IDs are not listed in `CLAUDE.md`, ask the user which Linear team to use and offer to
+  record the answer in `CLAUDE.md` for future runs
 - Create issues in dependency order so that `blockedBy` references are valid
 - If the document has no explicit phases, derive milestones from logical groupings and confirm with
   the user

--- a/.agents/commands/pr-fix.md
+++ b/.agents/commands/pr-fix.md
@@ -1,0 +1,539 @@
+# pr-fix
+
+Apply fixes for unresolved PR review comments, resolve merge conflicts with the base branch, commit, push, resolve threads, and monitor CI. Optionally watches for new review comments and re-applies fixes automatically.
+
+## Usage
+
+```
+/pr-fix <pr-number>
+/pr-fix <pr-number> --watch
+```
+
+## Examples
+
+```
+/pr-fix 123
+/pr-fix 456 --watch
+```
+
+> **TWO-PHASE SKILL**: Phase 1 (Steps 1-11) does the initial fix pass. Phase 2 (Step 12) creates a continuous watcher via CronCreate if `--watch` was passed. If `--watch` is used, the skill is NOT complete until Step 12's CronCreate call succeeds and you report the job ID to the user.
+
+## Step 1: Detect Repository
+
+Extract owner and repo from the git remote:
+
+```bash
+git remote get-url origin
+```
+
+Parse `owner` and `repo` from the URL (handles both `git@github.com:owner/repo.git` and `https://github.com/owner/repo.git` formats). Strip the `.git` suffix.
+
+## Step 2: Fetch PR Details and Checkout Branch
+
+Use local `gh` CLI to get PR metadata:
+
+```bash
+gh pr view <PR_NUMBER> --json title,baseRefName,headRefName,headRefOid,state
+```
+
+Extract:
+
+- `baseRefName` — the base branch
+- `headRefName` — the head/PR branch
+- `headRefOid` — the head commit SHA
+- `state` — must be `OPEN`
+
+If the PR is not open, inform the user and stop.
+
+Fetch and checkout the PR branch locally:
+
+```bash
+git fetch origin
+git checkout <headRefName>
+git pull origin <headRefName>
+```
+
+## Step 3: Check and Resolve Merge Conflicts
+
+### 3a: Check for merge conflicts with the base branch
+
+```bash
+git merge --no-commit --no-ff origin/<baseRefName> 2>&1
+```
+
+### 3b: If there are no conflicts (or already up to date)
+
+Abort the test merge only if one is active, then continue to Step 4:
+
+```bash
+# Only abort if MERGE_HEAD exists (a merge is in progress)
+git rev-parse --verify MERGE_HEAD >/dev/null 2>&1 && git merge --abort || true
+```
+
+### 3c: If there are merge conflicts
+
+The merge will report conflicting files. For each conflicting file:
+
+1. **Read the file** with conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) using the Read tool
+2. **Understand both sides**: The `HEAD` side is the PR branch changes, the `origin/<baseRefName>` side is the base branch changes
+3. **Resolve the conflict** intelligently:
+   - If the PR branch changes are newer/intentional, keep them
+   - If the base branch introduced a necessary change (new import, renamed function, updated API), incorporate it
+   - If both sides changed the same code for different reasons, merge both changes logically
+   - Read surrounding files if needed to understand the intent of each side
+4. **Edit the file** using the Edit tool to remove conflict markers and produce the correct merged result
+5. **Validate the resolved file**: `pnpm oxlint -c .oxlintrc.json <file>`
+
+After resolving all conflicts:
+
+```bash
+# Stage resolved files
+git add <list of resolved files>
+
+# Complete the merge
+git commit -m "$(cat <<'EOF'
+merge: resolve conflicts with <baseRefName>
+
+Resolved merge conflicts in:
+- <file1>
+- <file2>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+# Push the merge commit
+git push origin <headRefName>
+```
+
+Print a summary of resolved conflicts:
+
+```
+Resolved merge conflicts with <baseRefName>:
+  - <file1>: <brief description of resolution>
+  - <file2>: <brief description of resolution>
+```
+
+### 3d: If conflicts cannot be resolved automatically
+
+If a conflict is too ambiguous to resolve safely (e.g., both sides rewrote the same function entirely with different logic):
+
+1. Abort the merge: `git merge --abort`
+2. Inform the user which files have unresolvable conflicts and why
+3. Continue with Step 4 (review comment fixes) — the conflicts will need human intervention
+
+## Step 4: Collect Unresolved Review Comments
+
+Use `gh api graphql` to fetch all review threads on the PR:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first: 10) {
+              nodes {
+                databaseId
+                body
+                path
+                originalLine
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -f owner=<owner> -f repo=<repo> -F pr=<PR_NUMBER>
+```
+
+**Filter to only unresolved, non-outdated threads** (`isResolved: false` AND `isOutdated: false`).
+
+For each unresolved thread, extract:
+
+- `threadId` — the GraphQL node ID (for resolving later)
+- `path` — the file the comment is on
+- `line` — the line number (`originalLine`)
+- `body` — the comment text (contains the finding and suggestion)
+- `commentId` — the `databaseId` of the first comment (for replying)
+- `author` — who posted the comment
+
+Group findings by file for efficient fixing.
+
+**Both Claude and Codex comments are handled.** Claude uses `**[SEVERITY]**` prefixes. Codex may use different formats. Human comments are also included.
+
+## Step 5: Triage Findings
+
+Sort unresolved findings by severity. Parse severity from the comment body:
+
+- **Claude comments**: `**[CRITICAL]**`, `**[HIGH]**`, `**[MEDIUM]**`, `**[LOW]**` prefix format
+- **Codex comments**: May use `severity:` fields, `[issue]`/`[suggestion]` tags, or plain text — infer severity from language (e.g., "bug", "security" -> HIGH; "nit", "consider" -> LOW)
+- **Human comments**: Treat as HIGH by default unless they use language suggesting lower priority
+
+Priority order:
+
+1. **CRITICAL** — must fix
+2. **HIGH** — must fix
+3. **MEDIUM** — fix unless there's a good reason not to
+4. **LOW** — fix if straightforward
+
+Print a summary to the user before proceeding:
+
+```
+Found <N> unresolved review comments on PR #<number>:
+  Sources: X from Claude, Y from Codex, Z from humans
+  - X critical
+  - Y high
+  - Z medium
+  - W low
+
+Applying fixes...
+```
+
+## Step 6: Apply Fixes
+
+For each unresolved finding, grouped by file:
+
+### 6a: Read the file from local filesystem
+
+Use the Read tool to read the full file content. Understand the surrounding context — don't fix in isolation.
+
+### 6b: Apply the fix
+
+Use the Edit tool to make the change. Follow the suggestion in the review comment. If the comment describes a problem but not a specific fix, use your judgment to implement the correct solution.
+
+**Rules:**
+
+- Fix only what the comment asks for — don't refactor surrounding code
+- Preserve existing code style (indentation, naming conventions, etc.)
+- If a fix requires changes across multiple files (e.g., updating an interface), make all necessary changes
+- If a finding is about missing tests, write the test
+- If a finding cannot be fixed (e.g., it's a false positive or disagrees with project conventions), skip it and note it for Step 9
+
+### 6c: Validate the fix
+
+After each file is modified, run the project linter:
+
+```bash
+pnpm oxlint -c .oxlintrc.json <file>
+```
+
+## Step 7: Quality Gate
+
+After all fixes are applied, run broader quality checks:
+
+```bash
+# Typecheck
+pnpm typecheck:interface
+
+# Lint all modified files
+pnpm oxlint -c .oxlintrc.json <file1> <file2> ...
+```
+
+If errors are found, fix them before proceeding.
+
+## Step 8: Commit and Push
+
+### 8a: Stage all changed files
+
+```bash
+git add <list of changed files>
+```
+
+Only stage files that were actually modified as part of the fixes.
+
+Before committing, verify the staged set:
+
+```bash
+git diff --cached --name-only
+```
+
+Do not continue if unrelated files are staged.
+
+### 8b: Create a single commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix: address PR review findings
+
+Applied fixes for <N> review comments:
+- <brief summary of key fixes>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 8c: Push to remote
+
+```bash
+git push origin <headRefName>
+```
+
+## Step 9: Reply to and Resolve Review Threads
+
+For each finding that was fixed:
+
+### 9a: Reply to the comment thread
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments \
+  --method POST \
+  -f body="> <abbreviated original comment>
+
+Fixed in <commit_sha> — <brief description of what was changed>" \
+  -F in_reply_to=<commentId>
+```
+
+### 9b: Resolve the thread
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId=<threadId>
+```
+
+### 9c: For skipped findings
+
+If a finding was skipped (false positive, disagrees with conventions, etc.), reply explaining why it was not fixed, but do NOT resolve the thread — leave it for human review:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments \
+  --method POST \
+  -f body="> <abbreviated original comment>
+
+Skipped — <reason why this was not fixed>. Leaving for human review." \
+  -F in_reply_to=<commentId>
+```
+
+## Step 9.5: Reconcile All Current Open Threads
+
+Fetch unresolved, non-outdated review threads again and make sure **every** current thread is explicitly addressed:
+
+- **Fixed thread**: reply with commit SHA + resolve the thread
+- **Skipped thread**: reply with skip reason + leave unresolved
+
+Do not assume that replying to one duplicate comment is enough. If reviewers left the same finding on multiple lines/threads, reply to each thread individually.
+
+Verification check:
+
+- Fetch current unresolved, non-outdated threads
+- Inspect the latest comment on each thread
+- Confirm each thread has either a fix reply plus a resolved state, or a skip reply
+
+Do not report success while any unresolved, non-outdated thread lacks either a fix reply + resolution or a skip reply.
+
+## Step 10: Monitor CI After Push
+
+### 10a: Wait briefly for CI to start
+
+```bash
+sleep 15
+```
+
+### 10b: Check CI status
+
+```bash
+gh pr checks <PR_NUMBER> --repo <owner>/<repo>
+```
+
+### 10c: If CI is still running
+
+Poll up to 5 times with 30-second intervals:
+
+```bash
+gh pr checks <PR_NUMBER> --repo <owner>/<repo> --watch --fail-fast
+```
+
+If `--watch` is not available, poll manually:
+
+```bash
+for i in 1 2 3 4 5; do
+  STATUS=$(gh pr checks <PR_NUMBER> --repo <owner>/<repo> --json name,state --jq '[.[] | select(.state != "completed")] | length')
+  if [ "$STATUS" = "0" ]; then break; fi
+  sleep 30
+done
+```
+
+### 10d: If CI fails
+
+1. Get the failed check details:
+   ```bash
+   gh pr checks <PR_NUMBER> --repo <owner>/<repo> --json name,state,bucket,link --jq '.[] | select(.bucket == "fail")'
+   ```
+2. Fetch the CI logs for the failed job(s):
+   ```bash
+   gh run view <RUN_ID> --repo <owner>/<repo> --log-failed
+   ```
+3. Analyze the failure and determine if it was caused by the fix commit.
+4. If the failure is caused by the fix:
+   - Apply a corrective fix
+   - Stage, commit with message `fix: address CI failure from review fixes`
+   - Push again
+   - Re-check CI (repeat 10b-10d, max 2 retries to avoid infinite loops)
+5. If the failure is pre-existing (not caused by the fix commit): note it in the report but don't try to fix it.
+
+### 10e: If CI passes
+
+Continue to Step 11.
+
+## Step 11: Report to User
+
+Print a final summary:
+
+```
+PR #<number> fixes applied and pushed.
+
+Commit: <short_sha>
+Conflicts: <RESOLVED X files / NONE / UNRESOLVABLE>
+Fixed: <N> findings (X from Claude, Y from Codex, Z from humans)
+Skipped: <M> findings (see thread replies for reasons)
+CI: <PASS/FAIL/PENDING>
+
+Resolved threads: <N>
+Left open for human review: <M>
+```
+
+If conflicts were resolved, list each file and the resolution strategy.
+If conflicts could not be resolved, list the files and why.
+If any findings were skipped, list them with the reason.
+If CI failed on a pre-existing issue, note it separately.
+Also state whether every current unresolved, non-outdated thread was addressed in the reconciliation pass.
+
+If `--watch` was NOT passed, the skill is complete here.
+
+If `--watch` WAS passed, **you MUST proceed to Step 12**.
+
+## Step 12: Schedule Continuous Watch (only with --watch)
+
+**If `--watch` was passed, you MUST call `CronCreate` now.** Do not skip this step.
+
+Use `CronCreate` to schedule a recurring job every 2 minutes:
+
+- cron: `*/2 * * * *`
+- recurring: true
+- prompt: The prompt below, with all variables filled in (replace all `<PLACEHOLDERS>` with actual values):
+
+```
+You are the PR fix watcher for PR #<PR_NUMBER> in <owner>/<repo>.
+Repo path: <REPO_PATH>
+Head branch: <HEAD_BRANCH>
+Base branch: <BASE_BRANCH>
+
+This is a RECURRING cron job. Each run is one check cycle. After completing a cycle, simply end your response — the cron scheduler will invoke you again in 2 minutes.
+
+CYCLE START:
+
+1. CHECK PR STATE:
+   Run: cd <REPO_PATH> && gh pr view <PR_NUMBER> --json state --jq '.state'
+   If not "OPEN": say "PR #<PR_NUMBER> is no longer open (state: <STATE>). Fix watcher done." and end.
+
+2. FETCH AND SYNC:
+   Run: cd <REPO_PATH> && git fetch origin && git checkout <HEAD_BRANCH> && git pull origin <HEAD_BRANCH>
+
+3. CHECK MERGE CONFLICTS:
+   Run: cd <REPO_PATH> && git merge --no-commit --no-ff origin/<BASE_BRANCH> 2>&1
+   - If clean (or already up to date): run `git rev-parse --verify MERGE_HEAD >/dev/null 2>&1 && git merge --abort || true` and continue to step 4.
+   - If conflicts: for each conflicting file, read it with the Read tool, resolve conflict markers using the Edit tool (keep PR changes if intentional, incorporate base changes if necessary, merge both logically). Then: `git add <resolved files>` and `git commit -m "merge: resolve conflicts with <BASE_BRANCH>"` and `git push origin <HEAD_BRANCH>`. Report resolved files.
+   - If conflicts are too ambiguous: `git merge --abort`, report which files, continue to step 4.
+
+4. CHECK CI:
+   Run: cd <REPO_PATH> && gh pr checks <PR_NUMBER> --json name,state,bucket,link --jq '.[] | select(.bucket == "fail")'
+   If CI failures exist:
+   a. Get logs: `gh run view <RUN_ID> --repo <owner>/<repo> --log-failed`
+   b. If caused by a recent fix commit: apply corrective fix, commit "fix: address CI failure", push (max 2 retries)
+   c. If pre-existing: note it, do not fix
+
+5. FETCH UNRESOLVED REVIEW COMMENTS using gh api graphql:
+   Run:
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               isOutdated
+               comments(first: 10) {
+                 nodes {
+                   databaseId
+                   body
+                   path
+                   originalLine
+                   author { login }
+                 }
+               }
+             }
+           }
+         }
+       }
+     }' -f owner=<owner> -f repo=<repo> -F pr=<PR_NUMBER>
+
+   Filter to threads where isResolved=false AND isOutdated=false.
+   For each thread: extract threadId (the node id), path, line (originalLine), body, commentId (databaseId of first comment), author.
+
+6. EVALUATE:
+   If zero unresolved comments AND CI passing AND no conflicts: say "PR #<PR_NUMBER> is green — no unresolved comments, CI passing, no conflicts." and end this cycle.
+
+7. APPLY FIXES for unresolved comments:
+   a. Group by file. For each file: read with Read tool, apply fix with Edit tool per the comment suggestion.
+   b. Run pnpm oxlint -c .oxlintrc.json on modified files.
+   c. Stage: `git add <changed files>`
+   d. Commit: `git commit -m "$(cat <<'INNEREOF'
+fix: address PR review findings
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+INNEREOF
+)"`
+   e. Push: `git push origin <HEAD_BRANCH>`
+   f. For each fixed comment, reply in-thread:
+      `gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments --method POST -f body="> <abbreviated comment>\n\nFixed in <sha>" -F in_reply_to=<commentId>`
+   g. Resolve each thread:
+      `gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>`
+   h. For skipped findings, reply with skip reason but do NOT resolve the thread.
+   i. Say "Fixed <N> findings, pushed commit <sha>, resolved <N> threads."
+
+CYCLE END — the cron scheduler will run this again in 2 minutes.
+```
+
+**After CronCreate returns the job ID:**
+
+1. Report the job ID to the user
+2. Tell them they can cancel with `CronDelete` using that ID
+3. Note that the watcher auto-expires after 3 days
+4. Only THEN is the skill complete
+
+## Error Handling
+
+- If no unresolved review comments exist on first run: tell the user "No unresolved review comments found on PR #<number>." but still schedule the watcher if `--watch` was passed (comments may appear later from reviewers)
+- If checkout fails (dirty working tree): warn the user and suggest stashing or committing first
+- If push fails (e.g., branch protection): inform the user with the error
+- If a fix introduces a syntax error: revert that specific change and skip the finding
+- If resolving a thread fails: log the error but continue with other threads
+- If CI fix retries exceed 2 attempts: stop retrying, report the failure, and leave it for the user
+- If CronCreate is not available: skip continuous monitoring, inform the user that `--watch` requires CronCreate
+
+## Notes
+
+- **Local-first**: All code reading and editing happens on the local filesystem. Only GitHub API is used for reading review comments (via GraphQL) and posting replies/resolving threads (write operations).
+- **Handles all reviewers**: Picks up unresolved comments from Claude, Codex, Copilot, and human reviewers. Normalizes severity across different comment formats.
+- **CI-aware**: Monitors CI after pushing fixes. Automatically diagnoses and fixes CI failures caused by the fix commit (up to 2 retries). Pre-existing CI failures are reported but not touched.
+- **Conflict-aware**: Detects merge conflicts with the base branch before applying review fixes. Resolves conflicts intelligently by reading both sides and merging logically. Conflicts that can't be safely resolved are reported for human intervention.
+- **Quality gates**: Runs `pnpm oxlint` after each file fix and `pnpm typecheck:interface` after all fixes. Ensures fixes don't introduce new issues.
+- **Self-contained watcher**: The cron watcher does actual work inline (resolves conflicts, applies fixes, replies to threads, resolves threads) rather than re-invoking the skill. This avoids recursive watcher creation and ensures each cron tick is a complete fix cycle.
+- **Pairs with `/pr-review`**: `/pr-review` posts findings (from parallel Claude agents + optional Codex), `/pr-fix` applies fixes. With both using `--watch`, they form a fully autonomous review-fix loop.
+- Fixes are applied to the PR branch, not main/dev
+- One commit for all fixes — keeps the PR history clean
+- Each reply includes the commit SHA for traceability
+- Skipped findings are explicitly noted but left unresolved for humans
+- The cron watcher auto-expires after 3 days per system limits
+- The skill assumes it is invoked from within the git repository

--- a/.agents/commands/pr-fix.md
+++ b/.agents/commands/pr-fix.md
@@ -82,7 +82,7 @@ The merge will report conflicting files. For each conflicting file:
    - If both sides changed the same code for different reasons, merge both changes logically
    - Read surrounding files if needed to understand the intent of each side
 4. **Edit the file** using the Edit tool to remove conflict markers and produce the correct merged result
-5. **Validate the resolved file**: `pnpm oxlint -c .oxlintrc.json <file>`
+5. **Validate the resolved file**: `pnpm exec biome check <file>`
 
 After resolving all conflicts:
 
@@ -98,7 +98,7 @@ Resolved merge conflicts in:
 - <file1>
 - <file2>
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
 )"
 
@@ -220,7 +220,7 @@ Use the Edit tool to make the change. Follow the suggestion in the review commen
 After each file is modified, run the project linter:
 
 ```bash
-pnpm oxlint -c .oxlintrc.json <file>
+pnpm exec biome check <file>
 ```
 
 ## Step 7: Quality Gate
@@ -228,11 +228,11 @@ pnpm oxlint -c .oxlintrc.json <file>
 After all fixes are applied, run broader quality checks:
 
 ```bash
-# Typecheck
-pnpm typecheck:interface
+# Lint (biome check + checksum-address)
+pnpm lint
 
-# Lint all modified files
-pnpm oxlint -c .oxlintrc.json <file1> <file2> ...
+# Build (exercises tsc per package — there is no separate typecheck script)
+pnpm -r --if-present build
 ```
 
 If errors are found, fix them before proceeding.
@@ -264,7 +264,7 @@ fix: address PR review findings
 Applied fixes for <N> review comments:
 - <brief summary of key fixes>
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
 )"
 ```
@@ -486,12 +486,12 @@ CYCLE START:
 
 7. APPLY FIXES for unresolved comments:
    a. Group by file. For each file: read with Read tool, apply fix with Edit tool per the comment suggestion.
-   b. Run pnpm oxlint -c .oxlintrc.json on modified files.
+   b. Run pnpm exec biome check on modified files (or pnpm lint for the project-wide check).
    c. Stage: `git add <changed files>`
    d. Commit: `git commit -m "$(cat <<'INNEREOF'
 fix: address PR review findings
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 INNEREOF
 )"`
    e. Push: `git push origin <HEAD_BRANCH>`
@@ -528,7 +528,7 @@ CYCLE END — the cron scheduler will run this again in 2 minutes.
 - **Handles all reviewers**: Picks up unresolved comments from Claude, Codex, Copilot, and human reviewers. Normalizes severity across different comment formats.
 - **CI-aware**: Monitors CI after pushing fixes. Automatically diagnoses and fixes CI failures caused by the fix commit (up to 2 retries). Pre-existing CI failures are reported but not touched.
 - **Conflict-aware**: Detects merge conflicts with the base branch before applying review fixes. Resolves conflicts intelligently by reading both sides and merging logically. Conflicts that can't be safely resolved are reported for human intervention.
-- **Quality gates**: Runs `pnpm oxlint` after each file fix and `pnpm typecheck:interface` after all fixes. Ensures fixes don't introduce new issues.
+- **Quality gates**: Runs `pnpm exec biome check` after each file fix and `pnpm lint && pnpm -r --if-present build` after all fixes. Ensures fixes don't introduce new issues.
 - **Self-contained watcher**: The cron watcher does actual work inline (resolves conflicts, applies fixes, replies to threads, resolves threads) rather than re-invoking the skill. This avoids recursive watcher creation and ensures each cron tick is a complete fix cycle.
 - **Pairs with `/pr-review`**: `/pr-review` posts findings (from parallel Claude agents + optional Codex), `/pr-fix` applies fixes. With both using `--watch`, they form a fully autonomous review-fix loop.
 - Fixes are applied to the PR branch, not main/dev

--- a/.agents/commands/pr-fix.md
+++ b/.agents/commands/pr-fix.md
@@ -30,6 +30,22 @@ Parse `owner` and `repo` from the URL (handles both `git@github.com:owner/repo.g
 
 ## Step 2: Fetch PR Details and Checkout Branch
 
+### 2a: Check for clean working tree
+
+Before switching branches, verify the working tree is clean — abort the skill entirely if there are uncommitted changes:
+
+```bash
+git status --porcelain
+```
+
+If the output is non-empty, hard-abort with a clear message:
+
+```
+Working tree is not clean. Please commit or stash your changes before running /pr-fix.
+```
+
+### 2b: Fetch PR metadata
+
 Use local `gh` CLI to get PR metadata:
 
 ```bash
@@ -38,27 +54,32 @@ gh pr view <PR_NUMBER> --json title,baseRefName,headRefName,headRefOid,state
 
 Extract:
 
-- `baseRefName` — the base branch
-- `headRefName` — the head/PR branch
-- `headRefOid` — the head commit SHA
+- `<BASE_BRANCH>` — the base branch (`baseRefName`)
+- `<HEAD_BRANCH>` — the head/PR branch (`headRefName`)
+- `<HEAD_SHA>` — the head commit SHA (`headRefOid`)
 - `state` — must be `OPEN`
 
 If the PR is not open, inform the user and stop.
 
-Fetch and checkout the PR branch locally:
+### 2c: Fetch and checkout the PR branch
+
+Use `gh pr checkout` (cross-fork-safe — handles both existing and new local branches, and PRs from forks):
 
 ```bash
 git fetch origin
-git checkout <headRefName>
-git pull origin <headRefName>
+gh pr checkout <PR_NUMBER>
 ```
+
+This creates the local branch from the remote if needed, or switches to it if it already exists. It also handles PRs originating from forks correctly.
+
+**Note:** This will leave you on the PR branch when the skill finishes. The original branch is not restored automatically.
 
 ## Step 3: Check and Resolve Merge Conflicts
 
 ### 3a: Check for merge conflicts with the base branch
 
 ```bash
-git merge --no-commit --no-ff origin/<baseRefName> 2>&1
+git merge --no-commit --no-ff origin/<BASE_BRANCH> 2>&1
 ```
 
 ### 3b: If there are no conflicts (or already up to date)
@@ -75,7 +96,7 @@ git rev-parse --verify MERGE_HEAD >/dev/null 2>&1 && git merge --abort || true
 The merge will report conflicting files. For each conflicting file:
 
 1. **Read the file** with conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) using the Read tool
-2. **Understand both sides**: The `HEAD` side is the PR branch changes, the `origin/<baseRefName>` side is the base branch changes
+2. **Understand both sides**: The `HEAD` side is the PR branch changes, the `origin/<BASE_BRANCH>` side is the base branch changes
 3. **Resolve the conflict** intelligently:
    - If the PR branch changes are newer/intentional, keep them
    - If the base branch introduced a necessary change (new import, renamed function, updated API), incorporate it
@@ -92,7 +113,7 @@ git add <list of resolved files>
 
 # Complete the merge
 git commit -m "$(cat <<'EOF'
-merge: resolve conflicts with <baseRefName>
+merge: resolve conflicts with <BASE_BRANCH>
 
 Resolved merge conflicts in:
 - <file1>
@@ -103,13 +124,13 @@ EOF
 )"
 
 # Push the merge commit
-git push origin <headRefName>
+git push origin <HEAD_BRANCH>
 ```
 
 Print a summary of resolved conflicts:
 
 ```
-Resolved merge conflicts with <baseRefName>:
+Resolved merge conflicts with <BASE_BRANCH>:
   - <file1>: <brief description of resolution>
   - <file2>: <brief description of resolution>
 ```
@@ -127,6 +148,9 @@ If a conflict is too ambiguous to resolve safely (e.g., both sides rewrote the s
 Use `gh api graphql` to fetch all review threads on the PR:
 
 ```bash
+# Note: reviewThreads(first: 100) covers most PRs. If a PR has >100 review threads,
+# re-query using the pagination cursor from `pageInfo { hasNextPage endCursor }`
+# to fetch all threads. (Pagination not implemented here — flag and handle if hit.)
 gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -136,7 +160,7 @@ gh api graphql -f query='
             id
             isResolved
             isOutdated
-            comments(first: 10) {
+            comments(first: 50) {
               nodes {
                 databaseId
                 body
@@ -159,20 +183,37 @@ For each unresolved thread, extract:
 - `threadId` — the GraphQL node ID (for resolving later)
 - `path` — the file the comment is on
 - `line` — the line number (`originalLine`)
-- `body` — the comment text (contains the finding and suggestion)
-- `commentId` — the `databaseId` of the first comment (for replying)
-- `author` — who posted the comment
+- `body` — use **the most recent comment** in the thread (last in the `comments.nodes` array) — it may contain updated guidance
+- `commentId` — the `databaseId` of the **first** comment in the thread (for the `in_reply_to` reply target)
+- `author` — who posted the comment (to identify source: Claude, Codex, Copilot, or human)
 
 Group findings by file for efficient fixing.
 
 **Both Claude and Codex comments are handled.** Claude uses `**[SEVERITY]**` prefixes. Codex may use different formats. Human comments are also included.
 
-## Step 5: Triage Findings
+## Step 5: Triage & Relevance Assessment
 
-Sort unresolved findings by severity. Parse severity from the comment body:
+**Do NOT blindly fix every unresolved comment.** Each comment must pass relevance assessment before being queued for fixing. This prevents wasted effort, incorrect fixes, and regressions from applying stale or misunderstood suggestions.
+
+### 5a: Classify comment kind (and parse severity)
+
+For each unresolved thread, classify the **most recent comment** into one of these categories:
+
+| Category | Action | Examples |
+|---|---|---|
+| **Actionable fix** | Queue for fixing | "Use `bigint` for the amount", "Missing `.js` suffix on relative import", "Wrong SDK type" |
+| **Question / Clarification** | Skip — reply acknowledging, leave unresolved | "Why was this approach chosen?", "Is this intentional?", "What happens if X?" |
+| **Discussion / Opinion** | Skip — leave for human | "I'd prefer X over Y", "We should discuss whether...", "Not sure about this pattern" |
+| **Praise / Acknowledgment** | Skip — resolve thread | "LGTM", "Nice refactor", "Good catch" |
+| **Already addressed** | Skip — resolve with note | Comment refers to code that was changed in a subsequent commit |
+| **Stale / Inapplicable** | Skip — reply explaining | Comment references code that no longer exists at that location |
+
+**If classification is ambiguous, default to SKIP (leave for human review) rather than applying a potentially wrong fix.**
+
+While classifying, parse severity case-insensitively from the comment body:
 
 - **Claude comments**: `**[CRITICAL]**`, `**[HIGH]**`, `**[MEDIUM]**`, `**[LOW]**` prefix format
-- **Codex comments**: May use `severity:` fields, `[issue]`/`[suggestion]` tags, or plain text — infer severity from language (e.g., "bug", "security" -> HIGH; "nit", "consider" -> LOW)
+- **Codex comments**: May use `severity:` fields, `[issue]`/`[suggestion]` tags, or plain text — infer severity from language (e.g., "bug", "security" → HIGH; "nit", "consider" → LOW)
 - **Human comments**: Treat as HIGH by default unless they use language suggesting lower priority
 
 Priority order:
@@ -182,30 +223,111 @@ Priority order:
 3. **MEDIUM** — fix unless there's a good reason not to
 4. **LOW** — fix if straightforward
 
-Print a summary to the user before proceeding:
+### 5b: Check code freshness
+
+For each comment classified as "actionable fix," verify the referenced code still exists and is unchanged:
+
+```bash
+# Check if the file still exists
+test -f <path>
+```
+
+Using the Read tool, read the file at `path` and examine the area around `originalLine`. If:
+
+- The file no longer exists → re-classify as **Stale**
+- The code at that line has significantly changed (different logic, moved elsewhere) → re-classify as **Stale** and search for where the code moved to; only re-classify back to actionable if the same issue exists at the new location
+- The code is substantially the same → proceed
+
+### 5c: Check if already addressed
+
+For each remaining actionable comment, check whether the issue was already fixed in a commit after the review:
+
+```bash
+# Get commits on the file since the review comment was created
+git log --oneline --since="<comment_created_at>" -- <path>
+```
+
+If the most recent commit on the file is **after** the comment's `created_at`, mark the finding as "possibly already addressed" and require a verification re-read. Read the current state of the code at the referenced location — if the specific issue described in the comment (e.g., missing `.js` suffix, wrong type) is **no longer present in the current code**, classify as **Already addressed**.
+
+### 5d: Print assessment summary (BEFORE applying any fix)
+
+Print a summary to the user **before proceeding** — this gives them a chance to intervene:
 
 ```
-Found <N> unresolved review comments on PR #<number>:
+PR #<PR_NUMBER> — Review Comment Assessment:
+
+  Total unresolved threads: <N>
   Sources: X from Claude, Y from Codex, Z from humans
-  - X critical
-  - Y high
-  - Z medium
-  - W low
 
-Applying fixes...
+  Actionable fixes: <N>
+    - <X> critical, <Y> high, <Z> medium, <W> low
+  Skipped: <M>
+    - <A> questions/discussions (leaving for human)
+    - <B> stale/inapplicable (code changed)
+    - <C> already addressed (will resolve)
+    - <D> praise/acknowledgment (will resolve)
+
+  Per-comment bucket counts:
+  | Category            | Count |
+  |---------------------|-------|
+  | actionable          |   X   |
+  | question            |   X   |
+  | discussion          |   X   |
+  | praise              |   X   |
+  | already-addressed   |   X   |
+  | stale               |   X   |
+
+Proceeding with <N> actionable fixes...
 ```
+
+### 5e: Gate — only proceed with actionable + not-already-addressed
+
+Only proceed to Step 6 with comments classified as **actionable** AND **not already addressed**. All other categories are handled in Step 9 (replies) and Step 9.5 (reconciliation), not in Step 6 (fix application).
 
 ## Step 6: Apply Fixes
 
-For each unresolved finding, grouped by file:
+**Never apply a fix you don't fully understand. A skipped finding is always better than a wrong fix.**
 
-### 6a: Read the file from local filesystem
+For each actionable finding (from Step 5), grouped by file:
 
-Use the Read tool to read the full file content. Understand the surrounding context — don't fix in isolation.
+### 6a: Mandatory context-gathering (BEFORE any edit)
 
-### 6b: Apply the fix
+For each file with findings, build a complete understanding before touching anything:
 
-Use the Edit tool to make the change. Follow the suggestion in the review comment. If the comment describes a problem but not a specific fix, use your judgment to implement the correct solution.
+1. **Read the full file** — Use the Read tool. Understand the overall structure, not just the flagged line.
+
+2. **Read all files imported by the target file** — For TypeScript/NodeNext, every relative import is a `./xxx.js` reference; resolve them and read the source. Focus on:
+   - Type definitions, interfaces, or schemas referenced at the flagged location
+   - Helper modules used inside the changed function
+
+3. **Find callers** — Run grep to find every consumer of the symbol being changed:
+
+   ```bash
+   grep -rn "<exported-symbol-name>" packages/ test/
+   ```
+
+4. **If the change is in a public API**, read the corresponding `packages/<pkg>/src/index.ts` re-export entry point AND any test file under `packages/<pkg>/test/` that exercises the symbol.
+
+5. **If the comment cites an originating commit/PR** (e.g., "introduced in #1234" or `git blame` output), read the other files touched by that commit for context:
+
+   ```bash
+   git log --oneline -5 -- <path>
+   git show <commit>  # to see all files in the originating change
+   ```
+
+You do NOT need to read every transitive import — focus on files directly relevant to the specific fix.
+
+### 6b: Confidence assessment (BEFORE any edit)
+
+Before editing, write a one-line classification for the finding:
+
+- **HIGH** — You fully understand the change and its blast radius. **Proceed.**
+- **MEDIUM** — You understand the change but its blast radius is unclear. **Proceed but flag in the thread reply** that the fix should be double-checked.
+- **LOW** — You don't fully understand the change or the suggestion's reasoning. **Skip.** Record as "skipped: low confidence" and continue to the next finding. Reply on the thread explaining what's unclear; leave it unresolved for human review.
+
+### 6c: Apply the fix
+
+Use the Edit tool to make the change. Follow the suggestion in the review comment. If the comment describes a problem but not a specific fix, use the context gathered in 6a to implement the correct solution.
 
 **Rules:**
 
@@ -214,8 +336,9 @@ Use the Edit tool to make the change. Follow the suggestion in the review commen
 - If a fix requires changes across multiple files (e.g., updating an interface), make all necessary changes
 - If a finding is about missing tests, write the test
 - If a finding cannot be fixed (e.g., it's a false positive or disagrees with project conventions), skip it and note it for Step 9
+- If applying the fix would contradict another unresolved comment on the same code, skip both and flag the conflict for human review
 
-### 6c: Validate the fix
+### 6d: Validate the fix
 
 After each file is modified, run the project linter:
 
@@ -272,7 +395,7 @@ EOF
 ### 8c: Push to remote
 
 ```bash
-git push origin <headRefName>
+git push origin <HEAD_BRANCH>
 ```
 
 ## Step 9: Reply to and Resolve Review Threads
@@ -281,13 +404,20 @@ For each finding that was fixed:
 
 ### 9a: Reply to the comment thread
 
+Use a heredoc-built body file to ensure real newlines (not literal `\n`):
+
 ```bash
+BODY_FILE=$(mktemp)
+cat > "$BODY_FILE" <<'EOF'
+> <abbreviated original comment>
+
+Fixed in <HEAD_SHA> — <brief description of what was changed>
+EOF
 gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments \
   --method POST \
-  -f body="> <abbreviated original comment>
-
-Fixed in <commit_sha> — <brief description of what was changed>" \
+  --field body=@"$BODY_FILE" \
   -F in_reply_to=<commentId>
+rm -f "$BODY_FILE"
 ```
 
 ### 9b: Resolve the thread
@@ -303,15 +433,20 @@ gh api graphql -f query='
 
 ### 9c: For skipped findings
 
-If a finding was skipped (false positive, disagrees with conventions, etc.), reply explaining why it was not fixed, but do NOT resolve the thread — leave it for human review:
+If a finding was skipped (false positive, disagrees with conventions, low confidence, etc.), reply explaining why it was not fixed, but do NOT resolve the thread — leave it for human review:
 
 ```bash
+BODY_FILE=$(mktemp)
+cat > "$BODY_FILE" <<'EOF'
+> <abbreviated original comment>
+
+Skipped — <reason why this was not fixed>. Leaving for human review.
+EOF
 gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments \
   --method POST \
-  -f body="> <abbreviated original comment>
-
-Skipped — <reason why this was not fixed>. Leaving for human review." \
+  --field body=@"$BODY_FILE" \
   -F in_reply_to=<commentId>
+rm -f "$BODY_FILE"
 ```
 
 ## Step 9.5: Reconcile All Current Open Threads
@@ -353,25 +488,30 @@ Poll up to 5 times with 30-second intervals:
 gh pr checks <PR_NUMBER> --repo <owner>/<repo> --watch --fail-fast
 ```
 
-If `--watch` is not available, poll manually:
+If `--watch` is not available, poll manually using the documented `bucket` field:
 
 ```bash
+# Poll loop (up to 5 attempts, 30s apart)
 for i in 1 2 3 4 5; do
-  STATUS=$(gh pr checks <PR_NUMBER> --repo <owner>/<repo> --json name,state --jq '[.[] | select(.state != "completed")] | length')
-  if [ "$STATUS" = "0" ]; then break; fi
+  PENDING=$(gh pr checks <PR_NUMBER> --repo <owner>/<repo> --json name,bucket --jq '[.[] | select(.bucket == "pending")] | length')
+  if [ "$PENDING" = "0" ]; then break; fi
   sleep 30
 done
 ```
 
 ### 10d: If CI fails
 
-1. Get the failed check details:
+1. Get the failed check details and extract the run ID:
    ```bash
-   gh pr checks <PR_NUMBER> --repo <owner>/<repo> --json name,state,bucket,link --jq '.[] | select(.bucket == "fail")'
+   # Get failed checks
+   gh pr checks <PR_NUMBER> --repo <owner>/<repo> --json name,bucket,link --jq '.[] | select(.bucket == "fail")'
+
+   # Extract run ID from the failed check's link URL
+   RUN_ID=$(gh pr checks <PR_NUMBER> --repo <owner>/<repo> --json bucket,link --jq '.[] | select(.bucket == "fail") | .link | capture("/runs/(?<id>[0-9]+)") | .id' | head -1)
    ```
-2. Fetch the CI logs for the failed job(s):
+2. Fetch the CI logs for the failed job:
    ```bash
-   gh run view <RUN_ID> --repo <owner>/<repo> --log-failed
+   gh run view "$RUN_ID" --repo <owner>/<repo> --log-failed
    ```
 3. Analyze the failure and determine if it was caused by the fix commit.
 4. If the failure is caused by the fix:
@@ -390,9 +530,9 @@ Continue to Step 11.
 Print a final summary:
 
 ```
-PR #<number> fixes applied and pushed.
+PR #<PR_NUMBER> fixes applied and pushed.
 
-Commit: <short_sha>
+Commit: <HEAD_SHA_SHORT>
 Conflicts: <RESOLVED X files / NONE / UNRESOLVABLE>
 Fixed: <N> findings (X from Claude, Y from Codex, Z from humans)
 Skipped: <M> findings (see thread replies for reasons)
@@ -400,6 +540,8 @@ CI: <PASS/FAIL/PENDING>
 
 Resolved threads: <N>
 Left open for human review: <M>
+
+Note: You are now on branch <HEAD_BRANCH>.
 ```
 
 If conflicts were resolved, list each file and the resolution strategy.
@@ -437,7 +579,8 @@ CYCLE START:
    If not "OPEN": say "PR #<PR_NUMBER> is no longer open (state: <STATE>). Fix watcher done." and end.
 
 2. FETCH AND SYNC:
-   Run: cd <REPO_PATH> && git fetch origin && git checkout <HEAD_BRANCH> && git pull origin <HEAD_BRANCH>
+   Run: cd <REPO_PATH> && git fetch origin && gh pr checkout <PR_NUMBER>
+   (`gh pr checkout` is cross-fork-safe — it handles fork PRs and existing local branches.)
 
 3. CHECK MERGE CONFLICTS:
    Run: cd <REPO_PATH> && git merge --no-commit --no-ff origin/<BASE_BRANCH> 2>&1
@@ -446,11 +589,12 @@ CYCLE START:
    - If conflicts are too ambiguous: `git merge --abort`, report which files, continue to step 4.
 
 4. CHECK CI:
-   Run: cd <REPO_PATH> && gh pr checks <PR_NUMBER> --json name,state,bucket,link --jq '.[] | select(.bucket == "fail")'
+   Run: cd <REPO_PATH> && gh pr checks <PR_NUMBER> --json name,bucket,link --jq '.[] | select(.bucket == "fail")'
    If CI failures exist:
-   a. Get logs: `gh run view <RUN_ID> --repo <owner>/<repo> --log-failed`
-   b. If caused by a recent fix commit: apply corrective fix, commit "fix: address CI failure", push (max 2 retries)
-   c. If pre-existing: note it, do not fix
+   a. Extract run ID: RUN_ID=$(gh pr checks <PR_NUMBER> --json bucket,link --jq '.[] | select(.bucket == "fail") | .link | capture("/runs/(?<id>[0-9]+)") | .id' | head -1)
+   b. Get logs: `gh run view "$RUN_ID" --repo <owner>/<repo> --log-failed`
+   c. If caused by a recent fix commit: apply corrective fix, commit "fix: address CI failure", push (max 2 retries)
+   d. If pre-existing: note it, do not fix
 
 5. FETCH UNRESOLVED REVIEW COMMENTS using gh api graphql:
    Run:
@@ -463,7 +607,7 @@ CYCLE START:
                id
                isResolved
                isOutdated
-               comments(first: 10) {
+               comments(first: 50) {
                  nodes {
                    databaseId
                    body
@@ -479,15 +623,24 @@ CYCLE START:
      }' -f owner=<owner> -f repo=<repo> -F pr=<PR_NUMBER>
 
    Filter to threads where isResolved=false AND isOutdated=false.
-   For each thread: extract threadId (the node id), path, line (originalLine), body, commentId (databaseId of first comment), author.
+   For each thread: extract threadId (the node id), path, line (originalLine), body (use the **most recent** comment in the thread for the latest guidance), commentId (databaseId of the **first** comment, for the in_reply_to reply target), author.
+   Parse severity case-insensitively from the comment body.
 
 6. EVALUATE:
    If zero unresolved comments AND CI passing AND no conflicts: say "PR #<PR_NUMBER> is green — no unresolved comments, CI passing, no conflicts." and end this cycle.
 
 7. APPLY FIXES for unresolved comments:
-   a. Group by file. For each file: read with Read tool, apply fix with Edit tool per the comment suggestion.
+
+   **Confidence gate (BEFORE any edit):** For each unresolved comment:
+   - Classify as actionable / question / discussion / praise / already-addressed / stale (skip non-actionable; reply per kind in step f/h).
+   - For each actionable comment: read the file at the comment's path+line and verify the referenced code still exists / hasn't been already fixed in a later commit (`git log --oneline --since="<comment_created_at>" -- <path>`).
+   - **Mandatory context-gathering:** read the FULL file, read all files imported by it, and run `grep -rn "<exported-symbol-name>" packages/ test/` to find callers. If the change is in a public API, also read the corresponding `packages/<pkg>/src/index.ts` and any test file under `packages/<pkg>/test/`.
+   - Assign confidence: HIGH (proceed), MEDIUM (proceed but flag in reply), LOW (SKIP — record as "skipped: low confidence", reply with what's unclear, leave thread unresolved).
+   - **Never apply a fix you don't fully understand. A skipped finding is always better than a wrong fix.**
+
+   a. Group by file. For each file: apply fix with Edit tool per the comment suggestion (using the context already gathered above).
    b. Run pnpm exec biome check on modified files (or pnpm lint for the project-wide check).
-   c. Stage: `git add <changed files>`
+   c. Stage: `git add <changed files>` (verify only fix-related files are staged with `git diff --cached --name-only`; unstage unrelated files with `git reset HEAD <file>` if needed)
    d. Commit: `git commit -m "$(cat <<'INNEREOF'
 fix: address PR review findings
 
@@ -495,12 +648,21 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 INNEREOF
 )"`
    e. Push: `git push origin <HEAD_BRANCH>`
-   f. For each fixed comment, reply in-thread:
-      `gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments --method POST -f body="> <abbreviated comment>\n\nFixed in <sha>" -F in_reply_to=<commentId>`
+   f. For each fixed comment, reply in-thread using a heredoc-built body file for proper newlines:
+      ```
+      BODY_FILE=$(mktemp)
+      cat > "$BODY_FILE" <<'REPLYEOF'
+> <abbreviated comment>
+
+Fixed in <HEAD_SHA>
+REPLYEOF
+      gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments --method POST --field body=@"$BODY_FILE" -F in_reply_to=<commentId>
+      rm -f "$BODY_FILE"
+      ```
    g. Resolve each thread:
       `gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>`
-   h. For skipped findings, reply with skip reason but do NOT resolve the thread.
-   i. Say "Fixed <N> findings, pushed commit <sha>, resolved <N> threads."
+   h. For skipped findings (questions, stale, low-confidence), reply with skip reason via the same heredoc form but do NOT resolve the thread.
+   i. Say "Assessed <N> comments: fixed <X>, skipped <Y> (questions/stale/low-confidence). Pushed commit <HEAD_SHA>, resolved <X> threads."
 
 CYCLE END — the cron scheduler will run this again in 2 minutes.
 ```

--- a/.agents/commands/pr-review.md
+++ b/.agents/commands/pr-review.md
@@ -1,0 +1,461 @@
+# pr-review
+
+Reviews a GitHub Pull Request using parallel specialized agents, posts findings as inline review comments. Supports CI mode (GitHub Actions) and local mode. Optionally watches for new commits and re-reviews automatically.
+
+## Usage
+
+```
+/pr-review <pr-number>
+/pr-review <pr-number> --watch
+@claude /pr-review
+```
+
+## Examples
+
+```
+/pr-review 123
+/pr-review 456 --watch
+@claude /pr-review this PR
+```
+
+## Documentation Reference
+
+When reviewing, refer to these project docs as needed:
+
+| Document              | Path                                                | Use For                         |
+| --------------------- | --------------------------------------------------- | ------------------------------- |
+| **Project Context**   | `CLAUDE.md`                                         | Tech stack, commands, structure |
+| **Coding Guidelines** | `.agents/guidelines.md`                             | All code changes                |
+| **Chain Integration** | `docs/chains.md`                                    | New chain support PRs           |
+| **Deployment**        | `docs/deployment.md`                                | Build/Docker/CI changes         |
+| **Rewards**           | `apps/vvrm-app/src/contexts/Reward/rewards.md`      | Rewards feature changes         |
+| **Consumer API**      | `apps/vvrm-app/src/services/consumer-api/README.md` | API client changes              |
+
+## Skills Reference
+
+Consult these skills for in-depth best practices:
+
+| Skill                      | Path                                          | Use For                                |
+| -------------------------- | --------------------------------------------- | -------------------------------------- |
+| **React Best Practices**   | `.agents/skills/vercel-react-best-practices/` | Performance, rendering, async patterns |
+| **Composition Patterns**   | `.agents/skills/vercel-composition-patterns/` | Component architecture, props design   |
+| **Web Design Guidelines**  | `.agents/skills/web-design-guidelines/`       | UI/UX review, accessibility            |
+| **Next.js Best Practices** | `.agents/skills/next-best-practices/`         | App Router, RSC, data fetching         |
+| **React Doctor**           | `.agents/skills/react-doctor/`                | Common React issues                    |
+
+> **TWO-PHASE SKILL**: Phase 1 (Steps 1-8) does the initial review. Phase 2 (Step 9) creates a continuous watcher via CronCreate if `--watch` was passed. If `--watch` is used, the skill is NOT complete until Step 9's CronCreate call succeeds and you report the job ID to the user.
+
+## Step 1: Detect Environment and Repository
+
+### Environment Detection
+
+Detect your environment to determine the review mode:
+
+- **CI Mode**: If running in GitHub Actions (check for `CI=true` or `GITHUB_ACTIONS=true` environment variable), post review comments directly and submit a formal verdict
+- **Local Mode**: If running locally (no CI env vars), use parallel agents and post as `COMMENT` (never auto-approve or request changes)
+
+### Repository Detection
+
+Extract owner and repo from the git remote:
+
+```bash
+git remote get-url origin
+```
+
+Parse `owner` and `repo` from the URL (handles both `git@github.com:owner/repo.git` and `https://github.com/owner/repo.git` formats). Strip the `.git` suffix.
+
+## Step 2: Fetch PR Details
+
+Use local `gh` CLI to get PR metadata:
+
+```bash
+gh pr view <PR_NUMBER> --json title,body,baseRefName,headRefName,headRefOid,state
+```
+
+Extract:
+
+- `baseRefName` — the base branch
+- `headRefName` — the head/PR branch
+- `headRefOid` — the head commit SHA (this is your **last_reviewed_sha**)
+- `state` — must be `OPEN`
+
+Then fetch the latest remote state:
+
+```bash
+git fetch origin
+```
+
+If the PR is not open, inform the user and stop.
+
+## Step 3: Get Full PR Diff Locally
+
+**IMPORTANT: Use the local repo on disk, NOT the GitHub API, for reading code and diffs.**
+
+```bash
+# Get the merge base between PR head and base branch
+MERGE_BASE=$(git merge-base origin/<base_branch> origin/<head_branch>)
+
+# Full diff of the PR
+git diff $MERGE_BASE..origin/<head_branch>
+
+# List of changed files
+git diff --name-only $MERGE_BASE..origin/<head_branch>
+```
+
+Also read the actual changed files from the local filesystem using the Read tool so agents have full file context (not just diff hunks).
+
+## Step 4: Read Project Guidelines
+
+Before launching review agents, read the key reference documents so you can include relevant criteria in each agent's prompt:
+
+1. Read `.agents/guidelines.md` for coding standards
+2. Read relevant sections of the skills referenced above based on what files changed
+
+## Step 5: Launch Parallel Review Agents
+
+Launch ALL 5 review agents **in parallel** using the Agent tool (subagent_type: `"general-purpose"`). Each agent should:
+
+- Receive the full diff AND the full content of changed files (read from local filesystem)
+- Be told the repo path, owner, repo name, PR number, base branch, and head branch
+- Be instructed to analyze the **full PR diff** (not just latest commit)
+- Have access to read local files for additional context (e.g., imports, types, configs)
+- Return structured findings as a JSON array: `[{severity: "critical"|"high"|"medium"|"low", file: "path/to/file", line: number, description: "what is wrong and how to fix it"}]`
+- Only include **actionable** findings — no praise, no summaries
+
+### Agent 1: Code Quality
+
+Focus: TypeScript strict mode, type safety, early returns, `as` assertions, duplication, naming conventions, code smells, magic numbers, overly complex functions.
+
+Prompt must include:
+
+- Type safety issues (any types, type assertions, missing generics)
+- Error handling and edge cases
+- Code smells (duplicated logic, overly complex functions, magic numbers)
+- Early returns preferred over nested conditionals
+- Naming conventions per guidelines (PascalCase for components, camelCase for hooks, etc.)
+- Reference `.agents/guidelines.md` rules
+
+### Agent 2: React & Architecture
+
+Focus: Component patterns, hooks rules, React Compiler, re-render optimization, Suspense/error boundaries, Next.js App Router patterns.
+
+Prompt must include:
+
+- React best practices (hooks rules, effect dependencies, unnecessary re-renders)
+- Component patterns (prop drilling, component composition, separation of concerns)
+- Performance issues (check for manual memoization — should use React Compiler with `"use memo";` instead)
+- Re-render optimization (derived state, lazy init, functional setState)
+- Avoid boolean prop proliferation (use variants or compound components)
+- Prefer children over render props
+- App Router patterns (server vs client components, data fetching)
+- Client/server boundary violations
+- Reference `.agents/skills/vercel-react-best-practices/` and `.agents/skills/vercel-composition-patterns/`
+
+### Agent 3: Web3 Security
+
+Focus: Contract interactions, transaction parameters, wallet handling, permit flows, race conditions. **This is CRITICAL review territory.**
+
+Prompt must include:
+
+- Contract interactions: verify correct contract addresses, function signatures, and arguments
+- Transaction parameters: check gas estimates, value transfers, and calldata encoding
+- Reactivity concerns: can state changes cause unintended transaction parameters?
+- Wallet connection: proper account handling and chain verification
+- Hook usage: correct usage of wagmi hooks (useContractRead, useContractWrite, etc.)
+- Error handling: transaction failures, reverts, and user rejections
+- Race conditions in async operations
+- Missing transaction confirmations or proper waiting for receipts
+- Permit/deadline handling (avoid stale block timestamps)
+
+### Agent 4: Silent Failure Hunter
+
+Focus: Swallowed errors, missing error boundaries, empty catch blocks, unhandled promise rejections, missing loading/error states, dead code paths.
+
+Prompt must include:
+
+- Empty or overly broad catch blocks that swallow errors
+- Missing error boundaries around async components
+- Unhandled promise rejections (missing `.catch()` or try/catch)
+- Missing loading states for async operations
+- Missing error states for failed data fetches
+- Silently ignored return values from critical operations
+- Dead code paths that can never execute
+
+### Agent 5: Style & Guidelines Compliance
+
+Focus: Tailwind vs Emotion enforcement, import ordering, naming conventions, colocation, guidelines checklist.
+
+Prompt must include:
+
+- New components should use Tailwind (not Emotion)
+- No mixing Tailwind and Emotion in the same component
+- UI Kit V6 components for new unopinionated components
+- Import ordering per guidelines
+- Colocation: related code should be together, not in centralized folders
+- Reference `.agents/guidelines.md` and `.agents/skills/web-design-guidelines/`
+
+## Step 6: Aggregate and Deduplicate Findings
+
+Merge all agent results. Deduplicate findings that reference the same file+line. Keep the highest severity when duplicates exist.
+
+Map severity levels for display:
+
+- `critical` → 🔴 Critical
+- `high` → 🟡 Important
+- `medium` → 🔵 Medium
+- `low` → 🔵 Minor
+
+---
+
+## Step 7: Post Review (CI Mode)
+
+**Only follow this step if running in CI mode (GitHub Actions).**
+
+### 7a: Create pending review and add inline comments
+
+```bash
+# Create a pending review (returns review_id)
+# Note: omit the "event" field entirely to create a pending review — "PENDING" is not a valid event value
+REVIEW_ID=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews \
+  --method POST \
+  -f commit_id="<head_commit_sha>" \
+  --jq '.id')
+
+# For each finding, add an inline comment to the pending review
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/comments \
+  --method POST \
+  -f path="<file>" \
+  -F line=<line> \
+  -f side="RIGHT" \
+  -f body="**[SEVERITY]** <description>
+
+Suggestion: <how to fix>"
+```
+
+### 7b: Submit formal review with verdict
+
+**Choose the appropriate verdict based on findings:**
+
+| Verdict             | When                                              | Event             |
+| ------------------- | ------------------------------------------------- | ----------------- |
+| **Approve**         | No critical or important issues (minor issues OK) | `APPROVE`         |
+| **Request Changes** | Any critical issues, or multiple important issues | `REQUEST_CHANGES` |
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/events \
+  --method POST \
+  -f event="<APPROVE or REQUEST_CHANGES>" \
+  -f body="<!-- CLAUDE_REVIEW_COMPLETE -->
+<!-- CLAUDE_VERDICT:APPROVE -->  <!-- Only include for approvals -->
+## Code Review Summary
+
+### Overview
+<Brief summary of the PR and overall assessment>
+
+### Findings
+- 🔴 Critical: X issues
+- 🟡 Important: X issues
+- 🔵 Minor: X issues
+
+See inline comments for details.
+
+### Guidelines Compliance
+- [ ] Follows TypeScript strict mode
+- [ ] Uses early returns over nested conditionals
+- [ ] React Compiler (\`\"use memo\";\`) instead of manual memoization
+- [ ] Tailwind for new components (not Emotion)
+- [ ] Proper error handling with logger service
+- [ ] Naming conventions followed
+- [ ] Component composition patterns (no boolean prop proliferation)
+- [ ] Proper async/Suspense boundaries
+- [ ] No unnecessary re-renders
+
+### Verdict
+✅ **Approved** - Code looks good!
+<!-- OR -->
+❌ **Changes Requested** - Please address the issues above."
+```
+
+**Important notes for CI mode:**
+
+- Always include `<!-- CLAUDE_REVIEW_COMPLETE -->` in every review
+- For approvals, also include `<!-- CLAUDE_VERDICT:APPROVE -->` and use `APPROVE` event
+- Line numbers must match the NEW file in the diff (right side)
+- Use `side: "RIGHT"` for commenting on added/modified lines
+- For multi-line suggestions, use `start_line` and `line` parameters
+
+**After posting, skip to Step 8.** CI mode does not use `--watch`.
+
+---
+
+## Step 7 (alt): Post Review (Local Mode)
+
+**Only follow this step if running locally (NOT in CI).**
+
+### 7a: Create pending review and add inline comments
+
+```bash
+# Create a pending review (returns review_id)
+# Note: omit the "event" field entirely to create a pending review — "PENDING" is not a valid event value
+REVIEW_ID=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews \
+  --method POST \
+  -f commit_id="<head_commit_sha>" \
+  --jq '.id')
+
+# For each finding, add an inline comment to the pending review
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/comments \
+  --method POST \
+  -f path="<file>" \
+  -F line=<line> \
+  -f side="RIGHT" \
+  -f body="**[SEVERITY]** <description>
+
+Suggestion: <how to fix>"
+
+# Submit the review as COMMENT (never auto-approve or request changes in local mode)
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/events \
+  --method POST \
+  -f event="COMMENT" \
+  -f body="## Parallel PR Review (Claude)
+
+**Reviewed commit:** \`<short_sha>\`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | X |
+| 🟡 Important | X |
+| 🔵 Medium | X |
+| 🔵 Minor | X |
+
+_This is an automated parallel review. It will re-run when new commits are pushed (if watching)._"
+```
+
+**Important**: If the pending review API is not available, fall back to posting individual inline comments via `gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments`.
+
+If there are zero findings, still submit with a body saying "No issues found in this review."
+
+### 7b: Optional Codex pass
+
+Check if `codex` CLI is available:
+
+```bash
+which codex
+```
+
+If available, run in the background (do not wait for it to finish):
+
+```bash
+codex exec -c model_reasoning_effort=xhigh "Review PR #<PR_NUMBER> in this repo. The PR branch is <headRefName> based on <baseRefName>. Run 'git diff origin/<baseRefName>...origin/<headRefName>' to get the full diff. Analyze the changes for bugs, security issues, code quality, and best practices. Post your findings as inline review comments on the PR using 'gh api' to create a pull request review with comments on specific lines." 2>&1 | tail -50
+```
+
+If `codex` is not installed or the command fails, log the error and continue — Claude review is sufficient on its own.
+
+---
+
+## Step 8: Report to User
+
+Print a summary:
+
+```
+PR #<number> review posted:
+  Claude: <N> findings (X critical, Y important, Z medium, W minor)
+  Codex:  <triggered in background / not available>
+  Mode:   <CI / Local>
+Last reviewed commit: <short_sha>
+```
+
+If `--watch` was NOT passed (or in CI mode), the skill is complete here.
+
+If `--watch` WAS passed AND in local mode, **you MUST proceed to Step 9**.
+
+## Step 9: Schedule Continuous Watch (only with --watch, local mode only)
+
+**If `--watch` was passed, you MUST call `CronCreate` now.** Do not skip this step.
+
+Use `CronCreate` to schedule a recurring job every 2 minutes:
+
+- cron: `*/2 * * * *`
+- recurring: true
+- prompt: The prompt below, with all variables filled in (replace all `<PLACEHOLDERS>` with actual values):
+
+```
+You are the PR review watcher for PR #<PR_NUMBER> in <owner>/<repo>.
+Last reviewed commit SHA: <LAST_REVIEWED_SHA>.
+Repo path: <REPO_PATH>
+Head branch: <HEAD_BRANCH>
+Base branch: <BASE_BRANCH>
+
+This is a RECURRING cron job. Each run is one check cycle. After completing a cycle, simply end your response — the cron scheduler will invoke you again in 2 minutes.
+
+CYCLE START:
+
+1. FETCH AND CHECK STATE:
+   Run: cd <REPO_PATH> && git fetch origin
+   Run: git rev-parse origin/<HEAD_BRANCH>
+   Run: gh pr view <PR_NUMBER> --repo <owner>/<repo> --json state --jq '.state'
+   If not "OPEN": say "PR #<PR_NUMBER> is no longer open (state: <STATE>). Review watcher done." and end.
+
+2. COMPARE SHA:
+   Compare the current head SHA to the last reviewed SHA (<LAST_REVIEWED_SHA>).
+   If the SHA is the same: say "No new commits on PR #<PR_NUMBER>, still at <short_sha>." and end this cycle.
+
+3. NEW COMMIT DETECTED:
+   Say "New commit detected on PR #<PR_NUMBER>: <new_sha>. Running full review..."
+
+4. GET FULL PR DIFF:
+   Run: cd <REPO_PATH>
+   MERGE_BASE=$(git merge-base origin/<BASE_BRANCH> origin/<HEAD_BRANCH>)
+   git diff $MERGE_BASE..origin/<HEAD_BRANCH>
+   git diff --name-only $MERGE_BASE..origin/<HEAD_BRANCH>
+   Also read each changed file from the local filesystem using the Read tool for full context.
+
+5. READ GUIDELINES:
+   Read .agents/guidelines.md for coding standards.
+
+6. LAUNCH REVIEW AGENTS in parallel using the Agent tool (subagent_type: "general-purpose"):
+   a. code-quality — TypeScript strict mode, type safety, early returns, assertions, duplication, naming, code smells
+   b. react-architecture — component patterns, hooks, React Compiler ("use memo;"), re-render optimization, Next.js App Router
+   c. web3-security — contract interactions, tx params, wallets, permits, race conditions (CRITICAL)
+   d. silent-failure-hunter — swallowed errors, empty catch blocks, missing error boundaries, unhandled rejections
+   e. style-guidelines — Tailwind vs Emotion, import ordering, naming conventions, colocation
+   Each agent receives the full diff AND changed file contents, and returns findings as JSON: [{severity, file, line, description}]
+
+7. Collect and deduplicate all agent findings. Keep highest severity for same file+line.
+
+8. POST REVIEW to GitHub:
+   a. Create a pending review (omit event field): gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews --method POST -f commit_id="<new_sha>"
+   b. Add inline comments for each finding (format: "**[SEVERITY]** description")
+   c. Submit the review as COMMENT: gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/<REVIEW_ID>/events --method POST -f event="COMMENT"
+
+9. OPTIONAL CODEX: If `which codex` succeeds, run codex review in background.
+
+10. Say "Review posted for PR #<PR_NUMBER> commit <new_short_sha>: <N> findings (X critical, Y important, Z medium, W minor)."
+
+CYCLE END — the cron scheduler will run this again in 2 minutes.
+```
+
+**After CronCreate returns the job ID:**
+
+1. Report the job ID to the user
+2. Tell them they can cancel with `CronDelete` using that ID
+3. Note that the watcher auto-expires after 3 days
+4. Only THEN is the skill complete
+
+## Error Handling
+
+- If the PR doesn't exist: tell the user and stop
+- If the diff is too large for agents: split by file groups and review in batches
+- If posting review fails (e.g., permissions): fall back to posting a single PR comment with all findings using `gh api repos/<owner>/<repo>/issues/<PR_NUMBER>/comments`
+- If an agent fails: continue with results from other agents, note which aspect was skipped
+- If CronCreate is not available: skip continuous monitoring, inform the user that `--watch` requires CronCreate
+
+## Notes
+
+- **Local-first**: Always use local filesystem and git commands for reading code, diffs, and file contents. Only use GitHub API for posting reviews/comments (write operations). Never use the GitHub API to read diffs or file contents — the local repo has everything.
+- **Unified command**: This command replaces the old separate `/review` (CI-only) and `/pr-review` (local-only) commands. It auto-detects the environment and adapts its behavior.
+- **CI mode differences**: In CI, the review submits a formal verdict (`APPROVE` or `REQUEST_CHANGES`), includes `CLAUDE_REVIEW_COMPLETE` markers, and does not support `--watch`. In local mode, the review always posts as `COMMENT` and optionally supports `--watch`.
+- **Self-contained watcher**: The cron watcher performs the full review inline (launches agents, posts review) rather than re-invoking the skill. This avoids recursive watcher creation and ensures each cron tick is a complete review cycle.
+- Always review the FULL PR diff, not just the latest commit — this ensures context and cross-file impact are considered
+- Each re-review posts a new review (GitHub keeps the history)
+- This skill works on any repository — it detects owner/repo from git remote automatically
+- The skill assumes it is invoked from within the git repository

--- a/.agents/commands/pr-review.md
+++ b/.agents/commands/pr-review.md
@@ -31,6 +31,22 @@ When reviewing, refer to these project docs as needed:
 
 > **TWO-PHASE SKILL**: Phase 1 (Steps 1-8) does the initial review. Phase 2 (Step 9) creates a continuous watcher via CronCreate if `--watch` was passed. If `--watch` is used, the skill is NOT complete until Step 9's CronCreate call succeeds and you report the job ID to the user.
 
+## Placeholder convention
+
+Throughout this skill, the following placeholders are used consistently:
+
+| Placeholder | Source | Description |
+|---|---|---|
+| `<owner>` | parsed from git remote | GitHub repo owner |
+| `<repo>` | parsed from git remote | GitHub repo name |
+| `<PR_NUMBER>` | user argument | Pull request number |
+| `<BASE_BRANCH>` | `gh pr view` → `baseRefName` | PR base branch |
+| `<HEAD_BRANCH>` | `gh pr view` → `headRefName` | PR head branch |
+| `<HEAD_SHA>` | `gh pr view` → `headRefOid` | Head commit full SHA |
+| `<HEAD_SHA_SHORT>` | first 7 chars of `<HEAD_SHA>` | Head commit short SHA |
+| `<REPO_PATH>` | `git rev-parse --show-toplevel` | Absolute path to repo root |
+| `<BOT_LOGIN>` | `gh api user --jq '.login'` | Current GitHub user's login |
+
 ## Step 1: Detect Environment and Repository
 
 ### Environment Detection
@@ -48,7 +64,17 @@ Extract owner and repo from the git remote:
 git remote get-url origin
 ```
 
-Parse `owner` and `repo` from the URL (handles both `git@github.com:owner/repo.git` and `https://github.com/owner/repo.git` formats). Strip the `.git` suffix.
+Parse `<owner>` and `<repo>` from the URL (handles both `git@github.com:owner/repo.git` and `https://github.com/owner/repo.git` formats). Strip the `.git` suffix.
+
+### Current User Detection
+
+Determine the current GitHub user (needed for watcher SHA tracking):
+
+```bash
+BOT_LOGIN=$(gh api user --jq '.login')
+```
+
+Store this as `<BOT_LOGIN>` for use in Step 9.
 
 ## Step 2: Fetch PR Details
 
@@ -60,9 +86,9 @@ gh pr view <PR_NUMBER> --json title,body,baseRefName,headRefName,headRefOid,stat
 
 Extract:
 
-- `baseRefName` — the base branch
-- `headRefName` — the head/PR branch
-- `headRefOid` — the head commit SHA (this is your **last_reviewed_sha**)
+- `<BASE_BRANCH>` — the base branch (`baseRefName`)
+- `<HEAD_BRANCH>` — the head/PR branch (`headRefName`)
+- `<HEAD_SHA>` — the head commit SHA (`headRefOid`)
 - `state` — must be `OPEN`
 
 Then fetch the latest remote state:
@@ -79,13 +105,13 @@ If the PR is not open, inform the user and stop.
 
 ```bash
 # Get the merge base between PR head and base branch
-MERGE_BASE=$(git merge-base origin/<base_branch> origin/<head_branch>)
+MERGE_BASE=$(git merge-base origin/<BASE_BRANCH> origin/<HEAD_BRANCH>)
 
 # Full diff of the PR
-git diff $MERGE_BASE..origin/<head_branch>
+git diff $MERGE_BASE..origin/<HEAD_BRANCH>
 
 # List of changed files
-git diff --name-only $MERGE_BASE..origin/<head_branch>
+git diff --name-only $MERGE_BASE..origin/<HEAD_BRANCH>
 ```
 
 Also read the actual changed files from the local filesystem using the Read tool so agents have full file context (not just diff hunks).
@@ -99,7 +125,7 @@ Before launching review agents, read the key reference documents so you can incl
 
 ## Step 5: Launch Parallel Review Agents
 
-Launch ALL 5 review agents **in parallel** using the Agent tool (subagent_type: `"general-purpose"`). Each agent should:
+Launch ALL 7 review agents **in parallel** using the Agent tool (subagent_type: `"general-purpose"`). Each agent should:
 
 - Receive the full diff AND the full content of changed files (read from local filesystem)
 - Be told the repo path, owner, repo name, PR number, base branch, and head branch
@@ -120,6 +146,19 @@ Prompt must include:
 - Early returns preferred over nested conditionals
 - Naming conventions per `CLAUDE.md`
 - Reference `CLAUDE.md` and `CONTRIBUTING.md`
+
+**Cross-file impact (critical for an SDK):**
+- Changed exports from `packages/<pkg>/src/index.ts` — could break consumer code
+- Function signature changes on public APIs (parameter add/remove/reorder/type-narrow)
+- Renamed or removed exports
+- API contract changes (return type, thrown error type, async-vs-sync)
+- New deep imports into other packages (should go through `src/index.ts`)
+
+**Security:**
+- Hardcoded secrets, tokens, private keys, RPC URLs with credentials
+- Injection risks in any string-templated input (SQL-like queries, shell commands)
+- Authentication bypass / authorization checks missing on entry points
+- `eval`, `Function(...)` constructors, dynamic `import(<userInput>)` — flag any
 
 ### Agent 2: Module & API Architecture
 
@@ -182,9 +221,44 @@ Prompt must include:
 - Reuse of SDK types (`Address`, `MarketId`, `ChainId`, `BigIntish`) over local re-declarations
 - Reference `CLAUDE.md` and `biome.json`
 
+### Agent 6: Documentation Analyzer
+
+Focus: JSDoc/TSDoc on public APIs and types in `packages/<pkg>/src/index.ts` and the
+files it re-exports.
+
+Prompt must include:
+
+- New or modified public exports (types, functions, classes) have JSDoc/TSDoc with at
+  minimum: a one-line summary, `@param` for non-obvious args, `@returns` for non-trivial
+  return values, and `@throws` for typed `Error` subclasses
+- Doc comments are accurate vs. the implementation (no stale references to renamed args,
+  removed return values, changed throw behavior)
+- Public types use semantic names — flag generic `T`, `U`, `Foo` where domain names exist
+  (e.g. `Address`, `MarketId`)
+- README / package-level doc files are updated when the public API changes shape
+- Examples in doc comments compile (no obvious type errors in inline `@example` blocks)
+
+### Agent 7: Test Coverage Analyzer
+
+Focus: missing or weak tests in `packages/<pkg>/test/` for changes in `packages/<pkg>/src/`.
+
+Prompt must include:
+
+- New public exports without a corresponding test file under `packages/<pkg>/test/`
+- New code paths inside existing exports without test cases (branches, error paths,
+  edge cases like zero/MAX_UINT256/negative bigints)
+- Removed or modified public exports without tests updated
+- Onchain code paths (any code calling `viem`/`wagmi` actions) — confirm there's at
+  least one test that exercises the path against a fork or mock
+- Snapshot or schema tests updated when generated outputs change
+
 ## Step 6: Aggregate and Deduplicate Findings
 
-Merge all agent results. Deduplicate findings that reference the same file+line. Keep the highest severity when duplicates exist.
+Merge all agent results into a single list:
+
+1. Deduplicate findings that reference the same file + line (within **3 lines tolerance** — two findings on the same file within 3 lines of each other are treated as duplicates)
+2. When duplicates exist, keep the finding with the highest severity
+3. Sort by: file path (alphabetical, ASC), then line number (ASC), then severity (DESC)
 
 Map severity levels for display:
 
@@ -199,28 +273,33 @@ Map severity levels for display:
 
 **Only follow this step if running in CI mode (GitHub Actions).**
 
-### 7a: Create pending review and add inline comments
+### 7a: Build the comments array and submit atomically
+
+Construct a JSON object with all findings. Write it to a PR-specific temp file to avoid collisions with concurrent runs:
 
 ```bash
-# Create a pending review (returns review_id)
-# Note: omit the "event" field entirely to create a pending review — "PENDING" is not a valid event value
-REVIEW_ID=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews \
-  --method POST \
-  -f commit_id="<head_commit_sha>" \
-  --jq '.id')
-
-# For each finding, add an inline comment to the pending review
-gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/comments \
-  --method POST \
-  -f path="<file>" \
-  -F line=<line> \
-  -f side="RIGHT" \
-  -f body="**[SEVERITY]** <description>
-
-Suggestion: <how to fix>"
+REVIEW_FILE="/tmp/pr-review-<PR_NUMBER>-comments.json"
 ```
 
-### 7b: Submit formal review with verdict
+Build the JSON programmatically from the deduplicated findings. The structure must be:
+
+```json
+{
+  "commit_id": "<HEAD_SHA>",
+  "event": "<APPROVE or REQUEST_CHANGES>",
+  "body": "<REVIEW_BODY>",
+  "comments": [
+    {
+      "path": "<file>",
+      "line": <line_number>,
+      "side": "RIGHT",
+      "body": "**[SEVERITY]** <description>\n\nSuggestion: <how to fix>"
+    }
+  ]
+}
+```
+
+Each finding becomes one entry in the `comments` array.
 
 **Choose the appropriate verdict based on findings:**
 
@@ -229,11 +308,10 @@ Suggestion: <how to fix>"
 | **Approve**         | No critical or important issues (minor issues OK) | `APPROVE`         |
 | **Request Changes** | Any critical issues, or multiple important issues | `REQUEST_CHANGES` |
 
-```bash
-gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/events \
-  --method POST \
-  -f event="<APPROVE or REQUEST_CHANGES>" \
-  -f body="<!-- CLAUDE_REVIEW_COMPLETE -->
+The `body` field for CI mode must include the CI markers and the guidelines checklist:
+
+```
+<!-- CLAUDE_REVIEW_COMPLETE -->
 <!-- CLAUDE_VERDICT:APPROVE -->  <!-- Only include for approvals -->
 ## Code Review Summary
 
@@ -250,19 +328,31 @@ See inline comments for details.
 ### Guidelines Compliance
 - [ ] Follows TypeScript strict mode
 - [ ] Uses early returns over nested conditionals
-- [ ] \`bigint\` for onchain quantities; WAD-scaled where appropriate
-- [ ] Reuses SDK types (\`Address\`, \`MarketId\`, \`ChainId\`, \`BigIntish\`)
+- [ ] `bigint` for onchain quantities; WAD-scaled where appropriate
+- [ ] Reuses SDK types (`Address`, `MarketId`, `ChainId`, `BigIntish`)
 - [ ] Type-only imports where possible
-- [ ] Relative imports use \`.js\` suffix (NodeNext)
-- [ ] Public APIs explicitly re-exported from \`src/index.ts\`
-- [ ] Domain failures are typed \`Error\` subclasses
-- [ ] Biome clean (\`pnpm lint\`)
+- [ ] Relative imports use `.js` suffix (NodeNext)
+- [ ] Public APIs explicitly re-exported from `src/index.ts`
+- [ ] Domain failures are typed `Error` subclasses
+- [ ] Biome clean (`pnpm lint`)
 
 ### Verdict
 ✅ **Approved** - Code looks good!
 <!-- OR -->
-❌ **Changes Requested** - Please address the issues above."
+❌ **Changes Requested** - Please address the issues above.
 ```
+
+Submit the review and all inline comments in a **single atomic call**:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews \
+  --method POST \
+  --input "$REVIEW_FILE"
+```
+
+This creates the review and all inline comments atomically — no partial reviews if something fails midway.
+
+Clean up: `rm -f "$REVIEW_FILE"`
 
 **Important notes for CI mode:**
 
@@ -270,7 +360,8 @@ See inline comments for details.
 - For approvals, also include `<!-- CLAUDE_VERDICT:APPROVE -->` and use `APPROVE` event
 - Line numbers must match the NEW file in the diff (right side)
 - Use `side: "RIGHT"` for commenting on added/modified lines
-- For multi-line suggestions, use `start_line` and `line` parameters
+- For multi-line suggestions, use `start_line` and `line` parameters in each `comments[]` entry
+- If the review creation fails (e.g., permissions, line numbers out of range), fall back to a single PR comment via `gh api repos/<owner>/<repo>/issues/<PR_NUMBER>/comments`
 
 **After posting, skip to Step 8.** CI mode does not use `--watch`.
 
@@ -280,33 +371,40 @@ See inline comments for details.
 
 **Only follow this step if running locally (NOT in CI).**
 
-### 7a: Create pending review and add inline comments
+### 7a: Build the comments array and submit atomically
+
+Construct a JSON object with all findings. Write it to a PR-specific temp file to avoid collisions with concurrent runs:
 
 ```bash
-# Create a pending review (returns review_id)
-# Note: omit the "event" field entirely to create a pending review — "PENDING" is not a valid event value
-REVIEW_ID=$(gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews \
-  --method POST \
-  -f commit_id="<head_commit_sha>" \
-  --jq '.id')
+REVIEW_FILE="/tmp/pr-review-<PR_NUMBER>-comments.json"
+```
 
-# For each finding, add an inline comment to the pending review
-gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/comments \
-  --method POST \
-  -f path="<file>" \
-  -F line=<line> \
-  -f side="RIGHT" \
-  -f body="**[SEVERITY]** <description>
+Build the JSON programmatically from the deduplicated findings. The structure must be:
 
-Suggestion: <how to fix>"
+```json
+{
+  "commit_id": "<HEAD_SHA>",
+  "event": "COMMENT",
+  "body": "<REVIEW_BODY>",
+  "comments": [
+    {
+      "path": "<file>",
+      "line": <line_number>,
+      "side": "RIGHT",
+      "body": "**[SEVERITY]** <description>\n\nSuggestion: <how to fix>"
+    }
+  ]
+}
+```
 
-# Submit the review as COMMENT (never auto-approve or request changes in local mode)
-gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/events \
-  --method POST \
-  -f event="COMMENT" \
-  -f body="## Parallel PR Review (Claude)
+Each finding becomes one entry in the `comments` array. Always use `"event": "COMMENT"` in local mode — never auto-approve or request changes.
 
-**Reviewed commit:** \`<short_sha>\`
+The `body` field for local mode:
+
+```
+## Parallel PR Review (Claude)
+
+**Reviewed commit:** `<HEAD_SHA_SHORT>`
 
 | Severity | Count |
 |----------|-------|
@@ -315,12 +413,22 @@ gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/$REVIEW_ID/events \
 | 🔵 Medium | X |
 | 🔵 Minor | X |
 
-_This is an automated parallel review. It will re-run when new commits are pushed (if watching)._"
+_This is an automated parallel review. It will re-run when new commits are pushed (if watching)._
 ```
 
-**Important**: If the pending review API is not available, fall back to posting individual inline comments via `gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/comments`.
+Submit the review and all inline comments in a **single atomic call**:
 
-If there are zero findings, still submit with a body saying "No issues found in this review."
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews \
+  --method POST \
+  --input "$REVIEW_FILE"
+```
+
+Clean up: `rm -f "$REVIEW_FILE"`
+
+**Important**: If the atomic review API call fails (e.g., permissions, line numbers out of range), fall back to posting a single PR-level comment with all findings via `gh api repos/<owner>/<repo>/issues/<PR_NUMBER>/comments`.
+
+If there are zero findings, still submit with an empty `comments` array and a body saying "No issues found in this review."
 
 ### 7b: Optional Codex pass
 
@@ -333,7 +441,7 @@ which codex
 If available, run in the background (do not wait for it to finish):
 
 ```bash
-codex exec -c model_reasoning_effort=xhigh "Review PR #<PR_NUMBER> in this repo. The PR branch is <headRefName> based on <baseRefName>. Run 'git diff origin/<baseRefName>...origin/<headRefName>' to get the full diff. Analyze the changes for bugs, security issues, code quality, and best practices. Post your findings as inline review comments on the PR using 'gh api' to create a pull request review with comments on specific lines." 2>&1 | tail -50
+codex exec -c model_reasoning_effort=xhigh "Review PR #<PR_NUMBER> in this repo. The PR branch is <HEAD_BRANCH> based on <BASE_BRANCH>. Run 'git diff origin/<BASE_BRANCH>...origin/<HEAD_BRANCH>' to get the full diff. Analyze the changes for bugs, security issues, code quality, and best practices. Post your findings as inline review comments on the PR using 'gh api' to create a pull request review with comments on specific lines." 2>&1 | tail -50
 ```
 
 If `codex` is not installed or the command fails, log the error and continue — Claude review is sufficient on its own.
@@ -345,11 +453,11 @@ If `codex` is not installed or the command fails, log the error and continue —
 Print a summary:
 
 ```
-PR #<number> review posted:
+PR #<PR_NUMBER> review posted:
   Claude: <N> findings (X critical, Y important, Z medium, W minor)
   Codex:  <triggered in background / not available>
   Mode:   <CI / Local>
-Last reviewed commit: <short_sha>
+Last reviewed commit: <HEAD_SHA_SHORT>
 ```
 
 If `--watch` was NOT passed (or in CI mode), the skill is complete here.
@@ -368,10 +476,10 @@ Use `CronCreate` to schedule a recurring job every 2 minutes:
 
 ```
 You are the PR review watcher for PR #<PR_NUMBER> in <owner>/<repo>.
-Last reviewed commit SHA: <LAST_REVIEWED_SHA>.
 Repo path: <REPO_PATH>
 Head branch: <HEAD_BRANCH>
 Base branch: <BASE_BRANCH>
+Bot login: <BOT_LOGIN>
 
 This is a RECURRING cron job. Each run is one check cycle. After completing a cycle, simply end your response — the cron scheduler will invoke you again in 2 minutes.
 
@@ -383,41 +491,51 @@ CYCLE START:
    Run: gh pr view <PR_NUMBER> --repo <owner>/<repo> --json state --jq '.state'
    If not "OPEN": say "PR #<PR_NUMBER> is no longer open (state: <STATE>). Review watcher done." and end.
 
-2. COMPARE SHA:
-   Compare the current head SHA to the last reviewed SHA (<LAST_REVIEWED_SHA>).
-   If the SHA is the same: say "No new commits on PR #<PR_NUMBER>, still at <short_sha>." and end this cycle.
+2. GET LAST REVIEWED SHA:
+   Query the most recent review posted by the bot on this PR (derived at cycle start from GitHub, NOT baked in at CronCreate time):
+   Run: gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews?per_page=100 --jq '[.[] | select(.user.login == "<BOT_LOGIN>")] | sort_by(.submitted_at) | last | .commit_id'
+   If no review by <BOT_LOGIN> is found, fall back to the most recent review on the PR:
+   Run: gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews?per_page=100 --jq 'sort_by(.submitted_at) | last | .commit_id'
+   If still no previous review is found, treat LAST_REVIEWED_SHA as empty (review everything).
+   Otherwise set LAST_REVIEWED_SHA to the returned commit_id.
 
-3. NEW COMMIT DETECTED:
-   Say "New commit detected on PR #<PR_NUMBER>: <new_sha>. Running full review..."
+3. COMPARE SHA:
+   Compare the current head SHA (from step 1) to LAST_REVIEWED_SHA.
+   If they are the same: say "No new commits on PR #<PR_NUMBER>, still at <HEAD_SHA_SHORT>." and end this cycle.
 
-4. GET FULL PR DIFF:
+4. NEW COMMIT DETECTED:
+   Say "New commit detected on PR #<PR_NUMBER>: <HEAD_SHA>. Running full review..."
+
+5. GET FULL PR DIFF:
    Run: cd <REPO_PATH>
    MERGE_BASE=$(git merge-base origin/<BASE_BRANCH> origin/<HEAD_BRANCH>)
    git diff $MERGE_BASE..origin/<HEAD_BRANCH>
    git diff --name-only $MERGE_BASE..origin/<HEAD_BRANCH>
    Also read each changed file from the local filesystem using the Read tool for full context.
 
-5. READ GUIDELINES:
+6. READ GUIDELINES:
    Read CLAUDE.md and CONTRIBUTING.md for monorepo conventions.
 
-6. LAUNCH REVIEW AGENTS in parallel using the Agent tool (subagent_type: "general-purpose"):
-   a. code-quality — TypeScript strict mode, type safety, early returns, assertions, duplication, naming, code smells
+7. LAUNCH REVIEW AGENTS in parallel using the Agent tool (subagent_type: "general-purpose"):
+   a. code-quality — TypeScript strict mode, type safety, early returns, assertions, duplication, naming, code smells. ALWAYS include cross-file impact (changed exports from packages/<pkg>/src/index.ts, public API signature changes, renamed/removed exports, new deep imports) and security (hardcoded secrets/RPC URLs, injection risks, auth bypass, eval/Function/dynamic import).
    b. module-architecture — package boundaries, public exports from src/index.ts, type-only imports, .js suffix (NodeNext), reuse of SDK types (Address, MarketId, ChainId, BigIntish), bigint for onchain quantities, as const / satisfies for ABIs
    c. web3-security — contract interactions, tx params, wallets, permits, race conditions (CRITICAL)
    d. silent-failure-hunter — swallowed errors, empty catch blocks, missing error boundaries, unhandled rejections
    e. style-conventions — Biome clean (pnpm lint), import ordering, type-only imports, no edits to lib/ output, edits to generated *inputs* (graphql/*.gql), not generated files
+   f. documentation — JSDoc/TSDoc on public APIs in packages/<pkg>/src/index.ts and re-exported files; @param/@returns/@throws coverage; doc accuracy vs. implementation; semantic type names; README updates when public API changes; @example blocks compile.
+   g. test-coverage — missing tests in packages/<pkg>/test/ for new public exports; new branches/error paths/edge cases (zero, MAX_UINT256, negative bigints); modified/removed exports without test updates; onchain code paths with at least one fork/mock test; snapshot/schema tests updated when generated outputs change.
    Each agent receives the full diff AND changed file contents, and returns findings as JSON: [{severity, file, line, description}]
 
-7. Collect and deduplicate all agent findings. Keep highest severity for same file+line.
+8. Collect and deduplicate all agent findings (3-line tolerance). Keep highest severity for same file+line. Sort by file path ASC, line number ASC, severity DESC.
 
-8. POST REVIEW to GitHub:
-   a. Create a pending review (omit event field): gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews --method POST -f commit_id="<new_sha>"
-   b. Add inline comments for each finding (format: "**[SEVERITY]** description")
-   c. Submit the review as COMMENT: gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews/<REVIEW_ID>/events --method POST -f event="COMMENT"
+9. POST REVIEW to GitHub as a single atomic call:
+   Build a JSON file at /tmp/pr-review-<PR_NUMBER>-comments.json with commit_id (=<HEAD_SHA>), event="COMMENT", body (summary table), and comments[] array (one entry per finding with path, line, side="RIGHT", body).
+   Run: gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/reviews --method POST --input /tmp/pr-review-<PR_NUMBER>-comments.json
+   Clean up: rm -f /tmp/pr-review-<PR_NUMBER>-comments.json
 
-9. OPTIONAL CODEX: If `which codex` succeeds, run codex review in background.
+10. OPTIONAL CODEX: If `which codex` succeeds, run codex review in background.
 
-10. Say "Review posted for PR #<PR_NUMBER> commit <new_short_sha>: <N> findings (X critical, Y important, Z medium, W minor)."
+11. Say "Review posted for PR #<PR_NUMBER> commit <HEAD_SHA_SHORT>: <N> findings (X critical, Y important, Z medium, W minor)."
 
 CYCLE END — the cron scheduler will run this again in 2 minutes.
 ```

--- a/.agents/commands/pr-review.md
+++ b/.agents/commands/pr-review.md
@@ -22,26 +22,12 @@ Reviews a GitHub Pull Request using parallel specialized agents, posts findings 
 
 When reviewing, refer to these project docs as needed:
 
-| Document              | Path                                                | Use For                         |
-| --------------------- | --------------------------------------------------- | ------------------------------- |
-| **Project Context**   | `CLAUDE.md`                                         | Tech stack, commands, structure |
-| **Coding Guidelines** | `.agents/guidelines.md`                             | All code changes                |
-| **Chain Integration** | `docs/chains.md`                                    | New chain support PRs           |
-| **Deployment**        | `docs/deployment.md`                                | Build/Docker/CI changes         |
-| **Rewards**           | `apps/vvrm-app/src/contexts/Reward/rewards.md`      | Rewards feature changes         |
-| **Consumer API**      | `apps/vvrm-app/src/services/consumer-api/README.md` | API client changes              |
-
-## Skills Reference
-
-Consult these skills for in-depth best practices:
-
-| Skill                      | Path                                          | Use For                                |
-| -------------------------- | --------------------------------------------- | -------------------------------------- |
-| **React Best Practices**   | `.agents/skills/vercel-react-best-practices/` | Performance, rendering, async patterns |
-| **Composition Patterns**   | `.agents/skills/vercel-composition-patterns/` | Component architecture, props design   |
-| **Web Design Guidelines**  | `.agents/skills/web-design-guidelines/`       | UI/UX review, accessibility            |
-| **Next.js Best Practices** | `.agents/skills/next-best-practices/`         | App Router, RSC, data fetching         |
-| **React Doctor**           | `.agents/skills/react-doctor/`                | Common React issues                    |
+| Document            | Path                  | Use For                                                |
+| ------------------- | --------------------- | ------------------------------------------------------ |
+| **Project Context** | `CLAUDE.md`           | Monorepo conventions, naming, type/import discipline   |
+| **Contributing**    | `CONTRIBUTING.md`     | Dev setup, package layout, release/changesets flow     |
+| **TIB Template**    | `TIB/TIB-template.md` | Format for design docs referenced from PRs             |
+| **Biome config**    | `biome.json`          | Style/lint rules enforced on PRs (`pnpm lint`)         |
 
 > **TWO-PHASE SKILL**: Phase 1 (Steps 1-8) does the initial review. Phase 2 (Step 9) creates a continuous watcher via CronCreate if `--watch` was passed. If `--watch` is used, the skill is NOT complete until Step 9's CronCreate call succeeds and you report the job ID to the user.
 
@@ -108,8 +94,8 @@ Also read the actual changed files from the local filesystem using the Read tool
 
 Before launching review agents, read the key reference documents so you can include relevant criteria in each agent's prompt:
 
-1. Read `.agents/guidelines.md` for coding standards
-2. Read relevant sections of the skills referenced above based on what files changed
+1. Read `CLAUDE.md` and `CONTRIBUTING.md` for monorepo conventions.
+2. Read `biome.json` if style/lint findings are likely relevant to the diff.
 
 ## Step 5: Launch Parallel Review Agents
 
@@ -128,28 +114,29 @@ Focus: TypeScript strict mode, type safety, early returns, `as` assertions, dupl
 
 Prompt must include:
 
-- Type safety issues (any types, type assertions, missing generics)
+- Type safety issues (`any`, unsafe `as` assertions, missing generics)
 - Error handling and edge cases
 - Code smells (duplicated logic, overly complex functions, magic numbers)
 - Early returns preferred over nested conditionals
-- Naming conventions per guidelines (PascalCase for components, camelCase for hooks, etc.)
-- Reference `.agents/guidelines.md` rules
+- Naming conventions per `CLAUDE.md`
+- Reference `CLAUDE.md` and `CONTRIBUTING.md`
 
-### Agent 2: React & Architecture
+### Agent 2: Module & API Architecture
 
-Focus: Component patterns, hooks rules, React Compiler, re-render optimization, Suspense/error boundaries, Next.js App Router patterns.
+Focus: package boundaries, public surface, type/import discipline, NodeNext compatibility.
 
 Prompt must include:
 
-- React best practices (hooks rules, effect dependencies, unnecessary re-renders)
-- Component patterns (prop drilling, component composition, separation of concerns)
-- Performance issues (check for manual memoization — should use React Compiler with `"use memo";` instead)
-- Re-render optimization (derived state, lazy init, functional setState)
-- Avoid boolean prop proliferation (use variants or compound components)
-- Prefer children over render props
-- App Router patterns (server vs client components, data fetching)
-- Client/server boundary violations
-- Reference `.agents/skills/vercel-react-best-practices/` and `.agents/skills/vercel-composition-patterns/`
+- Public exports come from `packages/<pkg>/src/index.ts` only — no deep imports into other packages
+- Relative imports include `.js` suffix (NodeNext) — e.g. `export * from "./market/index.js"`
+- Prefer type-only imports where possible (`import type { Address } from "viem"`)
+- Reuse SDK types for protocol values: `Address`, `MarketId`, `ChainId`, `BigIntish`
+- `bigint` for onchain quantities and WAD-scaled rates (e.g. `92_0000000000000000n`)
+- `as const` and `satisfies` for protocol lists and ABI literals (e.g. `BLUE_OPERATIONS as const`)
+- Domain failures are typed `Error` subclasses with readonly inputs
+- Edits to generated **inputs** (e.g. `graphql/*.gql`), not generated files (e.g. `src/api/sdk.ts`)
+- No edits to build output under `lib/`
+- Reference `CLAUDE.md` and the package's own `package.json` `exports` field
 
 ### Agent 3: Web3 Security
 
@@ -181,18 +168,19 @@ Prompt must include:
 - Silently ignored return values from critical operations
 - Dead code paths that can never execute
 
-### Agent 5: Style & Guidelines Compliance
+### Agent 5: Style & Conventions Compliance
 
-Focus: Tailwind vs Emotion enforcement, import ordering, naming conventions, colocation, guidelines checklist.
+Focus: Biome compliance, import discipline, monorepo conventions.
 
 Prompt must include:
 
-- New components should use Tailwind (not Emotion)
-- No mixing Tailwind and Emotion in the same component
-- UI Kit V6 components for new unopinionated components
-- Import ordering per guidelines
-- Colocation: related code should be together, not in centralized folders
-- Reference `.agents/guidelines.md` and `.agents/skills/web-design-guidelines/`
+- Biome clean: 2-space indentation, organized imports, no unused imports/variables (`pnpm lint`)
+- Type-only imports where possible (`import type { ... }`)
+- Relative imports use `.js` suffix in source files (NodeNext)
+- No edits to generated files (e.g. `src/api/sdk.ts`) — change generated **inputs** instead
+- No edits to build output under `lib/`
+- Reuse of SDK types (`Address`, `MarketId`, `ChainId`, `BigIntish`) over local re-declarations
+- Reference `CLAUDE.md` and `biome.json`
 
 ## Step 6: Aggregate and Deduplicate Findings
 
@@ -262,13 +250,13 @@ See inline comments for details.
 ### Guidelines Compliance
 - [ ] Follows TypeScript strict mode
 - [ ] Uses early returns over nested conditionals
-- [ ] React Compiler (\`\"use memo\";\`) instead of manual memoization
-- [ ] Tailwind for new components (not Emotion)
-- [ ] Proper error handling with logger service
-- [ ] Naming conventions followed
-- [ ] Component composition patterns (no boolean prop proliferation)
-- [ ] Proper async/Suspense boundaries
-- [ ] No unnecessary re-renders
+- [ ] \`bigint\` for onchain quantities; WAD-scaled where appropriate
+- [ ] Reuses SDK types (\`Address\`, \`MarketId\`, \`ChainId\`, \`BigIntish\`)
+- [ ] Type-only imports where possible
+- [ ] Relative imports use \`.js\` suffix (NodeNext)
+- [ ] Public APIs explicitly re-exported from \`src/index.ts\`
+- [ ] Domain failures are typed \`Error\` subclasses
+- [ ] Biome clean (\`pnpm lint\`)
 
 ### Verdict
 ✅ **Approved** - Code looks good!
@@ -410,14 +398,14 @@ CYCLE START:
    Also read each changed file from the local filesystem using the Read tool for full context.
 
 5. READ GUIDELINES:
-   Read .agents/guidelines.md for coding standards.
+   Read CLAUDE.md and CONTRIBUTING.md for monorepo conventions.
 
 6. LAUNCH REVIEW AGENTS in parallel using the Agent tool (subagent_type: "general-purpose"):
    a. code-quality — TypeScript strict mode, type safety, early returns, assertions, duplication, naming, code smells
-   b. react-architecture — component patterns, hooks, React Compiler ("use memo;"), re-render optimization, Next.js App Router
+   b. module-architecture — package boundaries, public exports from src/index.ts, type-only imports, .js suffix (NodeNext), reuse of SDK types (Address, MarketId, ChainId, BigIntish), bigint for onchain quantities, as const / satisfies for ABIs
    c. web3-security — contract interactions, tx params, wallets, permits, race conditions (CRITICAL)
    d. silent-failure-hunter — swallowed errors, empty catch blocks, missing error boundaries, unhandled rejections
-   e. style-guidelines — Tailwind vs Emotion, import ordering, naming conventions, colocation
+   e. style-conventions — Biome clean (pnpm lint), import ordering, type-only imports, no edits to lib/ output, edits to generated *inputs* (graphql/*.gql), not generated files
    Each agent receives the full diff AND changed file contents, and returns findings as JSON: [{severity, file, line, description}]
 
 7. Collect and deduplicate all agent findings. Keep highest severity for same file+line.

--- a/.claude/commands/extract-plan.md
+++ b/.claude/commands/extract-plan.md
@@ -1,0 +1,1 @@
+../../.agents/commands/extract-plan.md

--- a/.claude/commands/pr-fix.md
+++ b/.claude/commands/pr-fix.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-fix.md

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review.md

--- a/.codex/prompts/extract-plan.md
+++ b/.codex/prompts/extract-plan.md
@@ -1,0 +1,1 @@
+../../.agents/commands/extract-plan.md

--- a/.codex/prompts/pr-fix.md
+++ b/.codex/prompts/pr-fix.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-fix.md

--- a/.codex/prompts/pr-review.md
+++ b/.codex/prompts/pr-review.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review.md


### PR DESCRIPTION
## Summary

Adds three slash-commands (`/extract-plan`, `/pr-review`, `/pr-fix`) as canonical files under `.agents/commands/`, with mode-`120000` symlinks under `.claude/commands/` and `.codex/prompts/` so Claude Code and Codex CLI both pick them up from the same source. The three files are then adapted for this SDK monorepo and meaningfully extended with workflow improvements ported from the user's personal `ben-pr-*` skills.

## Commits

1. **Add commands and symlink layout** — `extract-plan` copied from `morpho-apps` repo root; `pr-review` and `pr-fix` from `morpho-apps/apps/vvrm-app/.agents/commands/`. Each canonical file at `.agents/commands/<name>.md`; symlinks `.claude/commands/<name>.md` and `.codex/prompts/<name>.md` → `../../.agents/commands/<name>.md`.

2. **Adapt for the SDK monorepo** —
   - Drop broken slash-command refs (`/create-issue`, `/plan`).
   - Replace the morpho-apps Linear team IDs with an SDK-shaped scope table (`packages/blue-sdk*`, `packages/morpho-sdk`, `packages/*-viem`/`*-wagmi`, repo-wide).
   - Replace `pr-review.md`'s Documentation Reference table (which pointed to `apps/vvrm-app/...` and `docs/chains.md`) with the actual files in this repo: `CLAUDE.md`, `CONTRIBUTING.md`, `TIB/TIB-template.md`, `biome.json`. Drop the Skills Reference table entirely (no `.agents/skills/` here).
   - Rewrite the React/Next.js review agents (Agent 2 and Agent 5) to focus on **module/API architecture** (package boundaries, public exports from `src/index.ts`, type-only imports, `.js`-suffix relative imports for NodeNext, SDK-type reuse, `bigint` discipline, `as const`/`satisfies` for ABIs) and Biome conventions. Update the verdict checklist to match.
   - Replace `pnpm oxlint -c .oxlintrc.json` with `pnpm exec biome check` (per file) / `pnpm lint` (project-wide). Replace `pnpm typecheck:interface` (no such script) with `pnpm lint && pnpm -r --if-present build` (per-package tsc).
   - Bump Co-Author tag from Claude Opus 4.6 → 4.7.

3. **Port `ben-pr-*` workflow improvements** —
   - **`pr-review.md`**: canonical placeholder convention table; `<BOT_LOGIN>` capture; **Cross-file impact + Security** bullet groups in Agent 1 (critical for an SDK where signature changes break consumers silently); new **Agent 6: Documentation Analyzer** (JSDoc/TSDoc on public APIs) and **Agent 7: Test Coverage Analyzer** (missing tests under `packages/<pkg>/test/`); deterministic finding sort + 3-line dedup tolerance; **single atomic** `gh api .../reviews --method POST --input <json-file>` call (replaces 3+-call create-pending/add-comments/submit dance — no orphaned pending reviews on partial failure); watcher derives `<LAST_REVIEWED_SHA>` per cycle from GitHub instead of baking it in at CronCreate time, eliminating duplicate reviews on long-lived PRs.
   - **`pr-fix.md`**: clean-working-tree gate (hard-aborts on dirty tree); `gh pr checkout` instead of `git checkout`/`git pull` (cross-fork-safe); **Triage & Relevance Assessment** (Step 5a-5e) — classify each comment by kind, check code freshness, check whether a later commit already addressed it, gate to actionable-only before applying; **Confidence gate** (Step 6a-6d) — mandatory context-gathering (read full file + imports + `grep -rn` callers + `index.ts`/test for public APIs) and HIGH/MEDIUM/LOW assessment, **skip on LOW**; `comments(first: 50)` instead of `10` (stops truncating long threads); heredoc-built reply bodies via `mktemp` (fixes literal `\n` in posted comments); `bucket == "pending"` polling instead of the non-existent `state != "completed"` (fixes early-exit bug); `<RUN_ID>` regex extraction snippet (was referenced but never derived); confidence gate mirrored in the watcher cron loop.

The Web3 Security agent stays unconditional — every package in this repo is web3, so the `viem`/`wagmi`/`ethers`-import-detection gating from `ben-pr-review` would never trigger here and was deliberately omitted.

## Test plan

- [ ] In Claude Code, run `/extract-plan`, `/pr-review`, `/pr-fix` and confirm prompts load (resolved through the symlink).
- [ ] In Codex CLI, run the same prompts from `.codex/prompts/` and confirm they resolve.
- [ ] `git ls-files --stage` shows mode `100644` for the three `.agents/commands/*.md` and mode `120000` for all six `.claude/commands` and `.codex/prompts` entries.
- [ ] Run `/pr-review` against a real PR in this repo and confirm: 7 agents launch in parallel, atomic POST submits a single review, finding sort and 3-line dedup behave as expected.
- [ ] Run `/pr-fix` on a PR with a mix of actionable + question + praise + stale comments and confirm: triage classifies them correctly, low-confidence fixes are skipped with a reason, no `\n` literal appears in posted reply bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)