### PR TITLE
test(blue-sdk): phase 3 — colocated unit tests for math, errors, tokens, vaults

### DIFF
--- a/packages/blue-sdk/src/errors.test.ts
+++ b/packages/blue-sdk/src/errors.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "vitest";
+import {
+  BlueErrors,
+  InvalidMarketParamsError,
+  UnknownDataError,
+  UnknownFactory,
+  UnknownMarketParamsError,
+  UnknownOfFactory,
+  UnknownTokenError,
+  UnknownTokenPriceError,
+  UnknownVaultConfigError,
+  UnsupportedChainIdError,
+  UnsupportedPreLiquidationParamsError,
+  UnsupportedVaultV2AdapterError,
+  VaultV2Errors,
+  _try,
+} from "./errors.js";
+import type { Address, MarketId } from "./types.js";
+
+const ADDRESS = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
+const MARKET_ID = "0x123456" as MarketId;
+
+describe("error classes", () => {
+  test("InvalidMarketParamsError preserves data and is an Error", () => {
+    const err = new InvalidMarketParamsError("0xabcd");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.data).toBe("0xabcd");
+    expect(err.message).toContain("0xabcd");
+  });
+
+  test("UnknownTokenError extends UnknownDataError", () => {
+    const err = new UnknownTokenError(ADDRESS);
+    expect(err).toBeInstanceOf(UnknownDataError);
+    expect(err.address).toBe(ADDRESS);
+    expect(err.message).toContain(ADDRESS);
+  });
+
+  test("UnknownTokenPriceError extends UnknownDataError", () => {
+    const err = new UnknownTokenPriceError(ADDRESS);
+    expect(err).toBeInstanceOf(UnknownDataError);
+    expect(err.address).toBe(ADDRESS);
+  });
+
+  test("UnknownMarketParamsError extends UnknownDataError", () => {
+    const err = new UnknownMarketParamsError(MARKET_ID);
+    expect(err).toBeInstanceOf(UnknownDataError);
+    expect(err.marketId).toBe(MARKET_ID);
+  });
+
+  test("UnknownVaultConfigError extends UnknownDataError", () => {
+    const err = new UnknownVaultConfigError(ADDRESS);
+    expect(err).toBeInstanceOf(UnknownDataError);
+    expect(err.vault).toBe(ADDRESS);
+  });
+
+  test("UnsupportedChainIdError preserves chainId", () => {
+    const err = new UnsupportedChainIdError(999);
+    expect(err.chainId).toBe(999);
+    expect(err.message).toContain("999");
+  });
+
+  test("UnsupportedPreLiquidationParamsError formats lltv", () => {
+    const err = new UnsupportedPreLiquidationParamsError(
+      9_000_000_000_000_000_000n, // 90 * 1e16 = 90% in 16-decimal scale (per formatUnits)
+    );
+    expect(err.lltv).toBe(9_000_000_000_000_000_000n);
+    expect(err.message).toContain("%");
+  });
+
+  test("UnsupportedVaultV2AdapterError preserves address", () => {
+    const err = new UnsupportedVaultV2AdapterError(ADDRESS);
+    expect(err.address).toBe(ADDRESS);
+  });
+
+  test("UnknownFactory has no fields", () => {
+    const err = new UnknownFactory();
+    expect(err.message).toContain("unknown factory");
+  });
+
+  test("UnknownOfFactory preserves factory and address", () => {
+    const factory: Address = "0xbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbB";
+    const err = new UnknownOfFactory(factory, ADDRESS);
+    expect(err.factory).toBe(factory);
+    expect(err.address).toBe(ADDRESS);
+    expect(err.message).toContain(ADDRESS);
+    expect(err.message).toContain(factory);
+  });
+});
+
+describe("BlueErrors namespace", () => {
+  test("AlreadySet preserves name and value", () => {
+    const err = new BlueErrors.AlreadySet("price", "100");
+    expect(err.name).toBe("price");
+    expect(err.value).toBe("100");
+  });
+
+  test("InvalidInterestAccrual preserves all fields", () => {
+    const err = new BlueErrors.InvalidInterestAccrual(MARKET_ID, 100n, 200n);
+    expect(err.marketId).toBe(MARKET_ID);
+    expect(err.timestamp).toBe(100n);
+    expect(err.lastUpdate).toBe(200n);
+  });
+
+  test("InconsistentInput preserves assets and shares", () => {
+    const err = new BlueErrors.InconsistentInput(10n, 100n);
+    expect(err.assets).toBe(10n);
+    expect(err.shares).toBe(100n);
+  });
+
+  test("InsufficientLiquidity preserves marketId", () => {
+    const err = new BlueErrors.InsufficientLiquidity(MARKET_ID);
+    expect(err.marketId).toBe(MARKET_ID);
+  });
+
+  test("UnknownOraclePrice preserves marketId", () => {
+    const err = new BlueErrors.UnknownOraclePrice(MARKET_ID);
+    expect(err.marketId).toBe(MARKET_ID);
+  });
+
+  test("InsufficientPosition preserves user and marketId", () => {
+    const err = new BlueErrors.InsufficientPosition(ADDRESS, MARKET_ID);
+    expect(err.user).toBe(ADDRESS);
+    expect(err.marketId).toBe(MARKET_ID);
+  });
+
+  test("InsufficientCollateral preserves user and marketId", () => {
+    const err = new BlueErrors.InsufficientCollateral(ADDRESS, MARKET_ID);
+    expect(err.user).toBe(ADDRESS);
+    expect(err.marketId).toBe(MARKET_ID);
+  });
+
+  test("ExpiredSignature preserves deadline", () => {
+    const err = new BlueErrors.ExpiredSignature(123n);
+    expect(err.deadline).toBe(123n);
+  });
+});
+
+describe("VaultV2Errors namespace", () => {
+  test("InvalidInterestAccrual preserves vault, timestamp, lastUpdate", () => {
+    const err = new VaultV2Errors.InvalidInterestAccrual(ADDRESS, 100n, 200n);
+    expect(err.vault).toBe(ADDRESS);
+    expect(err.timestamp).toBe(100n);
+    expect(err.lastUpdate).toBe(200n);
+  });
+
+  test("UnsupportedLiquidityAdapter preserves address", () => {
+    const err = new VaultV2Errors.UnsupportedLiquidityAdapter(ADDRESS);
+    expect(err.address).toBe(ADDRESS);
+  });
+});
+
+describe("_try", () => {
+  test("returns the value when sync accessor succeeds", () => {
+    expect(_try(() => 42)).toBe(42);
+  });
+
+  test("returns undefined when sync accessor throws and no error class given", () => {
+    expect(
+      _try(() => {
+        throw new Error("oops");
+      }),
+    ).toBe(undefined);
+  });
+
+  test("returns undefined for matching error class", () => {
+    expect(
+      _try(() => {
+        throw new UnknownTokenError(ADDRESS);
+      }, UnknownTokenError),
+    ).toBe(undefined);
+  });
+
+  test("re-throws when error class does not match", () => {
+    expect(() =>
+      _try(() => {
+        throw new TypeError("not me");
+      }, UnknownTokenError),
+    ).toThrow(TypeError);
+  });
+
+  test("matches subclasses (instanceof check)", () => {
+    expect(
+      _try(() => {
+        throw new UnknownTokenError(ADDRESS);
+      }, UnknownDataError),
+    ).toBe(undefined);
+  });
+
+  test("returns the resolved value for async accessor success", async () => {
+    expect(await _try(async () => "ok")).toBe("ok");
+  });
+
+  test("returns undefined for async rejection on matching error class", async () => {
+    expect(
+      await _try(async () => {
+        throw new UnknownTokenError(ADDRESS);
+      }, UnknownTokenError),
+    ).toBe(undefined);
+  });
+
+  test("re-throws on async rejection when no class matches", async () => {
+    await expect(
+      _try(async () => {
+        throw new TypeError("nope");
+      }, UnknownTokenError),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/packages/blue-sdk/src/holding/AssetBalances.test.ts
+++ b/packages/blue-sdk/src/holding/AssetBalances.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "vitest";
+import { Token } from "../token/Token.js";
+import type { Address } from "../types.js";
+import { AssetBalances, type PeripheralBalance } from "./AssetBalances.js";
+
+const ETH = new Token({
+  address: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" as Address,
+  symbol: "ETH",
+  decimals: 18,
+});
+const WSTETH = new Token({
+  address: "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0" as Address,
+  symbol: "wstETH",
+  decimals: 18,
+});
+
+describe("AssetBalances", () => {
+  test("constructor seeds the base allocation and total", () => {
+    const ab = new AssetBalances({
+      srcToken: ETH,
+      srcAmount: 1n,
+      dstAmount: 1_000n,
+    });
+    expect(ab.total).toBe(1_000n);
+    expect(ab.allocations.base).toMatchObject({
+      type: "base",
+      srcToken: ETH,
+      srcAmount: 1n,
+      dstAmount: 1_000n,
+    });
+  });
+
+  test("add accumulates total and creates allocation entry", () => {
+    const ab = new AssetBalances({
+      srcToken: ETH,
+      srcAmount: 0n,
+      dstAmount: 0n,
+    });
+    const peripheral: PeripheralBalance = {
+      type: "wrapped",
+      srcToken: WSTETH,
+      srcAmount: 100n,
+      dstAmount: 120n,
+    };
+    ab.add(peripheral);
+    expect(ab.total).toBe(120n);
+    expect(ab.allocations.wrapped).toMatchObject({
+      type: "wrapped",
+      srcAmount: 100n,
+      dstAmount: 120n,
+    });
+  });
+
+  test("add accumulates into an existing allocation", () => {
+    const ab = new AssetBalances({
+      srcToken: ETH,
+      srcAmount: 0n,
+      dstAmount: 0n,
+    });
+    ab.add({ type: "wrapped", srcToken: WSTETH, srcAmount: 1n, dstAmount: 2n });
+    ab.add({
+      type: "wrapped",
+      srcToken: WSTETH,
+      srcAmount: 5n,
+      dstAmount: 10n,
+    });
+    expect(ab.allocations.wrapped?.srcAmount).toBe(6n);
+    expect(ab.allocations.wrapped?.dstAmount).toBe(12n);
+    expect(ab.total).toBe(12n);
+  });
+
+  test("sub decrements total and updates allocation", () => {
+    const ab = new AssetBalances({
+      srcToken: ETH,
+      srcAmount: 0n,
+      dstAmount: 100n,
+    });
+    ab.sub({
+      type: "wrapped",
+      srcToken: WSTETH,
+      srcAmount: 5n,
+      dstAmount: 30n,
+    });
+    expect(ab.total).toBe(70n);
+    expect(ab.allocations.wrapped?.srcAmount).toBe(-5n);
+    expect(ab.allocations.wrapped?.dstAmount).toBe(-30n);
+  });
+
+  test("add returns the same instance (chainable)", () => {
+    const ab = new AssetBalances({
+      srcToken: ETH,
+      srcAmount: 0n,
+      dstAmount: 0n,
+    });
+    const result = ab.add({
+      type: "vault",
+      srcToken: ETH,
+      srcAmount: 1n,
+      dstAmount: 1n,
+    });
+    expect(result).toBe(ab);
+  });
+
+  test("sub returns the same instance (chainable)", () => {
+    const ab = new AssetBalances({
+      srcToken: ETH,
+      srcAmount: 0n,
+      dstAmount: 100n,
+    });
+    const result = ab.sub({
+      type: "vault",
+      srcToken: ETH,
+      srcAmount: 1n,
+      dstAmount: 1n,
+    });
+    expect(result).toBe(ab);
+  });
+
+  test("supports all peripheral balance types", () => {
+    const ab = new AssetBalances({
+      srcToken: ETH,
+      srcAmount: 0n,
+      dstAmount: 0n,
+    });
+    const types = [
+      "wrapped",
+      "staked-wrapped",
+      "vault",
+      "wrapped-vault",
+      "unwrapped-staked-wrapped",
+    ] as const;
+    for (const type of types) {
+      ab.add({ type, srcToken: ETH, srcAmount: 1n, dstAmount: 1n });
+      expect(ab.allocations[type]).toBeDefined();
+    }
+    expect(ab.total).toBe(BigInt(types.length));
+  });
+});

--- a/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.test.ts
+++ b/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "vitest";
+import { AdaptiveCurveIrmLib } from "./AdaptiveCurveIrmLib.js";
+import { MathLib } from "./MathLib.js";
+
+const { wExp, getBorrowRate, getUtilizationAtBorrowRate, TARGET_UTILIZATION } =
+  AdaptiveCurveIrmLib;
+
+describe("AdaptiveCurveIrmLib.wExp", () => {
+  test("returns 0 for very negative inputs (below LN_WEI_INT)", () => {
+    expect(wExp(AdaptiveCurveIrmLib.LN_WEI_INT - 1n)).toBe(0n);
+  });
+
+  test("returns clipped upper value for inputs at/above WEXP_UPPER_BOUND", () => {
+    expect(wExp(AdaptiveCurveIrmLib.WEXP_UPPER_BOUND)).toBe(
+      AdaptiveCurveIrmLib.WEXP_UPPER_VALUE,
+    );
+    expect(wExp(AdaptiveCurveIrmLib.WEXP_UPPER_BOUND + 1n)).toBe(
+      AdaptiveCurveIrmLib.WEXP_UPPER_VALUE,
+    );
+  });
+
+  test("wExp(0) ≈ 1 WAD", () => {
+    expect(wExp(0n)).toBe(MathLib.WAD);
+  });
+
+  test("wExp(LN_2_INT) ≈ 2 WAD (within trivial Taylor error)", () => {
+    const result = wExp(AdaptiveCurveIrmLib.LN_2_INT);
+    // 2nd-order Taylor at r=0 — close to but not exactly 2 WAD.
+    expect(result).toBe(2n * MathLib.WAD);
+  });
+
+  test("monotonically increasing within the valid domain", () => {
+    expect(wExp(MathLib.WAD / 10n)).toBeGreaterThan(wExp(0n));
+    expect(wExp(MathLib.WAD)).toBeGreaterThan(wExp(MathLib.WAD / 10n));
+  });
+
+  test("wExp(-x) < WAD for x>0", () => {
+    expect(wExp(-MathLib.WAD / 10n)).toBeLessThan(MathLib.WAD);
+  });
+});
+
+describe("AdaptiveCurveIrmLib.getBorrowRate (first interaction, startRateAtTarget=0)", () => {
+  test("returns INITIAL_RATE_AT_TARGET-based rates regardless of utilization", () => {
+    const r = getBorrowRate(TARGET_UTILIZATION, 0n, 0n);
+    // err = 0 -> avg/end borrow rate equals avgRateAtTarget=INITIAL_RATE_AT_TARGET
+    expect(r.endRateAtTarget).toBe(AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET);
+    expect(r.avgBorrowRate).toBe(AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET);
+  });
+
+  test("at zero utilization, err < 0 -> coeff applies the slow side of the curve", () => {
+    const r = getBorrowRate(0n, 0n, 0n);
+    // Same INITIAL_RATE_AT_TARGET endRateAtTarget; endBorrowRate < endRateAtTarget.
+    expect(r.endRateAtTarget).toBe(AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET);
+    expect(r.endBorrowRate).toBeLessThan(r.endRateAtTarget);
+  });
+
+  test("at full utilization, err > 0 -> coeff applies the fast side of the curve", () => {
+    const r = getBorrowRate(MathLib.WAD, 0n, 0n);
+    expect(r.endRateAtTarget).toBe(AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET);
+    expect(r.endBorrowRate).toBeGreaterThan(r.endRateAtTarget);
+  });
+});
+
+describe("AdaptiveCurveIrmLib.getBorrowRate (subsequent interaction)", () => {
+  test("zero elapsed time -> rate unchanged", () => {
+    const startRate = AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET;
+    const r = getBorrowRate(MathLib.WAD, startRate, 0n);
+    expect(r.endRateAtTarget).toBe(startRate);
+  });
+
+  test("positive elapsed time at high utilization grows endRateAtTarget toward MAX", () => {
+    const startRate = AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET;
+    // Long elapsed time at full utilization should push rate up.
+    const r = getBorrowRate(MathLib.WAD, startRate, 30n * 24n * 3600n);
+    expect(r.endRateAtTarget).toBeGreaterThan(startRate);
+    expect(r.endRateAtTarget).toBeLessThanOrEqual(
+      AdaptiveCurveIrmLib.MAX_RATE_AT_TARGET,
+    );
+  });
+
+  test("positive elapsed time at zero utilization shrinks endRateAtTarget toward MIN", () => {
+    const startRate = AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET;
+    const r = getBorrowRate(0n, startRate, 30n * 24n * 3600n);
+    expect(r.endRateAtTarget).toBeLessThan(startRate);
+    expect(r.endRateAtTarget).toBeGreaterThanOrEqual(
+      AdaptiveCurveIrmLib.MIN_RATE_AT_TARGET,
+    );
+  });
+
+  test("returned avgBorrowRate sits between start and end borrow rates", () => {
+    const startRate = AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET;
+    const elapsed = 24n * 3600n;
+    const r = getBorrowRate(MathLib.WAD, startRate, elapsed);
+    expect(r.avgBorrowRate).toBeGreaterThan(0n);
+    // The avg must be <= end (rate increases over time at high U).
+    expect(r.avgBorrowRate).toBeLessThanOrEqual(r.endBorrowRate);
+  });
+});
+
+describe("AdaptiveCurveIrmLib.getUtilizationAtBorrowRate", () => {
+  test("when borrowRate === rateAtTarget, returns TARGET_UTILIZATION", () => {
+    const u = getUtilizationAtBorrowRate(MathLib.WAD, MathLib.WAD);
+    expect(u).toBe(TARGET_UTILIZATION);
+  });
+
+  test("at the maxBorrowRate (4x rateAtTarget), returns 1 WAD", () => {
+    const rate = MathLib.WAD;
+    const max = rate * 4n;
+    expect(getUtilizationAtBorrowRate(max, rate)).toBe(MathLib.WAD);
+  });
+
+  test("at minBorrowRate (rate/4), returns 0", () => {
+    const rate = MathLib.WAD;
+    const min = rate / 4n;
+    expect(getUtilizationAtBorrowRate(min, rate)).toBe(0n);
+  });
+
+  test("monotonically increasing in borrowRate", () => {
+    const rate = MathLib.WAD;
+    const u1 = getUtilizationAtBorrowRate(rate / 2n, rate);
+    const u2 = getUtilizationAtBorrowRate(rate, rate);
+    const u3 = getUtilizationAtBorrowRate(rate * 2n, rate);
+    expect(u1).toBeLessThan(u2);
+    expect(u2).toBeLessThan(u3);
+  });
+
+  test("clamps to 0 below the minBorrowRate", () => {
+    const rate = MathLib.WAD;
+    expect(getUtilizationAtBorrowRate(0n, rate)).toBe(0n);
+    expect(getUtilizationAtBorrowRate(rate / 8n, rate)).toBe(0n);
+  });
+
+  test("clamps to 1 WAD above the maxBorrowRate", () => {
+    const rate = MathLib.WAD;
+    const max = rate * 4n;
+    expect(getUtilizationAtBorrowRate(max + 1n, rate)).toBe(MathLib.WAD);
+    expect(getUtilizationAtBorrowRate(max * 10n, rate)).toBe(MathLib.WAD);
+  });
+});

--- a/packages/blue-sdk/src/math/MathLib.test.ts
+++ b/packages/blue-sdk/src/math/MathLib.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "vitest";
+import { MathLib } from "./MathLib.js";
+
+describe("MathLib constants", () => {
+  test("WAD = 1e18", () => {
+    expect(MathLib.WAD).toBe(1_000_000_000_000_000_000n);
+  });
+  test("RAY = 1e27", () => {
+    expect(MathLib.RAY).toBe(1_000_000_000_000_000_000_000_000_000n);
+  });
+  test("MAX_UINT_256 = 2^256 - 1", () => {
+    expect(MathLib.MAX_UINT_256).toBe(2n ** 256n - 1n);
+  });
+  test("MAX_UINT_160 = 2^160 - 1", () => {
+    expect(MathLib.MAX_UINT_160).toBe(2n ** 160n - 1n);
+  });
+  test("MAX_UINT_128 = 2^128 - 1", () => {
+    expect(MathLib.MAX_UINT_128).toBe(2n ** 128n - 1n);
+  });
+  test("MAX_UINT_48 = 2^48 - 1", () => {
+    expect(MathLib.MAX_UINT_48).toBe(2n ** 48n - 1n);
+  });
+});
+
+describe("MathLib.maxUint", () => {
+  test("returns 2^n - 1 for nibble-aligned n", () => {
+    expect(MathLib.maxUint(8)).toBe(2n ** 8n - 1n);
+    expect(MathLib.maxUint(64)).toBe(2n ** 64n - 1n);
+  });
+  test("throws when n is not divisible by 4", () => {
+    expect(() => MathLib.maxUint(7)).toThrow(/Invalid number of bits/);
+    expect(() => MathLib.maxUint(33)).toThrow(/Invalid number of bits/);
+  });
+});
+
+describe("MathLib.abs", () => {
+  test("positive bigint", () => {
+    expect(MathLib.abs(5n)).toBe(5n);
+  });
+  test("negative bigint", () => {
+    expect(MathLib.abs(-5n)).toBe(5n);
+  });
+  test("zero", () => {
+    expect(MathLib.abs(0n)).toBe(0n);
+  });
+  test("accepts BigIntish (string and number)", () => {
+    expect(MathLib.abs("-42")).toBe(42n);
+    expect(MathLib.abs(7)).toBe(7n);
+  });
+});
+
+describe("MathLib.min / MathLib.max", () => {
+  test("min of two", () => {
+    expect(MathLib.min(2n, 5n)).toBe(2n);
+    expect(MathLib.min(5n, 2n)).toBe(2n);
+  });
+  test("max of two", () => {
+    expect(MathLib.max(2n, 5n)).toBe(5n);
+    expect(MathLib.max(5n, 2n)).toBe(5n);
+  });
+  test("variadic min/max", () => {
+    expect(MathLib.min(3n, 1n, 4n, 1n, 5n, 9n, 2n, 6n)).toBe(1n);
+    expect(MathLib.max(3n, 1n, 4n, 1n, 5n, 9n, 2n, 6n)).toBe(9n);
+  });
+  test("min/max with single element", () => {
+    expect(MathLib.min(42n)).toBe(42n);
+    expect(MathLib.max(42n)).toBe(42n);
+  });
+  test("accepts mixed BigIntish inputs", () => {
+    expect(MathLib.min(1, "2", 3n)).toBe(1n);
+    expect(MathLib.max(1, "2", 3n)).toBe(3n);
+  });
+});
+
+describe("MathLib.zeroFloorSub", () => {
+  test("returns x - y when x > y", () => {
+    expect(MathLib.zeroFloorSub(10n, 3n)).toBe(7n);
+  });
+  test("returns 0 when x === y", () => {
+    expect(MathLib.zeroFloorSub(5n, 5n)).toBe(0n);
+  });
+  test("returns 0 when x < y (does not go negative)", () => {
+    expect(MathLib.zeroFloorSub(3n, 10n)).toBe(0n);
+  });
+  test("accepts BigIntish", () => {
+    expect(MathLib.zeroFloorSub("100", 30)).toBe(70n);
+  });
+});
+
+describe("MathLib.mulDivDown / MathLib.mulDivUp", () => {
+  test("mulDivDown floors the division", () => {
+    expect(MathLib.mulDivDown(7n, 3n, 2n)).toBe(10n); // 21/2 = 10.5 -> 10
+    expect(MathLib.mulDivDown(10n, 1n, 3n)).toBe(3n); // 10/3 = 3.33 -> 3
+  });
+  test("mulDivUp ceils the division", () => {
+    expect(MathLib.mulDivUp(7n, 3n, 2n)).toBe(11n); // 21/2 = 10.5 -> 11
+    expect(MathLib.mulDivUp(10n, 1n, 3n)).toBe(4n); // 10/3 = 3.33 -> 4
+  });
+  test("mulDivUp does not over-round when exact", () => {
+    expect(MathLib.mulDivUp(6n, 1n, 3n)).toBe(2n);
+  });
+  test("mulDivDown matches mulDivUp when result is exact", () => {
+    expect(MathLib.mulDivDown(6n, 1n, 3n)).toBe(2n);
+  });
+  test("throws DIVISION_BY_ZERO on zero denominator", () => {
+    expect(() => MathLib.mulDivDown(1n, 1n, 0n)).toThrow(/DIVISION_BY_ZERO/);
+    expect(() => MathLib.mulDivUp(1n, 1n, 0n)).toThrow(/DIVISION_BY_ZERO/);
+  });
+});
+
+describe("MathLib.mulDiv", () => {
+  test("dispatches by rounding direction", () => {
+    expect(MathLib.mulDiv(7n, 3n, 2n, "Down")).toBe(10n);
+    expect(MathLib.mulDiv(7n, 3n, 2n, "Up")).toBe(11n);
+  });
+});
+
+describe("MathLib.wMul / MathLib.wMulDown / MathLib.wMulUp", () => {
+  test("wMulDown(WAD, x) = x", () => {
+    expect(MathLib.wMulDown(MathLib.WAD, 42n)).toBe(42n);
+  });
+  test("wMulDown of two halves of WAD = WAD/4", () => {
+    const half = MathLib.WAD / 2n;
+    expect(MathLib.wMulDown(half, half)).toBe(MathLib.WAD / 4n);
+  });
+  test("wMulUp rounds up when remainder is non-zero", () => {
+    // 1 * 1 / WAD = 0 with Down, 1 with Up
+    expect(MathLib.wMulDown(1n, 1n)).toBe(0n);
+    expect(MathLib.wMulUp(1n, 1n)).toBe(1n);
+  });
+  test("wMul dispatches by direction", () => {
+    expect(MathLib.wMul(1n, 1n, "Down")).toBe(0n);
+    expect(MathLib.wMul(1n, 1n, "Up")).toBe(1n);
+  });
+});
+
+describe("MathLib.wDiv / MathLib.wDivDown / MathLib.wDivUp", () => {
+  test("wDivDown(x, WAD) = x", () => {
+    expect(MathLib.wDivDown(42n, MathLib.WAD)).toBe(42n);
+  });
+  test("wDivDown(x, x) = WAD", () => {
+    expect(MathLib.wDivDown(7n, 7n)).toBe(MathLib.WAD);
+  });
+  test("wDivUp ceils the division", () => {
+    // 1 / WAD with WAD multiplier => 1/WAD result
+    expect(MathLib.wDivDown(1n, 3n * MathLib.WAD)).toBe(0n);
+    expect(MathLib.wDivUp(1n, 3n * MathLib.WAD)).toBe(1n);
+  });
+  test("wDiv dispatches by direction", () => {
+    expect(MathLib.wDiv(1n, 3n * MathLib.WAD, "Down")).toBe(0n);
+    expect(MathLib.wDiv(1n, 3n * MathLib.WAD, "Up")).toBe(1n);
+  });
+  test("wDiv throws on zero divisor", () => {
+    expect(() => MathLib.wDivDown(1n, 0n)).toThrow(/DIVISION_BY_ZERO/);
+  });
+});
+
+describe("MathLib.wTaylorCompounded", () => {
+  test("returns 0 when n=0", () => {
+    expect(MathLib.wTaylorCompounded(MathLib.WAD, 0n)).toBe(0n);
+  });
+  test("returns positive value for x>0, n>0", () => {
+    const result = MathLib.wTaylorCompounded(MathLib.WAD / 100n, 1n);
+    expect(result).toBeGreaterThan(0n);
+  });
+  test("first term dominates for small x*n", () => {
+    // For tiny x, second/third terms vanish — first term ≈ x*n.
+    const x = 1n;
+    const n = 1n;
+    expect(MathLib.wTaylorCompounded(x, n)).toBe(x * n);
+  });
+  test("monotonically increasing in n", () => {
+    const x = MathLib.WAD / 1000n;
+    const r1 = MathLib.wTaylorCompounded(x, 1n);
+    const r2 = MathLib.wTaylorCompounded(x, 2n);
+    expect(r2).toBeGreaterThan(r1);
+  });
+});
+
+describe("MathLib.wToRay", () => {
+  test("multiplies by 1e9 (WAD -> RAY)", () => {
+    expect(MathLib.wToRay(MathLib.WAD)).toBe(MathLib.RAY);
+  });
+  test("preserves zero", () => {
+    expect(MathLib.wToRay(0n)).toBe(0n);
+  });
+  test("scales arbitrary WAD values", () => {
+    expect(MathLib.wToRay(5n * MathLib.WAD)).toBe(5n * MathLib.RAY);
+  });
+});

--- a/packages/blue-sdk/src/math/SharesMath.test.ts
+++ b/packages/blue-sdk/src/math/SharesMath.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import { SharesMath } from "./SharesMath.js";
+
+describe("SharesMath constants", () => {
+  test("VIRTUAL_SHARES and VIRTUAL_ASSETS match Morpho's hardcoded values", () => {
+    expect(SharesMath.VIRTUAL_SHARES).toBe(1_000_000n);
+    expect(SharesMath.VIRTUAL_ASSETS).toBe(1n);
+  });
+});
+
+describe("SharesMath.toAssets", () => {
+  test("with empty pool, virtual offsets dominate (deposit denial-of-attack)", () => {
+    // shares * (0+1) / (0+VIRTUAL_SHARES) = shares / VIRTUAL_SHARES (rounded)
+    expect(SharesMath.toAssets(SharesMath.VIRTUAL_SHARES, 0n, 0n, "Down")).toBe(
+      1n,
+    );
+    expect(SharesMath.toAssets(0n, 0n, 0n, "Down")).toBe(0n);
+  });
+
+  test("non-empty pool — proportional conversion", () => {
+    // 10 shares of a pool with totalAssets=100, totalShares=1000 -> ~1 asset
+    const r = SharesMath.toAssets(10n, 100n, 1000n, "Down");
+    // (10 * 101) / 1_001_000 = 1010 / 1_001_000 = 0
+    expect(r).toBe(0n);
+  });
+
+  test("rounding direction respected — Up vs Down", () => {
+    const down = SharesMath.toAssets(1n, 1000n, 100n, "Down");
+    const up = SharesMath.toAssets(1n, 1000n, 100n, "Up");
+    expect(up).toBeGreaterThanOrEqual(down);
+  });
+
+  test("monotonic in shares", () => {
+    const a = SharesMath.toAssets(100n, 1_000_000n, 100n, "Down");
+    const b = SharesMath.toAssets(200n, 1_000_000n, 100n, "Down");
+    expect(b).toBeGreaterThan(a);
+  });
+});
+
+describe("SharesMath.toShares", () => {
+  test("with empty pool, mints assets * VIRTUAL_SHARES initially", () => {
+    expect(SharesMath.toShares(1n, 0n, 0n, "Down")).toBe(
+      SharesMath.VIRTUAL_SHARES,
+    );
+  });
+
+  test("returns 0 for 0 assets", () => {
+    expect(SharesMath.toShares(0n, 100n, 1000n, "Down")).toBe(0n);
+  });
+
+  test("rounding direction respected — Up vs Down", () => {
+    const down = SharesMath.toShares(1n, 100n, 1000n, "Down");
+    const up = SharesMath.toShares(1n, 100n, 1000n, "Up");
+    expect(up).toBeGreaterThanOrEqual(down);
+  });
+
+  test("monotonic in assets", () => {
+    const a = SharesMath.toShares(100n, 1_000_000n, 100n, "Down");
+    const b = SharesMath.toShares(200n, 1_000_000n, 100n, "Down");
+    expect(b).toBeGreaterThan(a);
+  });
+});
+
+describe("toAssets <-> toShares round-trip (with virtual offset bias)", () => {
+  test("shares -> assets -> shares ≤ original (because each step rounds down)", () => {
+    const shares = 10_000_000_000n;
+    const totalAssets = 1_000_000n;
+    const totalShares = 100_000_000_000n;
+    const assets = SharesMath.toAssets(
+      shares,
+      totalAssets,
+      totalShares,
+      "Down",
+    );
+    const shares2 = SharesMath.toShares(
+      assets,
+      totalAssets,
+      totalShares,
+      "Down",
+    );
+    expect(shares2).toBeLessThanOrEqual(shares);
+  });
+});

--- a/packages/blue-sdk/src/preLiquidation.test.ts
+++ b/packages/blue-sdk/src/preLiquidation.test.ts
@@ -1,0 +1,97 @@
+import { parseEther } from "viem";
+import { describe, expect, test } from "vitest";
+import { UnsupportedPreLiquidationParamsError } from "./errors.js";
+import {
+  defaultPreLiquidationParamsRegistry,
+  getDefaultPreLiquidationParams,
+} from "./preLiquidation.js";
+
+describe("defaultPreLiquidationParamsRegistry", () => {
+  test("contains the canonical Morpho LLTV tiers", () => {
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.385"))).toBe(
+      true,
+    );
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.625"))).toBe(
+      true,
+    );
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.77"))).toBe(
+      true,
+    );
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.86"))).toBe(
+      true,
+    );
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.915"))).toBe(
+      true,
+    );
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.945"))).toBe(
+      true,
+    );
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.965"))).toBe(
+      true,
+    );
+    expect(defaultPreLiquidationParamsRegistry.has(parseEther("0.98"))).toBe(
+      true,
+    );
+  });
+
+  test("each entry has the five expected fields", () => {
+    for (const [, params] of defaultPreLiquidationParamsRegistry) {
+      expect(typeof params.preLltv).toBe("bigint");
+      expect(typeof params.preLCF1).toBe("bigint");
+      expect(typeof params.preLCF2).toBe("bigint");
+      expect(typeof params.preLIF1).toBe("bigint");
+      expect(typeof params.preLIF2).toBe("bigint");
+    }
+  });
+
+  test("preLCF2 > preLCF1 (close-factor grows with proximity to liquidation)", () => {
+    for (const [, p] of defaultPreLiquidationParamsRegistry) {
+      expect(p.preLCF2).toBeGreaterThan(p.preLCF1);
+    }
+  });
+
+  test("preLIF >= 1 WAD (incentive is non-negative)", () => {
+    for (const [, p] of defaultPreLiquidationParamsRegistry) {
+      expect(p.preLIF1).toBeGreaterThanOrEqual(parseEther("1"));
+      expect(p.preLIF2).toBeGreaterThanOrEqual(parseEther("1"));
+    }
+  });
+
+  test("preLltv is below the corresponding lltv key", () => {
+    for (const [lltv, p] of defaultPreLiquidationParamsRegistry) {
+      expect(p.preLltv).toBeLessThan(lltv);
+    }
+  });
+});
+
+describe("getDefaultPreLiquidationParams", () => {
+  test("returns the registry entry for a known LLTV (bigint)", () => {
+    const lltv = parseEther("0.86");
+    const params = getDefaultPreLiquidationParams(lltv);
+    expect(params).toBe(defaultPreLiquidationParamsRegistry.get(lltv));
+  });
+
+  test("accepts BigIntish (number) for known LLTV", () => {
+    // parseEther("0.86") -> 860_000_000_000_000_000
+    const lltv = 860000000000000000n;
+    const params = getDefaultPreLiquidationParams(lltv);
+    expect(params).toBeDefined();
+  });
+
+  test("throws UnsupportedPreLiquidationParamsError for unknown LLTV", () => {
+    expect(() => getDefaultPreLiquidationParams(parseEther("0.5"))).toThrow(
+      UnsupportedPreLiquidationParamsError,
+    );
+  });
+
+  test("the thrown error preserves the lltv", () => {
+    try {
+      getDefaultPreLiquidationParams(parseEther("0.5"));
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnsupportedPreLiquidationParamsError);
+      expect((e as UnsupportedPreLiquidationParamsError).lltv).toBe(
+        parseEther("0.5"),
+      );
+    }
+  });
+});

