### PR TITLE
fix(blue-sdk-viem): validate permit domains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@
 - Prefer deleting unclear helpers, constants, exports, or duplicated logic before adding abstractions.
 - Add dependencies only when they directly reduce integrator risk or complexity in the owning package.
 - Codify security-sensitive behavior as tests, especially routing, authorization, chain, and accounting invariants.
+- Add concise JSDoc to every new exported JavaScript class, object, constant, or function; avoid JSDoc on internal locals and test helpers.
 
 ## Continuous Improvement
 

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -9,6 +9,8 @@
 - Keep publish exports in `publishConfig.exports`; mirror `types`, `import`, and `require`.
 - Put host libraries in `peerDependencies`, with local test versions in `devDependencies`.
 - Subpath exports need both package exports and TS path support, e.g. `./vitest`.
+- Declare package-specific errors in one centralized error module for that package.
+- Quote interpolated error parameter values in messages, e.g. `expected "${expected}", got "${actual}"`.
 - Each package should own one responsibility; split framework adapters from protocol/core logic.
 - Framework coupling belongs in explicitly named adapter packages such as `*-wagmi`, never in core SDK packages.
 - Change generated inputs, not generated files; keep generated artifacts out of hand-written design decisions.

--- a/packages/blue-sdk-viem/src/error.ts
+++ b/packages/blue-sdk-viem/src/error.ts
@@ -1,4 +1,30 @@
+import type { Address, ChainId } from "@morpho-org/blue-sdk";
 import { BaseError, ContractFunctionRevertedError } from "viem";
