### PR TITLE
fix(simulation-sdk): match reallocatableVaults case-insensitively (SDK-144)

### DIFF
--- a/packages/simulation-sdk/src/SimulationState.ts
+++ b/packages/simulation-sdk/src/SimulationState.ts
@@ -637,7 +637,7 @@ export class SimulationState implements InputSimulationState {
     marketId: MarketId,
     {
       enabled = true,
-      reallocatableVaults = keys(this.vaultMarketConfigs),
+      reallocatableVaults,
       defaultMaxWithdrawalUtilization = DEFAULT_WITHDRAWAL_TARGET_UTILIZATION,
       maxWithdrawalUtilization = {},
       delay = Time.s.from.h(1n),
@@ -645,8 +645,19 @@ export class SimulationState implements InputSimulationState {
   ) {
     if (!enabled) return { withdrawals: [], data: this };
 
-    // Filter the vaults that have the market enabled and configured on the PublicAllocator.
-    reallocatableVaults = reallocatableVaults.filter((vault) => {
+    const configuredVaults = keys(this.vaultMarketConfigs);
+    // EVM addresses are case-insensitive; resolve caller casing back to the stored key.
+    const vaultKeyByLower = new Map<string, Address>(
+      configuredVaults.map((k) => [k.toLowerCase(), k]),
+    );
+
+    reallocatableVaults = Array.from(
+      new Set(
+        (reallocatableVaults ?? configuredVaults)
+          .map((v) => vaultKeyByLower.get(v.toLowerCase()))
+          .filter(isDefined),
+      ),
+    ).filter((vault) => {
       const vaultMarketConfig = this.vaultMarketConfigs[vault]?.[marketId];
 
       return (

--- a/packages/simulation-sdk/src/SimulationState.ts
+++ b/packages/simulation-sdk/src/SimulationState.ts
@@ -651,6 +651,7 @@ export class SimulationState implements InputSimulationState {
       configuredVaults.map((k) => [k.toLowerCase(), k]),
     );
 
+    // Filter the vaults that have the market enabled and configured on the PublicAllocator.
     reallocatableVaults = Array.from(
       new Set(
         (reallocatableVaults ?? configuredVaults)

--- a/packages/simulation-sdk/test/SimulationState.test.ts
+++ b/packages/simulation-sdk/test/SimulationState.test.ts
@@ -465,4 +465,36 @@ describe("SimulationState", () => {
       );
     });
   });
+
+  describe("reallocatableVaults address casing", () => {
+    const targetUtilization = parseEther("1");
+
+    test("should match vaults regardless of caller-provided casing", () => {
+      const expected = dataFixture.getMarketPublicReallocations(marketA1.id, {
+        defaultMaxWithdrawalUtilization: targetUtilization,
+      });
+
+      const lowerCased = dataFixture.getMarketPublicReallocations(marketA1.id, {
+        defaultMaxWithdrawalUtilization: targetUtilization,
+        reallocatableVaults: [
+          vaultA.address.toLowerCase() as typeof vaultA.address,
+          vaultC.address.toLowerCase() as typeof vaultC.address,
+        ],
+      });
+
+      expect(lowerCased.withdrawals).toEqual(expected.withdrawals);
+    });
+
+    test("should ignore unknown vaults instead of throwing", () => {
+      const { withdrawals } = dataFixture.getMarketPublicReallocations(
+        marketA1.id,
+        {
+          defaultMaxWithdrawalUtilization: targetUtilization,
+          reallocatableVaults: [randomAddress()],
+        },
+      );
+
+      expect(withdrawals).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`SimulationState.getMarketPublicReallocations` keyed `reallocatableVaults` lookups directly on caller-provided strings, so the same onchain vault under a different valid hex casing was silently dropped from the candidate set. Resolve incoming addresses back to the stored key casing (and dedupe) before filtering, so an allowlist assembled from a different source (lowercase API vs checksummed registry) still matches the assembled state.

Linear: [SDK-144](https://linear.app/morpho-labs/issue/SDK-144/morp2-29low-case-sensitive-reallocatablevaults-matching-silently)

## Test plan

- [x] `pnpm exec vitest run packages/simulation-sdk/test/SimulationState.test.ts`
- [x] new test: same withdrawals when `reallocatableVaults` is passed lowercased
- [x] new test: unknown addresses are ignored instead of throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