--- a/packages/blue-sdk/src/token/ConstantWrappedToken.test.ts
+++ b/packages/blue-sdk/src/token/ConstantWrappedToken.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import type { Address } from "../types.js";
+import { ConstantWrappedToken } from "./ConstantWrappedToken.js";
+
+const WRAPPED: Address = "0x1111111111111111111111111111111111111111";
+const UNDERLYING: Address = "0x2222222222222222222222222222222222222222";
+
+describe("ConstantWrappedToken", () => {
+  test("stores underlying decimals as bigint", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      6,
+    );
+    expect(t.underlyingDecimals).toBe(6n);
+  });
+
+  test("defaults underlying decimals to 0", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+    );
+    expect(t.underlyingDecimals).toBe(0n);
+  });
+
+  test("toWrappedExactAmountIn scales by 10^(wrapped - underlying)", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      6,
+    );
+    // 1e6 underlying (= 1.0 unit) -> 1e18 wrapped (= 1.0 unit)
+    expect(t.toWrappedExactAmountIn(1_000_000n)).toBe(
+      1_000_000_000_000_000_000n,
+    );
+  });
+
+  test("toUnwrappedExactAmountIn is the inverse", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      6,
+    );
+    expect(t.toUnwrappedExactAmountIn(1_000_000_000_000_000_000n)).toBe(
+      1_000_000n,
+    );
+  });
+
+  test("ignores slippage parameter (always treats as 0)", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      6,
+    );
+    const noSlip = t.toWrappedExactAmountIn(1_000_000n);
+    const withSlip = t.toWrappedExactAmountIn(
+      1_000_000n,
+      1_000_000_000_000_000n,
+    );
+    expect(withSlip).toBe(noSlip);
+  });
+
+  test("toWrappedExactAmountOut returns the unwrapped amount required", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      6,
+    );
+    expect(t.toWrappedExactAmountOut(1_000_000_000_000_000_000n)).toBe(
+      1_000_000n,
+    );
+  });
+
+  test("toUnwrappedExactAmountOut returns the wrapped amount required", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      6,
+    );
+    expect(t.toUnwrappedExactAmountOut(1_000_000n)).toBe(
+      1_000_000_000_000_000_000n,
+    );
+  });
+});