+
+/** Thrown when a permit domain targets another chain; consumers should not sign it. */
+export class InvalidPermitDomainChainIdError extends Error {
+  constructor(
+    public readonly token: Address,
+    public readonly expectedChainId: ChainId,
+    public readonly domainChainId: number | undefined,
+  ) {
+    super(
+      `Invalid permit domain chain ID for token "${token}": expected "${expectedChainId}", got "${domainChainId}"`,
+    );
+  }
+}
+
+/** Thrown when a permit domain targets another token; consumers should not sign it. */
+export class InvalidPermitDomainVerifyingContractError extends Error {
+  constructor(
+    public readonly token: Address,
+    public readonly domainVerifyingContract: Address | undefined,
+  ) {
+    super(
+      `Invalid permit domain verifying contract: expected "${token}", got "${domainVerifyingContract}"`,
+    );
+  }
+}
 
 /**
  * Checks if an error is a contract revert with the "UnknownOfFactory" error name.

--- a/packages/blue-sdk-viem/src/index.ts
+++ b/packages/blue-sdk-viem/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./abis.js";
+export * from "./error.js";
 export * from "./fetch/index.js";
 export * from "./signatures/index.js";
 export * from "./types.js";

--- a/packages/blue-sdk-viem/src/signatures/permit.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit.ts
@@ -4,7 +4,11 @@ import {
   type Token,
   getChainAddresses,
 } from "@morpho-org/blue-sdk";
-import type { TypedDataDefinition } from "viem";
+import { type TypedDataDefinition, isAddressEqual } from "viem";
+import {
+  InvalidPermitDomainChainIdError,
+  InvalidPermitDomainVerifyingContractError,
+} from "../error.js";
 
 export interface PermitArgs {
   erc20: Token;
@@ -27,6 +31,8 @@ const permitTypes = {
 
 /**
  * Permit signature for ERC20 tokens, following EIP-2612.
+ * Fails closed when fetched EIP-5267 metadata is not bound to the token and chain.
+ * Consumers should use another approval path instead of signing an unsafe domain.
  * Docs: https://eips.ethereum.org/EIPS/eip-2612
  */
 export const getPermitTypedData = (
@@ -35,7 +41,29 @@ export const getPermitTypedData = (
 ): TypedDataDefinition<typeof permitTypes, "Permit"> => {
   const { usdc, eurc } = getChainAddresses(chainId);
 
-  const domain = erc20.eip5267Domain?.eip712Domain ?? {
+  const domain = erc20.eip5267Domain?.eip712Domain;
+
+  if (domain != null) {
+    if (domain.chainId !== chainId) {
+      throw new InvalidPermitDomainChainIdError(
+        erc20.address,
+        chainId,
+        domain.chainId,
+      );
+    }
+
+    if (
+      domain.verifyingContract == null ||
+      !isAddressEqual(domain.verifyingContract, erc20.address)
+    ) {
+      throw new InvalidPermitDomainVerifyingContractError(
+        erc20.address,
+        domain.verifyingContract,
+      );
+    }
+  }
+
+  const permitDomain = domain ?? {
     name: erc20.name,
     version: erc20.address === usdc || erc20.address === eurc ? "2" : "1",
     chainId,
@@ -43,7 +71,7 @@ export const getPermitTypedData = (
   };
 
   return {
-    domain,
+    domain: permitDomain,
     types: permitTypes,
     message: {
       owner,

--- a/packages/blue-sdk-viem/test/Permit.test.ts
+++ b/packages/blue-sdk-viem/test/Permit.test.ts
@@ -1,0 +1,122 @@
+import { ChainId, Eip5267Domain, Token } from "@morpho-org/blue-sdk";
+import { randomAddress } from "@morpho-org/test";
+import { zeroHash } from "viem";
+import { describe, expect, test } from "vitest";
+import {
+  InvalidPermitDomainChainIdError,
+  InvalidPermitDomainVerifyingContractError,
+} from "../src/error.js";
+import { getPermitTypedData } from "../src/signatures/permit.js";
+
+const owner = randomAddress();
+
+const spender = randomAddress();
+
+const permitArgs = (token: Token) => ({
+  erc20: token,
+  owner,
+  spender,
+  allowance: 1n,
+  nonce: 0n,
+  deadline: 1n,
+});
+
+const tokenWithDomain = (
+  address = randomAddress(),
+  fields: `0x${string}` = "0x0f",
+  chainId = BigInt(ChainId.EthMainnet),
+  verifyingContract = address,
+) =>
+  new Token({
+    address,
+    name: "Token",
+    eip5267Domain: new Eip5267Domain({
+      fields,
+      name: "Token",
+      version: "1",
+      chainId,
+      verifyingContract,
+      salt: zeroHash,
+      extensions: [],
+    }),
+  });
+
+describe("getPermitTypedData", () => {
+  test("uses fetched EIP-5267 domain when bound to the token and chain", () => {
+    const token = tokenWithDomain();
+
+    const typedData = getPermitTypedData(permitArgs(token), ChainId.EthMainnet);
+
+    expect(typedData.domain).toStrictEqual({
+      name: "Token",
+      version: "1",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token.address,
+    });
+  });
+
+  test("throws when fetched EIP-5267 domain points to another token", () => {
+    const token = tokenWithDomain();
+    const verifyingContract = randomAddress();
+    const tokenWithForeignDomain = tokenWithDomain(
+      token.address,
+      "0x0f",
+      BigInt(ChainId.EthMainnet),
+      verifyingContract,
+    );
+
+    expect(() =>
+      getPermitTypedData(
+        permitArgs(tokenWithForeignDomain),
+        ChainId.EthMainnet,
+      ),
+    ).toThrow(
+      new InvalidPermitDomainVerifyingContractError(
+        token.address,
+        verifyingContract,
+      ),
+    );
+  });
+
+  test("throws when fetched EIP-5267 domain points to another chain", () => {
+    const token = tokenWithDomain(
+      randomAddress(),
+      "0x0f",
+      BigInt(ChainId.PolygonMainnet),
+    );
+
+    expect(() =>
+      getPermitTypedData(permitArgs(token), ChainId.EthMainnet),
+    ).toThrow(
+      new InvalidPermitDomainChainIdError(
+        token.address,
+        ChainId.EthMainnet,
+        ChainId.PolygonMainnet,
+      ),
+    );
+  });
+
+  test("throws when fetched EIP-5267 domain does not bind to a token address", () => {
+    const token = tokenWithDomain(randomAddress(), "0x07");
+
+    expect(() =>
+      getPermitTypedData(permitArgs(token), ChainId.EthMainnet),
+    ).toThrow(
+      new InvalidPermitDomainVerifyingContractError(token.address, undefined),
+    );
+  });
+
+  test("throws when fetched EIP-5267 domain does not bind to a chain", () => {
+    const token = tokenWithDomain(randomAddress(), "0x0b");
+
+    expect(() =>
+      getPermitTypedData(permitArgs(token), ChainId.EthMainnet),
+    ).toThrow(
+      new InvalidPermitDomainChainIdError(
+        token.address,
+        ChainId.EthMainnet,
+        undefined,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds fail-closed validation when EIP-5267 metadata is consumed for ERC-2612 permit typed data. If a fetched domain is present but does not bind to the requested token address or chain, `getPermitTypedData` now throws a dedicated error instead of allowing consumers to sign a mismatched domain.

Also centralizes the new blue-sdk-viem errors, exports them from the package entrypoint, adds focused tests for domain mismatch cases, and records package/monorepo conventions for centralized errors, quoted error parameters, and exported-symbol JSDoc.

## Root Cause

`fetchToken` correctly reads onchain metadata without validation, but the permit signing boundary previously trusted the fetched EIP-5267 domain wholesale. That let a token-provided domain override the safe address/chain fallback at the point of consumption.

## Linked Issue

Fixes [SDK-117](https://linear.app/morpho-labs/issue/SDK-117/morp2-67low-unvalidated-eip-5267-verifyingcontract-lets-token-fetch)

## Validation

- `pnpm exec vitest run --project blue-sdk-viem packages/blue-sdk-viem/test/Permit.test.ts`
- `pnpm lint`
- `pnpm --filter @morpho-org/blue-sdk-viem build`
- `pnpm exec tsc --noEmit -p packages/morpho-sdk/tsconfig.json`