### PR TITLE
fix(permit): drop EIP-5267 domain when chainId mismatches active chain

### DIFF
--- a/packages/blue-sdk-viem/src/signatures/permit.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit.ts
@@ -35,12 +35,17 @@ export const getPermitTypedData = (
 ): TypedDataDefinition<typeof permitTypes, "Permit"> => {
   const { usdc, eurc } = getChainAddresses(chainId);
 
-  const domain = erc20.eip5267Domain?.eip712Domain ?? {
-    name: erc20.name,
-    version: erc20.address === usdc || erc20.address === eurc ? "2" : "1",
-    chainId,
-    verifyingContract: erc20.address,
-  };
+  // EIP-5267: ignore foreign-chain domains (https://eips.ethereum.org/EIPS/eip-5267#security-considerations).
+  const eip712Domain = erc20.eip5267Domain?.eip712Domain;
+  const domain =
+    eip712Domain?.chainId === chainId
+      ? eip712Domain
+      : {
+          name: erc20.name,
+          version: erc20.address === usdc || erc20.address === eurc ? "2" : "1",
+          chainId,
+          verifyingContract: erc20.address,
+        };
 
   return {
     domain,

--- a/packages/blue-sdk-viem/test/permit.test.ts
+++ b/packages/blue-sdk-viem/test/permit.test.ts
@@ -1,0 +1,100 @@
+import {
+  ChainId,
+  Eip5267Domain,
+  Token,
+  addressesRegistry,
+} from "@morpho-org/blue-sdk";
+import { type Address, zeroHash } from "viem";
+import { describe, expect, it } from "vitest";
+import { getPermitTypedData } from "../src/signatures/permit.js";
+
+const { usdc } = addressesRegistry[ChainId.EthMainnet];
+const owner = "0x0000000000000000000000000000000000000001" as Address;
+const spender = "0x0000000000000000000000000000000000000002" as Address;
+const baseArgs = {
+  owner,
+  spender,
+  allowance: 1n,
+  nonce: 0n,
+  deadline: 0n,
+};
+
+describe("getPermitTypedData", () => {
+  it("ignores EIP-5267 domain when chainId mismatches active chain", () => {
+    const erc20 = new Token({
+      address: usdc,
+      decimals: 6,
+      symbol: "USDC",
+      name: "USD Coin",
+      eip5267Domain: new Eip5267Domain({
+        fields: "0x0f",
+        name: "USD Coin",
+        version: "2",
+        chainId: BigInt(ChainId.BaseMainnet),
+        verifyingContract: usdc,
+        salt: zeroHash,
+        extensions: [],
+      }),
+    });
+
+    const { domain } = getPermitTypedData(
+      { ...baseArgs, erc20 },
+      ChainId.EthMainnet,
+    );
+
+    expect(domain?.chainId).toBe(ChainId.EthMainnet);
+    expect(domain?.verifyingContract).toBe(usdc);
+  });
+
+  it("uses EIP-5267 domain when chainId matches active chain", () => {
+    const erc20 = new Token({
+      address: usdc,
+      decimals: 6,
+      symbol: "USDC",
+      name: "USD Coin",
+      eip5267Domain: new Eip5267Domain({
+        fields: "0x0f",
+        name: "USD Coin",
+        version: "2",
+        chainId: BigInt(ChainId.EthMainnet),
+        verifyingContract: usdc,
+        salt: zeroHash,
+        extensions: [],
+      }),
+    });
+
+    const { domain } = getPermitTypedData(
+      { ...baseArgs, erc20 },
+      ChainId.EthMainnet,
+    );
+
+    expect(domain?.chainId).toBe(ChainId.EthMainnet);
+    expect(domain?.name).toBe("USD Coin");
+    expect(domain?.version).toBe("2");
+  });
+
+  it("ignores EIP-5267 domain when chainId field is absent", () => {
+    const erc20 = new Token({
+      address: usdc,
+      decimals: 6,
+      symbol: "USDC",
+      name: "USD Coin",
+      eip5267Domain: new Eip5267Domain({
+        fields: "0x0b",
+        name: "USD Coin",
+        version: "2",
+        chainId: 0n,
+        verifyingContract: usdc,
+        salt: zeroHash,
+        extensions: [],
+      }),
+    });
+
+    const { domain } = getPermitTypedData(
+      { ...baseArgs, erc20 },
+      ChainId.EthMainnet,
+    );
+
+    expect(domain?.chainId).toBe(ChainId.EthMainnet);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves [SDK-125 / MORP2-54](https://linear.app/morpho-labs/issue/SDK-125/morp2-54low-unvalidated-eip-5267-chainid-lets-token-fetch-request).

A malicious token can return an EIP-5267 domain whose `chainId` points at a foreign chain. `getPermitTypedData` previously trusted that domain unconditionally, so the SDK could request a permit signature scoped to chain B while the user transacts on chain A. If the same token is mirrored at the same address on chain B, the signature is replayable there.

[EIP-5267](https://eips.ethereum.org/EIPS/eip-5267#security-considerations) explicitly tells user agents to validate the reported `chainId` against the active chain before signing.

## Fix

- `getPermitTypedData` now ignores the EIP-5267 domain when its `chainId` is absent or does not match the active chain, and falls back to the SDK-derived domain.
- Added unit tests covering the foreign-chainId, missing-chainId, and matching-chainId cases.

## Test plan

- [x] `pnpm test run --project blue-sdk-viem packages/blue-sdk-viem/test/permit.test.ts`
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