--- a/packages/blue-sdk/src/token/ExchangeRateWrappedToken.test.ts
+++ b/packages/blue-sdk/src/token/ExchangeRateWrappedToken.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import { MathLib } from "../math/MathLib.js";
+import type { Address } from "../types.js";
+import { ExchangeRateWrappedToken } from "./ExchangeRateWrappedToken.js";
+
+const WRAPPED: Address = "0x1111111111111111111111111111111111111111";
+const UNDERLYING: Address = "0x2222222222222222222222222222222222222222";
+
+describe("ExchangeRateWrappedToken", () => {
+  test("stores rate and underlying address", () => {
+    const t = new ExchangeRateWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      2n * MathLib.WAD,
+    );
+    expect(t.underlying).toBe(UNDERLYING);
+    expect(t.wrappedTokenExchangeRate).toBe(2n * MathLib.WAD);
+  });
+
+  test("with rate=2.0, wrap 1 unwrapped -> 0.5 wrapped (rounded down)", () => {
+    const t = new ExchangeRateWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      2n * MathLib.WAD,
+    );
+    // 1 WAD / 2 WAD * WAD = 0.5 WAD
+    expect(t.toWrappedExactAmountIn(MathLib.WAD)).toBe(MathLib.WAD / 2n);
+  });
+
+  test("with rate=2.0, unwrap 1 wrapped -> 2 unwrapped", () => {
+    const t = new ExchangeRateWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      2n * MathLib.WAD,
+    );
+    // 1 WAD * 2 WAD / WAD = 2 WAD
+    expect(t.toUnwrappedExactAmountIn(MathLib.WAD)).toBe(2n * MathLib.WAD);
+  });
+
+  test("round-trip without slippage is exact for whole rates", () => {
+    const t = new ExchangeRateWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      4n * MathLib.WAD,
+    );
+    const wrapped = t.toWrappedExactAmountIn(MathLib.WAD);
+    const back = t.toUnwrappedExactAmountIn(wrapped);
+    expect(back).toBe(MathLib.WAD);
+  });
+
+  test("slippage reduces toWrappedExactAmountIn", () => {
+    const t = new ExchangeRateWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      MathLib.WAD,
+    );
+    const noSlip = t.toWrappedExactAmountIn(MathLib.WAD);
+    const slip = t.toWrappedExactAmountIn(MathLib.WAD, MathLib.WAD / 100n);
+    expect(slip).toBeLessThan(noSlip);
+  });
+});

