### PR TITLE
test(morpho-ts): phase 1 — colocated unit tests, raise coverage to 96%

### DIFF
--- a/packages/morpho-ts/src/format/array.test.ts
+++ b/packages/morpho-ts/src/format/array.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { formatEnumeration, formatUnion } from "./array.js";
+
+describe("formatUnion", () => {
+  test("returns empty string for empty list", () => {
+    expect(formatUnion([])).toBe("");
+  });
+
+  test("returns the single element for one-item list", () => {
+    expect(formatUnion(["a"])).toBe("a");
+  });
+
+  test("joins two items with ' or '", () => {
+    expect(formatUnion(["a", "b"])).toBe("a or b");
+  });
+
+  test("joins three items with commas and ' or ' before the last", () => {
+    expect(formatUnion(["a", "b", "c"])).toBe("a, b or c");
+  });
+
+  test("joins four items", () => {
+    expect(formatUnion(["a", "b", "c", "d"])).toBe("a, b, c or d");
+  });
+
+  test("preserves whitespace inside items", () => {
+    expect(formatUnion(["foo bar", "baz"])).toBe("foo bar or baz");
+  });
+
+  test("preserves empty-string items as-is", () => {
+    expect(formatUnion(["", ""])).toBe(" or ");
+  });
+
+  test("does not mutate the input array", () => {
+    const items = ["x", "y", "z"];
+    const copy = [...items];
+    formatUnion(items);
+    expect(items).toEqual(copy);
+  });
+});
+
+describe("formatEnumeration", () => {
+  test("returns empty string for empty list", () => {
+    expect(formatEnumeration([])).toBe("");
+  });
+
+  test("returns the single element for one-item list", () => {
+    expect(formatEnumeration(["a"])).toBe("a");
+  });
+
+  test("joins two items with ' and '", () => {
+    expect(formatEnumeration(["a", "b"])).toBe("a and b");
+  });
+
+  test("joins three items with commas and ' and ' before the last", () => {
+    expect(formatEnumeration(["a", "b", "c"])).toBe("a, b and c");
+  });
+
+  test("joins four items", () => {
+    expect(formatEnumeration(["a", "b", "c", "d"])).toBe("a, b, c and d");
+  });
+
+  test("does not mutate the input array", () => {
+    const items = ["x", "y", "z"];
+    const copy = [...items];
+    formatEnumeration(items);
+    expect(items).toEqual(copy);
+  });
+});

