### PR TITLE
fix(ci): disable install scripts when installing npm in publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,10 @@ jobs:
       # Trusted publishing requires npm >= 11.5.1, but Node 22.22.2's bundled npm 10.9.7
       # currently fails to self-upgrade directly to npm@latest with MODULE_NOT_FOUND
       # (missing promise-retry). Pin a known-good npm 11 release instead.
-      - run: npm install -g npm@11.11.0
+      # `--ignore-scripts` ensures a compromised npm package cannot execute
+      # arbitrary code inside this release job (which holds id-token:write
+      # and contents:write).
+      - run: npm install -g npm@11.11.0 --ignore-scripts
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Issue (Cantina SDK-103 / MORP2-71)

The publish workflow installs `npm` globally inside a job that holds `id-token: write` + `contents: write`. `npm` is pinned to `11.11.0` (good), but install scripts for the upgrade still run in this privileged context.

## Exploit

A compromise of the `npm` package itself (or any of its transitive install-script-running deps for that exact pinned version) gets arbitrary code execution inside the official release runner, before `changeset/release` publishes. Result: malicious tarball published to `@morpho-org/*` with valid OIDC provenance attesting an official CI release.

## Fix

Add `--ignore-scripts` so a compromised npm package cannot execute install hooks inside the privileged runner.

## Migration of [morpho-sdk#128](https://github.com/morpho-org/morpho-sdk/pull/128)

Same fix as the standalone-repo PR, adapted for `.github/workflows/publish.yml` here (the standalone repo's `release.yml` has been replaced by this workflow). Linear: [SDK-103](https://linear.app/morpho-labs/issue/SDK-103/morp2-71medium-consumer-sdk-release-trusts-a-live-npmlatest-tarball).

cc @Rubilmax

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