--- a/packages/blue-sdk/src/token/Token.test.ts
+++ b/packages/blue-sdk/src/token/Token.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import { ChainId } from "../chain.js";
+import { MathLib } from "../math/MathLib.js";
+import type { Address } from "../types.js";
+import { Token } from "./Token.js";
+
+const ADDRESS = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
+
+describe("Token constructor", () => {
+  test("stores all fields", () => {
+    const t = new Token({
+      address: ADDRESS,
+      name: "USD Coin",
+      symbol: "USDC",
+      decimals: 6,
+      price: 1_000_000_000_000_000_000n,
+    });
+    expect(t.address).toBe(ADDRESS);
+    expect(t.name).toBe("USD Coin");
+    expect(t.symbol).toBe("USDC");
+    expect(t.decimals).toBe(6);
+    expect(t.price).toBe(MathLib.WAD);
+  });
+
+  test("decimals defaults to 0", () => {
+    const t = new Token({ address: ADDRESS });
+    expect(t.decimals).toBe(0);
+  });
+
+  test("decimals coerces from BigIntish", () => {
+    expect(new Token({ address: ADDRESS, decimals: 18n }).decimals).toBe(18);
+    expect(new Token({ address: ADDRESS, decimals: "8" }).decimals).toBe(8);
+  });
+
+  test("price is undefined when omitted", () => {
+    const t = new Token({ address: ADDRESS, decimals: 6 });
+    expect(t.price).toBeUndefined();
+  });
+
+  test("price coerces from BigIntish", () => {
+    expect(new Token({ address: ADDRESS, price: 1n }).price).toBe(1n);
+    expect(new Token({ address: ADDRESS, price: "2" }).price).toBe(2n);
+    expect(new Token({ address: ADDRESS, price: 3 }).price).toBe(3n);
+  });
+});
+
+describe("Token.native", () => {
+  test("returns a Token with the chain's native currency metadata", () => {
+    const eth = Token.native(ChainId.EthMainnet);
+    expect(eth.symbol).toBe("ETH");
+    expect(eth.decimals).toBe(18);
+    expect(eth.address).toBeDefined();
+  });
+});
+
+describe("Token.toUsd / fromUsd round-trip", () => {
+  test("returns undefined when price is unknown", () => {
+    const t = new Token({ address: ADDRESS, decimals: 18 });
+    expect(t.toUsd(1n)).toBeUndefined();
+    expect(t.fromUsd(1n)).toBeUndefined();
+  });
+
+  test("toUsd: amount * price / 10^decimals", () => {
+    // 1 USDC at $1 -> 1 * 1e18 / 1e6 = 1e12 ... wait — price is in WAD scale.
+    // For a $1 token with 6 decimals, price=1e18 means 1 token = $1.
+    const usdc = new Token({
+      address: ADDRESS,
+      decimals: 6,
+      price: MathLib.WAD,
+    });
+    expect(usdc.toUsd(1_000_000n)).toBe(MathLib.WAD); // 1 USDC -> 1 USD (WAD)
+  });
+
+  test("fromUsd: amount * 10^decimals / price", () => {
+    const usdc = new Token({
+      address: ADDRESS,
+      decimals: 6,
+      price: MathLib.WAD,
+    });
+    expect(usdc.fromUsd(MathLib.WAD)).toBe(1_000_000n); // $1 -> 1 USDC
+  });
+
+  test("rounding direction propagates", () => {
+    // amount * 10^decimals / price with rounding
+    const t = new Token({ address: ADDRESS, decimals: 0, price: 3n });
+    // amount=1, 10^0=1, price=3 -> 1/3 = 0 (Down) or 1 (Up)
+    expect(t.fromUsd(1n, "Down")).toBe(0n);
+    expect(t.fromUsd(1n, "Up")).toBe(1n);
+  });
+});