--- a/packages/morpho-ts/src/format/locale.test.ts
+++ b/packages/morpho-ts/src/format/locale.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  convertNumStrFromEffectiveTo,
+  convertNumStrToLocal,
+  getEffectiveLocale,
+  getEnUSNumberToLocalParts,
+  getLocaleSymbols,
+} from "./locale.js";
+
+describe("getLocaleSymbols", () => {
+  test("returns en-US symbols", () => {
+    const r = getLocaleSymbols("en-US");
+    expect(r.decimalSymbol).toBe(".");
+    expect(r.groupSymbol).toBe(",");
+    expect(r.locale).toBe("en-US");
+  });
+
+  test("returns fr-FR symbols (decimal=',' and a non-breaking space group)", () => {
+    const r = getLocaleSymbols("fr-FR");
+    expect(r.decimalSymbol).toBe(",");
+    // Group symbol in fr-FR is a NBSP/narrow NBSP — assert it is NOT "," or "."
+    expect(r.groupSymbol).not.toBe(",");
+    expect(r.groupSymbol).not.toBe(".");
+    expect(r.locale).toBe("fr-FR");
+  });
+
+  test("returns de-DE symbols (decimal=',' group='.')", () => {
+    const r = getLocaleSymbols("de-DE");
+    expect(r.decimalSymbol).toBe(",");
+    expect(r.groupSymbol).toBe(".");
+    expect(r.locale).toBe("de-DE");
+  });
+
+  test("falls back to en-US when locale is invalid", () => {
+    // The function still echoes back the input locale string but uses en-US formatter on RangeError
+    const r = getLocaleSymbols("not-a-real-locale");
+    // The decimal/group come from the en-US fallback
+    expect(r.decimalSymbol).toBe(".");
+    expect(r.groupSymbol).toBe(",");
+    // Locale string is echoed back as-is
+    expect(r.locale).toBe("not-a-real-locale");
+  });
+});
+
+describe("getEffectiveLocale", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("returns en-US when window is undefined (Node)", () => {
+    expect(typeof globalThis.window).toBe("undefined");
+    expect(getEffectiveLocale()).toBe("en-US");
+  });
+
+  test("returns navigator.language when window is defined and language is valid", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { language: "fr-FR" });
+    vi.stubGlobal("document", { documentElement: { lang: "" } });
+    expect(getEffectiveLocale()).toBe("fr-FR");
+  });
+
+  test("falls back to document.documentElement.lang when navigator.language is empty", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { language: "" });
+    vi.stubGlobal("document", { documentElement: { lang: "de-DE" } });
+    expect(getEffectiveLocale()).toBe("de-DE");
+  });
+
+  test("falls back to en-US when both navigator.language and document.lang are missing", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { language: "" });
+    vi.stubGlobal("document", { documentElement: { lang: "" } });
+    expect(getEffectiveLocale()).toBe("en-US");
+  });
+
+  test("falls back to en-US when locale is invalid", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { language: "not-a-real-locale-bad!" });
+    vi.stubGlobal("document", { documentElement: { lang: "" } });
+    expect(getEffectiveLocale()).toBe("en-US");
+  });
+});
+
+describe("convertNumStrToLocal", () => {
+  test("returns input unchanged when from and to locales share symbols (en-US)", () => {
+    expect(convertNumStrToLocal("1,234.56", "en-US", "en-US")).toBe("1,234.56");
+  });
+
+  test("converts en-US to de-DE (swaps , and .)", () => {
+    expect(convertNumStrToLocal("1,234.56", "en-US", "de-DE")).toBe("1.234,56");
+  });
+
+  test("converts de-DE back to en-US (round trip)", () => {
+    const enToDe = convertNumStrToLocal("1,234.56", "en-US", "de-DE");
+    expect(convertNumStrToLocal(enToDe, "de-DE", "en-US")).toBe("1,234.56");
+  });
+
+  test("handles values with multiple group separators", () => {
+    expect(convertNumStrToLocal("1,234,567.89", "en-US", "de-DE")).toBe(
+      "1.234.567,89",
+    );
+  });
+
+  test("handles negative numbers", () => {
+    expect(convertNumStrToLocal("-1,234.56", "en-US", "de-DE")).toBe(
+      "-1.234,56",
+    );
+  });
+
+  test("handles zero", () => {
+    expect(convertNumStrToLocal("0", "en-US", "de-DE")).toBe("0");
+  });
+});
+
+describe("convertNumStrFromEffectiveTo", () => {
+  test("uses en-US as the from locale in Node", () => {
+    expect(convertNumStrFromEffectiveTo("1,234.56", "de-DE")).toBe("1.234,56");
+  });
+});
+
+describe("getEnUSNumberToLocalParts", () => {
+  test("formats to en-US when locale='en-US'", () => {
+    const r = getEnUSNumberToLocalParts("1,234.56", "en-US");
+    expect(r.value).toBe("1,234.56");
+    expect(r.decimalSymbol).toBe(".");
+    expect(r.groupSymbol).toBe(",");
+    expect(r.locale).toBe("en-US");
+  });
+
+  test("formats to de-DE", () => {
+    const r = getEnUSNumberToLocalParts("1,234.56", "de-DE");
+    expect(r.value).toBe("1.234,56");
+    expect(r.decimalSymbol).toBe(",");
+    expect(r.groupSymbol).toBe(".");
+    expect(r.locale).toBe("de-DE");
+  });
+
+  test("falls back to effective locale (en-US in Node) when locale arg omitted", () => {
+    const r = getEnUSNumberToLocalParts("1,234.56");
+    expect(r.value).toBe("1,234.56");
+    expect(r.locale).toBe("en-US");
+  });
+
+  test("handles whole numbers", () => {
+    const r = getEnUSNumberToLocalParts("1,000", "de-DE");
+    expect(r.value).toBe("1.000");
+  });
+
+  test("handles fractional values without group separator", () => {
+    const r = getEnUSNumberToLocalParts("0.5", "de-DE");
+    expect(r.value).toBe("0,5");
+  });
+});

--- a/packages/morpho-ts/src/format/string.test.ts
+++ b/packages/morpho-ts/src/format/string.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { formatLongString } from "./string.js";
+
+describe("formatLongString", () => {
+  test("returns the input unchanged when maxLength is undefined", () => {
+    expect(formatLongString("hello world")).toBe("hello world");
+  });
+
+  test("returns the input unchanged when maxLength >= input length", () => {
+    expect(formatLongString("hello", 5)).toBe("hello");
+    expect(formatLongString("hello", 10)).toBe("hello");
+  });
+
+  test("returns '...' when maxLength <= 3", () => {
+    expect(formatLongString("anything", 0)).toBe("...");
+    expect(formatLongString("anything", 1)).toBe("...");
+    expect(formatLongString("anything", 2)).toBe("...");
+    expect(formatLongString("anything", 3)).toBe("...");
+  });
+
+  test("returns first char + '...' when maxLength === 4 (nChar === 1)", () => {
+    expect(formatLongString("anything", 4)).toBe("a...");
+    expect(formatLongString("morpho.org", 4)).toBe("m...");
+  });
+
+  test("splits and inserts '...' for longer maxLengths", () => {
+    // maxLength=7 → nChar=4 → first 2 chars + "..." + last 2 chars
+    expect(formatLongString("morpho.org", 7)).toBe("mo...rg");
+  });
+
+  test("works with maxLength=5 (nChar=2)", () => {
+    // nChar=2 → first 1 char + "..." + last 1 char
+    expect(formatLongString("morpho.org", 5)).toBe("m...g");
+  });
+
+  test("rounds nChar/2 when nChar is odd (maxLength=6)", () => {
+    // nChar=3 → Math.round(3/2)=2 first chars + "..." + last 1.5 → "rg".slice(-1) = "g"
+    const result = formatLongString("morpho.org", 6);
+    expect(result.startsWith("mo...")).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(6 + 3);
+  });
+
+  test("handles empty string", () => {
+    expect(formatLongString("", 5)).toBe("");
+    expect(formatLongString("", 0)).toBe("");
+  });
+
+  test("handles single character", () => {
+    expect(formatLongString("a", 5)).toBe("a");
+    expect(formatLongString("a", 1)).toBe("a");
+  });
+
+  test("does not mutate the input", () => {
+    const input = "hello";
+    formatLongString(input, 4);
+    expect(input).toBe("hello");
+  });
+});

