### PR TITLE
fix(reallocations): avoid redundant vault fee on interleaved flat sequence (SDK-123)

### DIFF
--- a/packages/bundler-sdk-viem/src/operations.ts
+++ b/packages/bundler-sdk-viem/src/operations.ts
@@ -398,7 +398,26 @@ export const populateSubBundle = (
         );
       }
 
-      for (const { vault, ...withdrawal } of withdrawals) {
+      // Public allocator fees are charged per vault call, so finalizing a new
+      // vault before scanning the rest of the flat sequence can charge an
+      // avoidable extra fee when an already-selected vault reappears later
+      // with enough remaining liquidity to cover the residual shortfall.
+      for (let i = 0; i < withdrawals.length; i++) {
+        if (requiredAssets === 0n) break;
+
+        const { vault, ...withdrawal } = withdrawals[i]!;
+
+        if (!(vault in reallocations)) {
+          let availableFromSelected = 0n;
+          for (let j = i + 1; j < withdrawals.length; j++) {
+            if (withdrawals[j]!.vault in reallocations) {
+              availableFromSelected += withdrawals[j]!.assets;
+              if (availableFromSelected >= requiredAssets) break;
+            }
+          }
+          if (availableFromSelected >= requiredAssets) continue;
+        }
+
         const vaultReallocations = (reallocations[vault] ??= []);
         const vaultMarketReallocation = vaultReallocations.find(
           (item) => item.id === withdrawal.id,
@@ -418,8 +437,6 @@ export const populateSubBundle = (
           });
 
         requiredAssets -= reallocatedAssets;
-
-        if (requiredAssets === 0n) break;
       }
 
       // TODO: we know there are no unwrap native in the middle

--- a/packages/morpho-sdk/src/helpers/computeReallocations.test.ts
+++ b/packages/morpho-sdk/src/helpers/computeReallocations.test.ts
@@ -434,6 +434,57 @@ describe("computeReallocations", () => {
       expect(result[0]!.withdrawals[0]!.amount).toBe(200n * MathLib.WAD);
     });
 
+    test("should not introduce a new vault when a later same-vault withdrawal can cover the residual (SDK-123)", () => {
+      // Phase 2 produces an interleaved flat sequence [A:150, B:60, A:50] with
+      // requiredAssets = 200. A naive greedy capping commits A:150, then B:50,
+      // and exits before reaching the later A:50 — paying a redundant vault
+      // fee on B even though A alone (150 + 50) covers the shortfall.
+      const tm = makeMarket(targetParams, {
+        totalSupplyAssets: 800n * MathLib.WAD,
+        totalBorrowAssets: 500n * MathLib.WAD,
+      });
+      const borrowAmount = 500n * MathLib.WAD;
+
+      // friendlyTargetMarket: enough supply post-reallocation → phase 2 not triggered.
+      const friendlyTargetMarket = makeMarket(targetParams, {
+        totalSupplyAssets: 1500n * MathLib.WAD,
+        totalBorrowAssets: 500n * MathLib.WAD,
+      });
+
+      const data = makeMockState({
+        targetMarket: tm,
+        friendlyWithdrawals: [
+          { id: sourceA.id, vault: VAULT_A, assets: 150n * MathLib.WAD },
+          { id: sourceB.id, vault: VAULT_B, assets: 60n * MathLib.WAD },
+          { id: sourceC.id, vault: VAULT_A, assets: 50n * MathLib.WAD },
+        ],
+        friendlyTargetMarket,
+        vaultFees: { [VAULT_A]: 1000n, [VAULT_B]: 2000n },
+      });
+
+      const result = computeReallocations({
+        reallocationData: data,
+        marketId: targetParams.id,
+        borrowAmount,
+        // 100% target → requiredAssets = newBorrow - newSupply = 1000 - 800 = 200 WAD.
+        options: {
+          enabled: true,
+          supplyTargetUtilization: { [targetParams.id]: MathLib.WAD },
+        },
+      });
+
+      // Only VAULT_A should be touched — VAULT_B is unnecessary.
+      expect(result).toHaveLength(1);
+      expect(result[0]!.vault).toBe(VAULT_A);
+      expect(result[0]!.withdrawals).toHaveLength(2);
+
+      const totalAmount = result[0]!.withdrawals.reduce(
+        (sum, w) => sum + w.amount,
+        0n,
+      );
+      expect(totalAmount).toBe(200n * MathLib.WAD);
+    });
+
     test("should cap second withdrawal mid-iteration when requiredAssets is exhausted", () => {
       const borrowAmount = 500n * MathLib.WAD;
 

--- a/packages/morpho-sdk/src/helpers/computeReallocations.ts
+++ b/packages/morpho-sdk/src/helpers/computeReallocations.ts
@@ -91,7 +91,26 @@ export const computeReallocations = ({
   const reallocationsMap: Record<Address, { id: MarketId; assets: bigint }[]> =
     {};
 
-  for (const { vault, ...withdrawal } of withdrawals) {
+  // Public allocator fees are charged per vault call, so finalizing a new
+  // vault before scanning the rest of the flat sequence can charge an
+  // avoidable extra fee when an already-selected vault reappears later with
+  // enough remaining liquidity to cover the residual shortfall.
+  for (let i = 0; i < withdrawals.length; i++) {
+    if (requiredAssets === 0n) break;
+
+    const { vault, ...withdrawal } = withdrawals[i]!;
+
+    if (!(vault in reallocationsMap)) {
+      let availableFromSelected = 0n;
+      for (let j = i + 1; j < withdrawals.length; j++) {
+        if (withdrawals[j]!.vault in reallocationsMap) {
+          availableFromSelected += withdrawals[j]!.assets;
+          if (availableFromSelected >= requiredAssets) break;
+        }
+      }
+      if (availableFromSelected >= requiredAssets) continue;
+    }
+
     const vaultReallocations = (reallocationsMap[vault] ??= []);
     const existing = vaultReallocations.find(
       (item) => item.id === withdrawal.id,
@@ -110,7 +129,6 @@ export const computeReallocations = ({
     }
 
     requiredAssets -= reallocatedAssets;
-    if (requiredAssets === 0n) break;
   }
 
   // Transform into VaultReallocation[] format.


### PR DESCRIPTION
## Summary

- `getMarketPublicReallocations` produces a flat per-market withdrawal sequence. Both the bundler planner (`bundler-sdk-viem/src/operations.ts`) and the consumer-side `computeReallocations` helper (`morpho-sdk/src/helpers/computeReallocations.ts`) then group by vault on the fly inside a greedy capping loop that exits as soon as `requiredAssets` reaches zero.
- When the flat sequence is interleaved (e.g. `[A:150, B:60, A:50]` with `requiredAssets=200`), the loop commits to vault B before ever reaching the later vault-A entry — even though A alone (150 + 50) covered the shortfall. Public allocator fees are charged per vault call, so this paid an avoidable extra fee.
- Fix: before introducing a new vault, scan ahead for already-selected vaults that can cover the residual; if so, skip the new-vault entry. This preserves the existing greedy market ordering and only opts out of redundant new-vault commits.

Linear: [SDK-123](https://linear.app/morpho-labs/issue/SDK-123)

## Test plan

- [x] Added a regression unit test in `computeReallocations.test.ts` exercising the interleaved `[A, B, A]` sequence — asserts only `VAULT_A` appears in the output and the total taken equals `requiredAssets`.
- [x] Existing `computeReallocations` unit tests still pass (14/14).
- [ ] Manually validated against an interleaved real-world scenario via the bundler fork tests (requires `MAINNET_RPC_URL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)