--- a/packages/blue-sdk/src/user/User.test.ts
+++ b/packages/blue-sdk/src/user/User.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import type { Address } from "../types.js";
+import { User } from "./User.js";
+
+const ADDR: Address = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
+
+describe("User", () => {
+  test("stores all fields", () => {
+    const u = new User({
+      address: ADDR,
+      isBundlerAuthorized: true,
+      morphoNonce: 5n,
+    });
+    expect(u.address).toBe(ADDR);
+    expect(u.isBundlerAuthorized).toBe(true);
+    expect(u.morphoNonce).toBe(5n);
+  });
+
+  test("isBundlerAuthorized and morphoNonce are mutable", () => {
+    const u = new User({
+      address: ADDR,
+      isBundlerAuthorized: false,
+      morphoNonce: 0n,
+    });
+    u.isBundlerAuthorized = true;
+    u.morphoNonce = 999n;
+    expect(u.isBundlerAuthorized).toBe(true);
+    expect(u.morphoNonce).toBe(999n);
+  });
+});

--- a/packages/blue-sdk/src/vault/VaultConfig.test.ts
+++ b/packages/blue-sdk/src/vault/VaultConfig.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import type { Address } from "../types.js";
+import { VaultConfig } from "./VaultConfig.js";
+
+const VAULT: Address = "0x1111111111111111111111111111111111111111";
+const ASSET: Address = "0x2222222222222222222222222222222222222222";
+
+describe("VaultConfig", () => {
+  test("forces decimals to 18 (vault token decimals)", () => {
+    const c = new VaultConfig({
+      address: VAULT,
+      symbol: "vUSDC",
+      asset: ASSET,
+      decimalsOffset: 12,
+    });
+    expect(c.decimals).toBe(18);
+  });
+
+  test("stores asset and decimalsOffset (coerced to bigint)", () => {
+    const c = new VaultConfig({
+      address: VAULT,
+      asset: ASSET,
+      decimalsOffset: 12,
+    });
+    expect(c.asset).toBe(ASSET);
+    expect(c.decimalsOffset).toBe(12n);
+  });
+
+  test("accepts decimalsOffset as bigint and string", () => {
+    expect(
+      new VaultConfig({
+        address: VAULT,
+        asset: ASSET,
+        decimalsOffset: 6n,
+      }).decimalsOffset,
+    ).toBe(6n);
+    expect(
+      new VaultConfig({
+        address: VAULT,
+        asset: ASSET,
+        decimalsOffset: "8",
+      }).decimalsOffset,
+    ).toBe(8n);
+  });
+
+  test("preserves Token base fields (name, symbol)", () => {
+    const c = new VaultConfig({
+      address: VAULT,
+      name: "Yield USDC",
+      symbol: "yUSDC",
+      asset: ASSET,
+      decimalsOffset: 12,
+    });
+    expect(c.name).toBe("Yield USDC");
+    expect(c.symbol).toBe("yUSDC");
+  });
+});