--- a/packages/morpho-ts/src/time/time.test.ts
+++ b/packages/morpho-ts/src/time/time.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "vitest";
+import { Time } from "./time.js";
+
+describe("Time — unit conversion matrix", () => {
+  describe("from larger to smaller (multiplication)", () => {
+    test("s ↔ ms", () => {
+      expect(Time.ms.from.s(1)).toBe(1000);
+      expect(Time.ms.from.s(1n)).toBe(1000n);
+    });
+    test("min ↔ s, ms", () => {
+      expect(Time.s.from.min(1)).toBe(60);
+      expect(Time.ms.from.min(1)).toBe(60_000);
+    });
+    test("h ↔ min, s, ms", () => {
+      expect(Time.min.from.h(1)).toBe(60);
+      expect(Time.s.from.h(1)).toBe(3_600);
+      expect(Time.ms.from.h(1)).toBe(3_600_000);
+    });
+    test("d ↔ h, min, s, ms", () => {
+      expect(Time.h.from.d(1)).toBe(24);
+      expect(Time.min.from.d(1)).toBe(1_440);
+      expect(Time.s.from.d(1)).toBe(86_400);
+      expect(Time.ms.from.d(1)).toBe(86_400_000);
+    });
+    test("w → d (7 days/week)", () => {
+      expect(Time.d.from.w(1)).toBe(7);
+      expect(Time.d.from.w(2)).toBe(14);
+    });
+    test("mo → d (31 days/month)", () => {
+      expect(Time.d.from.mo(1)).toBe(31);
+    });
+    test("y → d (365 days/year)", () => {
+      expect(Time.d.from.y(1)).toBe(365);
+    });
+  });
+
+  describe("from smaller to larger (integer division)", () => {
+    test("ms → s truncates remainder (bigint)", () => {
+      expect(Time.s.from.ms(1999n)).toBe(1n);
+      expect(Time.s.from.ms(2000n)).toBe(2n);
+    });
+    test("ms → s preserves number type for number input", () => {
+      // Passing a number returns a number (not bigint).
+      const r = Time.s.from.ms(2000);
+      expect(typeof r).toBe("number");
+      expect(r).toBe(2);
+    });
+    test("s → min truncates remainder", () => {
+      expect(Time.min.from.s(59n)).toBe(0n);
+      expect(Time.min.from.s(120n)).toBe(2n);
+    });
+    test("d → y", () => {
+      expect(Time.y.from.d(364n)).toBe(0n);
+      expect(Time.y.from.d(365n)).toBe(1n);
+      expect(Time.y.from.d(730n)).toBe(2n);
+    });
+  });
+
+  describe("identity (same unit)", () => {
+    test("returns the input value verbatim for both number and bigint", () => {
+      expect(Time.s.from.s(42n)).toBe(42n);
+      expect(Time.s.from.s(42)).toBe(42);
+      expect(Time.h.from.h(7)).toBe(7);
+    });
+  });
+
+  describe("number/bigint type preservation", () => {
+    test("bigint input → bigint output (multiplication)", () => {
+      const r = Time.ms.from.s(5n);
+      expect(typeof r).toBe("bigint");
+      expect(r).toBe(5_000n);
+    });
+    test("number input → number output (multiplication)", () => {
+      const r = Time.ms.from.s(5);
+      expect(typeof r).toBe("number");
+      expect(r).toBe(5_000);
+    });
+    test("bigint input → bigint output (division)", () => {
+      const r = Time.s.from.ms(5_000n);
+      expect(typeof r).toBe("bigint");
+      expect(r).toBe(5n);
+    });
+    test("number input → number output (division)", () => {
+      const r = Time.s.from.ms(5_000);
+      expect(typeof r).toBe("number");
+      expect(r).toBe(5);
+    });
+  });
+
+  describe("large values", () => {
+    test("year → ms produces the expected millisecond count", () => {
+      expect(Time.ms.from.y(1n)).toBe(31_536_000_000n);
+    });
+    test("survives extremely large bigints without precision loss", () => {
+      expect(Time.s.from.y(10_000_000_000n)).toBe(
+        10_000_000_000n * 365n * 24n * 60n * 60n,
+      );
+    });
+  });
+});
+
+describe("Time.fromPeriod", () => {
+  test("converts a single-unit period (string form) using duration=1", () => {
+    expect(Time.ms.fromPeriod("s")).toBe(1000);
+    expect(Time.s.fromPeriod("min")).toBe(60);
+  });
+
+  test("converts a Period object with custom duration", () => {
+    expect(Time.ms.fromPeriod({ unit: "s", duration: 123 })).toBe(123_000);
+  });
+
+  test("rounds down when converting to a coarser unit", () => {
+    expect(Time.min.fromPeriod({ unit: "s", duration: 123 })).toBe(2);
+  });
+
+  test("identity period (same unit) returns the duration verbatim", () => {
+    expect(Time.s.fromPeriod({ unit: "s", duration: 42 })).toBe(42);
+  });
+
+  test("returns 0 when the duration is smaller than one of the target unit", () => {
+    expect(Time.h.fromPeriod({ unit: "s", duration: 30 })).toBe(0);
+  });
+});
+
+describe("Time.toPeriod", () => {
+  test("expands a unit string to a duration=1 period", () => {
+    expect(Time.toPeriod("s")).toEqual({ unit: "s", duration: 1 });
+    expect(Time.toPeriod("y")).toEqual({ unit: "y", duration: 1 });
+  });
+
+  test("returns the period object unchanged when given an object", () => {
+    const period = { unit: "min" as const, duration: 30 };
+    expect(Time.toPeriod(period)).toBe(period);
+  });
+});
+
+describe("Time.wait", () => {
+  test("resolves after the specified ms delay", async () => {
+    const start = Date.now();
+    await Time.wait(50);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40);
+  });
+
+  test("resolves with the provided value", async () => {
+    expect(await Time.wait(0, "done")).toBe("done");
+  });
+
+  test("resolves with undefined when no value provided", async () => {
+    expect(await Time.wait(0)).toBe(undefined);
+  });
+});
+
+describe("Time.timestamp", () => {
+  test("returns a bigint approximating Date.now()/1000", () => {
+    const ts = Time.timestamp();
+    expect(typeof ts).toBe("bigint");
+    const now = BigInt(Math.ceil(Date.now() / 1_000));
+    // Allow a few seconds of drift.
+    expect(ts >= now - 2n && ts <= now + 2n).toBe(true);
+  });
+
+  test("matches Math.ceil(Date.now()/1000)", () => {
+    const before = Math.ceil(Date.now() / 1_000);
+    const ts = Time.timestamp();
+    const after = Math.ceil(Date.now() / 1_000);
+    expect(ts).toBeGreaterThanOrEqual(BigInt(before));
+    expect(ts).toBeLessThanOrEqual(BigInt(after));
+  });
+});

--- a/packages/morpho-ts/src/urls.test.ts
+++ b/packages/morpho-ts/src/urls.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+  BLUE_API_BASE_URL,
+  BLUE_API_GRAPHQL_URL,
+  CDN_BASE_URL,
+  DOCS_BASE_URL,
+  MORPHO_DOMAIN,
+  OPTIMIZERS_API_BASE_URL,
+  OPTIMIZERS_BASE_URL,
+  REWARDS_BASE_URL,
+  getSubdomainBaseUrl,
+} from "./urls.js";
+
+describe("urls", () => {
+  describe("MORPHO_DOMAIN", () => {
+    test("is the canonical morpho.org domain", () => {
+      expect(MORPHO_DOMAIN).toBe("morpho.org");
+    });
+  });
+
+  describe("getSubdomainBaseUrl", () => {
+    test("composes https://<sub>.morpho.org", () => {
+      expect(getSubdomainBaseUrl("foo")).toBe("https://foo.morpho.org");
+    });
+
+    test("supports hyphenated subdomains", () => {
+      expect(getSubdomainBaseUrl("foo-bar")).toBe("https://foo-bar.morpho.org");
+    });
+
+    test("does not validate the subdomain (trusts caller)", () => {
+      expect(getSubdomainBaseUrl("")).toBe("https://.morpho.org");
+    });
+  });
+
+  describe("exported subdomain URLs", () => {
+    test("CDN_BASE_URL points to cdn", () => {
+      expect(CDN_BASE_URL).toBe("https://cdn.morpho.org");
+    });
+    test("DOCS_BASE_URL points to docs", () => {
+      expect(DOCS_BASE_URL).toBe("https://docs.morpho.org");
+    });
+    test("BLUE_API_BASE_URL points to api", () => {
+      expect(BLUE_API_BASE_URL).toBe("https://api.morpho.org");
+    });
+    test("REWARDS_BASE_URL points to rewards", () => {
+      expect(REWARDS_BASE_URL).toBe("https://rewards.morpho.org");
+    });
+    test("OPTIMIZERS_BASE_URL points to optimizers", () => {
+      expect(OPTIMIZERS_BASE_URL).toBe("https://optimizers.morpho.org");
+    });
+    test("OPTIMIZERS_API_BASE_URL aliases the api subdomain", () => {
+      expect(OPTIMIZERS_API_BASE_URL).toBe("https://api.morpho.org");
+    });
+  });
+
+  describe("BLUE_API_GRAPHQL_URL", () => {
+    test("appends /graphql to the API base URL", () => {
+      expect(BLUE_API_GRAPHQL_URL).toBe("https://api.morpho.org/graphql");
+    });
+
+    test("is a valid absolute URL", () => {
+      expect(() => new URL(BLUE_API_GRAPHQL_URL)).not.toThrow();
+      expect(new URL(BLUE_API_GRAPHQL_URL).pathname).toBe("/graphql");
+    });
+  });
+});