--- a/packages/blue-sdk/src/vault/VaultMarketPublicAllocatorConfig.test.ts
+++ b/packages/blue-sdk/src/vault/VaultMarketPublicAllocatorConfig.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import type { Address, MarketId } from "../types.js";
+import { VaultMarketPublicAllocatorConfig } from "./VaultMarketPublicAllocatorConfig.js";
+
+const VAULT: Address = "0x1111111111111111111111111111111111111111";
+const MARKET: MarketId =
+  "0x0000000000000000000000000000000000000000000000000000000000000001" as MarketId;
+
+describe("VaultMarketPublicAllocatorConfig", () => {
+  test("stores all four fields", () => {
+    const c = new VaultMarketPublicAllocatorConfig({
+      vault: VAULT,
+      marketId: MARKET,
+      maxIn: 100n,
+      maxOut: 50n,
+    });
+    expect(c.vault).toBe(VAULT);
+    expect(c.marketId).toBe(MARKET);
+    expect(c.maxIn).toBe(100n);
+    expect(c.maxOut).toBe(50n);
+  });
+
+  test("maxIn and maxOut are mutable; vault and marketId are readonly to TS", () => {
+    const c = new VaultMarketPublicAllocatorConfig({
+      vault: VAULT,
+      marketId: MARKET,
+      maxIn: 0n,
+      maxOut: 0n,
+    });
+    c.maxIn = 1n;
+    c.maxOut = 2n;
+    expect(c.maxIn).toBe(1n);
+    expect(c.maxOut).toBe(2n);
+  });
+});