--- a/packages/morpho-ts/src/utils.test.ts
+++ b/packages/morpho-ts/src/utils.test.ts
@@ -1,0 +1,516 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  ZERO_ADDRESS,
+  bigIntComparator,
+  createGetValue,
+  createHasValue,
+  deepFreeze,
+  entries,
+  filterDefined,
+  fromEntries,
+  getLast,
+  getLastDefined,
+  getValue,
+  hasValue,
+  isDefined,
+  isNotNull,
+  isNotUndefined,
+  keys,
+  mergeEntries,
+  retryPromiseLinearBackoff,
+  transformValue,
+  values,
+} from "./utils.js";
+
+describe("ZERO_ADDRESS", () => {
+  test("is the canonical zero address", () => {
+    expect(ZERO_ADDRESS).toBe("0x0000000000000000000000000000000000000000");
+  });
+
+  test("has length 42 (0x + 40 hex chars)", () => {
+    expect(ZERO_ADDRESS.length).toBe(42);
+  });
+});
+
+describe("isNotNull", () => {
+  test("returns true for non-null values including undefined, 0, '', NaN, false", () => {
+    expect(isNotNull(0)).toBe(true);
+    expect(isNotNull("")).toBe(true);
+    expect(isNotNull(false)).toBe(true);
+    expect(isNotNull(undefined as unknown as number)).toBe(true);
+    expect(isNotNull(Number.NaN)).toBe(true);
+    expect(isNotNull({})).toBe(true);
+    expect(isNotNull([])).toBe(true);
+  });
+
+  test("returns false for null", () => {
+    expect(isNotNull(null)).toBe(false);
+  });
+
+  test("narrows the type", () => {
+    const v: string | null = "hello" as string | null;
+    if (isNotNull(v)) {
+      // type-narrowed to string at compile time
+      expect(v.length).toBe(5);
+    }
+  });
+});
+
+describe("isNotUndefined", () => {
+  test("returns true for non-undefined values including null, 0, '', false", () => {
+    expect(isNotUndefined(0)).toBe(true);
+    expect(isNotUndefined("")).toBe(true);
+    expect(isNotUndefined(false)).toBe(true);
+    expect(isNotUndefined(null as unknown as number)).toBe(true);
+  });
+
+  test("returns false for undefined", () => {
+    expect(isNotUndefined(undefined)).toBe(false);
+  });
+});
+
+describe("isDefined", () => {
+  test("returns false for null and undefined", () => {
+    expect(isDefined(null)).toBe(false);
+    expect(isDefined(undefined)).toBe(false);
+  });
+
+  test("returns true for falsy non-null/undefined values", () => {
+    expect(isDefined(0)).toBe(true);
+    expect(isDefined("")).toBe(true);
+    expect(isDefined(false)).toBe(true);
+    expect(isDefined(Number.NaN)).toBe(true);
+    expect(isDefined({})).toBe(true);
+    expect(isDefined([])).toBe(true);
+  });
+});
+
+describe("bigIntComparator", () => {
+  test("ascending order by default", () => {
+    const items = [{ v: 3n }, { v: 1n }, { v: 2n }];
+    items.sort(bigIntComparator((x) => x.v));
+    expect(items.map((x) => x.v)).toEqual([1n, 2n, 3n]);
+  });
+
+  test("descending order", () => {
+    const items = [{ v: 3n }, { v: 1n }, { v: 2n }];
+    items.sort(bigIntComparator((x) => x.v, "desc"));
+    expect(items.map((x) => x.v)).toEqual([3n, 2n, 1n]);
+  });
+
+  test("treats null/undefined values as larger than any concrete bigint (placed last)", () => {
+    const items = [{ v: 1n }, { v: null }, { v: 2n }, { v: undefined }];
+    items.sort(bigIntComparator((x) => x.v));
+    // null/undefined go last in ascending order
+    expect(items.slice(0, 2).map((x) => x.v)).toEqual([1n, 2n]);
+    expect(items[2]!.v == null).toBe(true);
+    expect(items[3]!.v == null).toBe(true);
+  });
+
+  test("treats two null/undefined entries as equal (returns 0)", () => {
+    const cmp = bigIntComparator<{ v: bigint | null }>((x) => x.v);
+    expect(cmp({ v: null }, { v: null })).toBe(0);
+  });
+
+  test("works with very large bigints", () => {
+    const items = [{ v: 2n ** 256n - 1n }, { v: 0n }, { v: 1n }];
+    items.sort(bigIntComparator((x) => x.v));
+    expect(items.map((x) => x.v)).toEqual([0n, 1n, 2n ** 256n - 1n]);
+  });
+});
+
+describe("getValue / hasValue / createGetValue / createHasValue", () => {
+  const obj = {
+    a: 1,
+    nested: { b: 2, deep: { c: 3 } },
+    n: null as null | number,
+    u: undefined as undefined | string,
+  };
+
+  test("getValue with shallow path", () => {
+    expect(getValue(obj, "a")).toBe(1);
+  });
+
+  test("getValue with dotted path", () => {
+    expect(getValue(obj, "nested.b")).toBe(2);
+    expect(getValue(obj, "nested.deep.c")).toBe(3);
+  });
+
+  test("getValue returns null when path traverses null", () => {
+    expect(getValue({ a: null as null | { b: number } }, "a.b" as never)).toBe(
+      null,
+    );
+  });
+
+  test("getValue returns undefined when key missing", () => {
+    expect(getValue(obj, "nested.missing" as never)).toBe(undefined);
+  });
+
+  test("hasValue returns true for present non-nullish values", () => {
+    expect(hasValue(obj, "a")).toBe(true);
+    expect(hasValue(obj, "nested.b")).toBe(true);
+  });
+
+  test("hasValue returns false for null/undefined values", () => {
+    expect(hasValue(obj, "n")).toBe(false);
+    expect(hasValue(obj, "u")).toBe(false);
+  });
+
+  test("createGetValue returns a reusable getter", () => {
+    const getA = createGetValue<typeof obj>("a");
+    expect(getA(obj)).toBe(1);
+  });
+
+  test("createHasValue returns a reusable predicate", () => {
+    const hasA = createHasValue<typeof obj>("a");
+    expect(hasA(obj)).toBe(true);
+    expect(hasA({ ...obj, a: undefined as unknown as number })).toBe(false);
+  });
+});
+
+describe("transformValue", () => {
+  test("applies the transform when value is defined", () => {
+    expect(transformValue(2, (n) => n * 3)).toBe(6);
+  });
+
+  test("returns null/undefined unchanged without invoking transform", () => {
+    const fn = vi.fn((x: number) => x);
+    expect(transformValue(null, fn)).toBe(null);
+    expect(transformValue(undefined, fn)).toBe(undefined);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("preserves falsy non-nullish values (0, '')", () => {
+    expect(transformValue(0, (n) => n + 1)).toBe(1);
+    expect(transformValue("", (s) => `${s}x`)).toBe("x");
+  });
+});
+
+describe("keys / values / entries / fromEntries", () => {
+  test("keys() returns sorted-by-insertion (numeric first, then string)", () => {
+    expect(keys({ b: 2, a: 1, "3": "c" })).toEqual(["3", "b", "a"]);
+  });
+
+  test("keys() handles empty object", () => {
+    expect(keys({})).toEqual([]);
+  });
+
+  test("keys() handles null/undefined input", () => {
+    expect(keys()).toEqual([]);
+    expect(keys(null as unknown as object)).toEqual([]);
+  });
+
+  test("keys() of an array yields stringified indices", () => {
+    expect(keys([10, 20, 30])).toEqual(["0", "1", "2"]);
+  });
+
+  test("values() returns object values", () => {
+    expect(values({ a: 1, b: 2 })).toEqual([1, 2]);
+  });
+
+  test("values() handles null/undefined input", () => {
+    expect(values()).toEqual([]);
+    expect(values(null as unknown as object)).toEqual([]);
+  });
+
+  test("values() of an array yields the elements", () => {
+    expect(values([10, 20, 30])).toEqual([10, 20, 30]);
+  });
+
+  test("entries() returns key/value pairs", () => {
+    expect(entries({ a: 1, b: 2 })).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]);
+  });
+
+  test("entries() handles null/undefined input", () => {
+    expect(entries()).toEqual([]);
+    expect(entries(null as unknown as object)).toEqual([]);
+  });
+
+  test("fromEntries reconstructs object from iterable of pairs", () => {
+    expect(
+      fromEntries([
+        ["a", 1],
+        ["b", 2],
+      ] as const),
+    ).toEqual({ a: 1, b: 2 });
+  });
+
+  test("fromEntries handles a Map", () => {
+    expect(
+      fromEntries(
+        new Map([
+          ["a", 1],
+          ["b", 2],
+        ]),
+      ),
+    ).toEqual({ a: 1, b: 2 });
+  });
+});
+
+describe("mergeEntries", () => {
+  test("merges duplicate keys via merger", () => {
+    const merged = mergeEntries<string, number>(
+      [
+        ["a", 1],
+        ["a", 2],
+        ["b", 3],
+      ],
+      (prev, value) => prev + value,
+    );
+    expect(merged).toEqual({ a: 3, b: 3 });
+  });
+
+  test("preserves first occurrence when merger returns prev", () => {
+    const merged = mergeEntries<string, number>(
+      [
+        ["a", 1],
+        ["a", 99],
+      ],
+      (prev) => prev,
+    );
+    expect(merged).toEqual({ a: 1 });
+  });
+
+  test("returns empty record for empty input", () => {
+    expect(
+      mergeEntries(
+        [] as readonly (readonly [string, number])[],
+        (a, b) => a + b,
+      ),
+    ).toEqual({});
+  });
+
+  test("does not call merger for first occurrence of a key", () => {
+    const merger = vi.fn((a: number, b: number) => a + b);
+    mergeEntries<string, number>(
+      [
+        ["a", 1],
+        ["b", 2],
+      ],
+      merger,
+    );
+    expect(merger).not.toHaveBeenCalled();
+  });
+
+  test("supports objects (last-write semantics via merger)", () => {
+    const merged = mergeEntries<string, { x: number }>(
+      [
+        ["a", { x: 1 }],
+        ["a", { x: 2 }],
+      ],
+      (_, v) => v,
+    );
+    expect(merged).toEqual({ a: { x: 2 } });
+  });
+});
+
+describe("retryPromiseLinearBackoff", () => {
+  test("returns the result on first success without retry", async () => {
+    const fn = vi.fn(async () => "ok");
+    const result = await retryPromiseLinearBackoff(fn, {
+      timeout: 1,
+      retries: 3,
+    });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries on failure and eventually succeeds", async () => {
+    let attempts = 0;
+    const fn = vi.fn(async () => {
+      attempts++;
+      if (attempts < 3) throw new Error("transient");
+      return "ok";
+    });
+    const result = await retryPromiseLinearBackoff(fn, {
+      timeout: 1,
+      retries: 5,
+    });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test("throws 'too many retries' when retries exhausted", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("always");
+    });
+    await expect(
+      retryPromiseLinearBackoff(fn, { timeout: 1, retries: 2 }),
+    ).rejects.toThrow("too many retries");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("throws 'stopped retrying' when onError returns truthy", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("nope");
+    });
+    const onError = vi.fn(async () => true);
+    await expect(
+      retryPromiseLinearBackoff(fn, { timeout: 1, retries: 5, onError }),
+    ).rejects.toThrow("stopped retrying");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues retrying when onError returns falsy", async () => {
+    let attempts = 0;
+    const fn = vi.fn(async () => {
+      attempts++;
+      if (attempts < 2) throw new Error("transient");
+      return "ok";
+    });
+    const onError = vi.fn(async () => false);
+    const result = await retryPromiseLinearBackoff(fn, {
+      timeout: 1,
+      retries: 5,
+      onError,
+    });
+    expect(result).toBe("ok");
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses default timeout=100 and retries=8 when omitted", async () => {
+    const fn = vi.fn(async () => "ok");
+    const result = await retryPromiseLinearBackoff(fn, {});
+    expect(result).toBe("ok");
+  });
+
+  test("forwards thrown errors to onError with the attempt index", async () => {
+    const errors: unknown[] = [];
+    const indices: number[] = [];
+    let attempts = 0;
+    const fn = vi.fn(async () => {
+      attempts++;
+      if (attempts < 3) throw new Error(`fail-${attempts}`);
+      return "done";
+    });
+    await retryPromiseLinearBackoff(fn, {
+      timeout: 1,
+      retries: 5,
+      onError: async (err, i) => {
+        errors.push(err);
+        indices.push(i);
+      },
+    });
+    expect(errors).toHaveLength(2);
+    expect((errors[0] as Error).message).toBe("fail-1");
+    expect((errors[1] as Error).message).toBe("fail-2");
+    expect(indices).toEqual([0, 1]);
+  });
+});
+
+describe("getLast", () => {
+  test("returns the last element of a non-empty array", () => {
+    expect(getLast([1, 2, 3])).toBe(3);
+  });
+
+  test("returns undefined for empty array", () => {
+    expect(getLast([] as number[])).toBe(undefined);
+  });
+
+  test("returns the only element for singleton", () => {
+    expect(getLast([42])).toBe(42);
+  });
+
+  test("preserves null/undefined values at the end", () => {
+    expect(getLast([1, null] as Array<number | null>)).toBe(null);
+    expect(getLast([1, undefined] as Array<number | undefined>)).toBe(
+      undefined,
+    );
+  });
+});
+
+describe("filterDefined", () => {
+  test("removes null and undefined", () => {
+    expect(
+      filterDefined([1, null, 2, undefined, 3] as Array<
+        number | null | undefined
+      >),
+    ).toEqual([1, 2, 3]);
+  });
+
+  test("preserves falsy values that are defined (0, '', false)", () => {
+    expect(
+      filterDefined([0, "", false, null, undefined] as Array<unknown>),
+    ).toEqual([0, "", false]);
+  });
+
+  test("returns empty array when all values are nullish", () => {
+    expect(
+      filterDefined([null, undefined] as Array<number | null | undefined>),
+    ).toEqual([]);
+  });
+
+  test("returns a new array (does not mutate input)", () => {
+    const input = [1, null, 2] as Array<number | null>;
+    const result = filterDefined(input);
+    expect(result).not.toBe(input);
+    expect(input).toEqual([1, null, 2]);
+  });
+});
+
+describe("getLastDefined", () => {
+  test("returns the last defined value", () => {
+    expect(getLastDefined([1, null, 2, undefined])).toBe(2);
+  });
+
+  test("returns undefined when no defined values exist", () => {
+    expect(
+      getLastDefined([null, undefined, null] as Array<
+        number | null | undefined
+      >),
+    ).toBe(undefined);
+  });
+
+  test("returns the only element when array has one defined value", () => {
+    expect(getLastDefined([42])).toBe(42);
+  });
+});
+
+describe("deepFreeze", () => {
+  test("freezes top-level object", () => {
+    const obj = { a: 1, b: 2 };
+    deepFreeze(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+  });
+
+  test("freezes nested objects", () => {
+    const obj = { a: 1, nested: { b: 2, deep: { c: 3 } } };
+    deepFreeze(obj);
+    expect(Object.isFrozen(obj.nested)).toBe(true);
+    expect(Object.isFrozen(obj.nested.deep)).toBe(true);
+  });
+
+  test("freezes arrays", () => {
+    const obj = { items: [1, 2, 3] };
+    deepFreeze(obj);
+    expect(Object.isFrozen(obj.items)).toBe(true);
+  });
+
+  test("returns the same reference", () => {
+    const obj = { a: 1 };
+    expect(deepFreeze(obj)).toBe(obj);
+  });
+
+  test("returns null/undefined unchanged", () => {
+    expect(deepFreeze(null)).toBe(null);
+    expect(deepFreeze(undefined)).toBe(undefined);
+  });
+
+  test("frozen objects throw on mutation in strict mode", () => {
+    const obj = { a: 1 };
+    deepFreeze(obj);
+    expect(() => {
+      obj.a = 2;
+    }).toThrow();
+  });
+
+  test("handles primitive scalars without throwing", () => {
+    // The implementation calls Object.getOwnPropertyNames which works on primitives via boxing.
+    expect(() => deepFreeze(0 as unknown as object)).not.toThrow();
+    expect(() => deepFreeze("string" as unknown as object)).not.toThrow();
+  });
+});

--- a/packages/morpho-ts/tsconfig.build.cjs.json
+++ b/packages/morpho-ts/tsconfig.build.cjs.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/cjs",
     "tsBuildInfoFile": "tsconfig.cjs.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/morpho-ts/tsconfig.build.esm.json
+++ b/packages/morpho-ts/tsconfig.build.esm.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/esm",
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
         "packages/test/**",
         "packages/test-wagmi/**",
         "packages/morpho-test/**",
+        "packages/**/src/**/*.test.ts",
+        "packages/**/src/**/__test-utils__/**",
+        "packages/**/src/**/__mocks__/**",
+        "packages/**/src/**/__fixtures__/**",
+        "packages/**/src/**/index.ts",
+        "packages/**/src/**/*.d.ts",
+        "packages/**/src/**/abis.ts",
+        "packages/**/src/api/sdk.ts",
+        "packages/**/src/api/types.ts",
       ],
     },
     sequence: {
@@ -22,7 +31,10 @@ export default defineConfig({
         extends: true,
         test: {
           name: "morpho-ts",
-          include: ["packages/morpho-ts/test/**/*.test.ts"],
+          include: [
+            "packages/morpho-ts/test/**/*.test.ts",
+            "packages/morpho-ts/src/**/*.test.ts",
+          ],
         },
       },
       {


### PR DESCRIPTION
Implements **Phase 1** of TIB-2026-04-27 (#556). Stacked on the TIB PR; will auto-retarget once #556 lands.

## What lands

- **vitest.config.ts**: union the `morpho-ts` project include to match both the existing `test/` files (untouched) and new `src/**/*.test.ts`. Tighten `coverage.exclude` to drop `*.test.ts`, `__test-utils__/`, barrel `index.ts`, `abis.ts`, and `api/{sdk,types}.ts`.
- **packages/morpho-ts/tsconfig.build.{cjs,esm}.json**: add `exclude` so `src/**/*.test.ts` and `__test-utils__/` do not reach `lib/`.
- **6 new colocated test files** in `packages/morpho-ts/src/` covering every public function not already tested by the existing `test/{format,time,utils}.test.ts` files (which are NOT moved or modified, per the TIB).

## Coverage

| Metric | Before | After | Delta |
| --- | --- | --- | --- |
| **morpho-ts line coverage** | 78.60% | **96.32%** | +17.72 pp |
| Files at 100% (was 0%) | — | `urls.ts`, `utils.ts`, `format/array.ts`, `format/string.ts` | 4 |
| Files unchanged from existing tests | — | `format/format.ts` 94.1%, `time/time.ts` 96.6%, `format/locale.ts` 96.8% | — |

## What is tested

- `urls.ts` — every exported constant + `getSubdomainBaseUrl`.
- `utils.ts` — `isNotNull`, `isNotUndefined`, `isDefined`, `bigIntComparator` (asc/desc, nulls, large bigints), `getValue`/`hasValue`/`createGetValue`/`createHasValue`/`transformValue` (incl. dotted paths), `keys`/`values`/`entries`/`fromEntries`/`mergeEntries`, `retryPromiseLinearBackoff` (success, retry-then-succeed, exhaust, `onError` truthy/falsy, default args), `getLast`/`filterDefined`/`getLastDefined`, `deepFreeze`.
- `time/time.test.ts` — full unit-conversion matrix (ms↔s↔min↔h↔d↔w↔mo↔y), number/bigint type preservation, `fromPeriod`/`toPeriod`, `Time.wait`, `Time.timestamp`.
- `format/array.test.ts` — `formatUnion`, `formatEnumeration`.
- `format/string.test.ts` — `formatLongString` edge cases (maxLength ≤ 3, =4, odd nChar, empty input).
- `format/locale.test.ts` — `getLocaleSymbols` (en-US, fr-FR, de-DE, fallback), `getEffectiveLocale` (Node + browser globals stubbed via `vi.stubGlobal`), `convertNumStrToLocal`, `convertNumStrFromEffectiveTo`, `getEnUSNumberToLocalParts`.

## Test plan

- [x] `pnpm test --project morpho-ts --run` → 9 files / 265 tests pass.
- [x] `pnpm test:coverage --project morpho-ts` → 96.32% line coverage.
- [x] `pnpm --filter @morpho-org/morpho-ts build` succeeds.
- [x] `find packages/morpho-ts/lib -name "*.test.*"` → empty.

## TIB conventions used (validated by this phase)

1. **Colocation**: `src/Foo.test.ts` next to `src/Foo.ts`.
2. **Existing tests untouched**: `test/{format,time,utils}.test.ts` stay where they are; vitest project `include` is a union of both.
3. **No mocking primitives needed yet** (this is pure TS); `createMockClient` / `nock` enter from Phase 5 onwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->