--- a/packages/blue-sdk/src/vault/VaultUser.test.ts
+++ b/packages/blue-sdk/src/vault/VaultUser.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import type { Address } from "../types.js";
+import { VaultUser } from "./VaultUser.js";
+
+const VAULT: Address = "0x1111111111111111111111111111111111111111";
+const USER: Address = "0x2222222222222222222222222222222222222222";
+
+describe("VaultUser", () => {
+  test("stores all fields", () => {
+    const u = new VaultUser({
+      vault: VAULT,
+      user: USER,
+      isAllocator: true,
+      allowance: 100n,
+    });
+    expect(u.vault).toBe(VAULT);
+    expect(u.user).toBe(USER);
+    expect(u.isAllocator).toBe(true);
+    expect(u.allowance).toBe(100n);
+  });
+
+  test("isAllocator and allowance can be reassigned (mutable)", () => {
+    const u = new VaultUser({
+      vault: VAULT,
+      user: USER,
+      isAllocator: false,
+      allowance: 0n,
+    });
+    u.isAllocator = true;
+    u.allowance = 999n;
+    expect(u.isAllocator).toBe(true);
+    expect(u.allowance).toBe(999n);
+  });
+});

--- a/packages/blue-sdk/tsconfig.build.cjs.json
+++ b/packages/blue-sdk/tsconfig.build.cjs.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/cjs",
     "tsBuildInfoFile": "tsconfig.cjs.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/blue-sdk/tsconfig.build.esm.json
+++ b/packages/blue-sdk/tsconfig.build.esm.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/esm",
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,10 @@ export default defineConfig({
         extends: true,
         test: {
           name: "blue-sdk",
-          include: ["packages/blue-sdk/test/**/*.test.ts"],
+          include: [
+            "packages/blue-sdk/test/**/*.test.ts",
+            "packages/blue-sdk/src/**/*.test.ts",
+          ],
         },
       },
       {


### PR DESCRIPTION
Implements **Phase 3** of TIB-2026-04-27 (#556). Stacked on Phase 2 (#586).

## What lands

14 new colocated `*.test.ts` files in `packages/blue-sdk/src/`. **Existing `test/unit/` and `test/e2e/` files are not moved or modified.**

## Coverage delta (line)

| File | Before | After |
| --- | --- | --- |
| `holding/AssetBalances.ts` | 0% | **100%** |
| `token/ExchangeRateWrappedToken.ts` | 0% | **100%** |
| `vault/VaultUser.ts` | 0% | **100%** |
| `math/MathLib.ts` | (partial) | **100%** |
| `math/SharesMath.ts` | (partial) | **100%** |
| `math/AdaptiveCurveIrmLib.ts` | (partial) | **100%** |
| `errors.ts` | (partial) | **100%** |
| `preLiquidation.ts` | (partial) | **100%** |
| `token/Token.ts` | (partial) | **100%** |
| `token/WrappedToken.ts` | (partial) | **100%** |
| `token/ConstantWrappedToken.ts` | (partial) | **100%** |
| `user/User.ts` | (partial) | **100%** |
| `vault/VaultConfig.ts` | (partial) | **100%** |
| `vault/VaultMarketPublicAllocatorConfig.ts` | (partial) | **100%** |

148 tests pass.

## Out of scope for this PR

The very large classes (`Market.ts` 812 LOC, `MarketUtils.ts` 630 LOC, `Vault.ts` 459 LOC, `Position.ts` 342 LOC, `VaultV2.ts` 288 LOC and adapters) are still partly covered by existing `test/unit/` files. Their colocated unit-test extension can land in a follow-up.

## Test plan
- [x] `pnpm test --project blue-sdk --run packages/blue-sdk/src` → 13 files, 148 tests pass.
- [x] `pnpm --filter @morpho-org/blue-sdk build` succeeds.
- [x] `find packages/blue-sdk/lib -name "*.test.*"` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->