### PR TITLE
fix(permit): verify EIP-712 domain on-chain instead of guessing

### DIFF
--- a/.changeset/permit-domain-verification.md
+++ b/.changeset/permit-domain-verification.md
@@ -1,0 +1,24 @@
+---
+"@morpho-org/blue-sdk-viem": minor
+"@morpho-org/morpho-sdk": minor
+"@morpho-org/bundler-sdk-viem": minor
+"@morpho-org/migration-sdk-viem": minor
+---
+
+Verify ERC-2612 permit domains on-chain instead of guessing them from token metadata.
+
+`getPermitTypedData` no longer falls back to a hand-maintained `(name, "1" | "2")`
+heuristic when EIP-5267 metadata is missing. It either uses an EIP-5267 domain or a
+caller-supplied verified domain, otherwise it throws the new
+`UnverifiablePermitDomainError`.
+
+A new `getVerifiedPermitDomain(client, params)` helper discovers a token's EIP-712
+permit domain by reading its on-chain `DOMAIN_SEPARATOR()` and matching it against
+candidate `(name, version)` pairs (defaults: `(token.name, "1" | "2")`, plus optional
+`extraCandidates`). It returns `null` when no candidate matches.
+
+`getRequirements` now routes to simple permit only when the domain can be verified
+this way; otherwise it falls back to Permit2. The previous behaviour silently signed
+a guessed domain, producing a locally valid signature whose on-chain `permit()` call
+reverted. `bundler-sdk-viem` and `migration-sdk-viem` permit signers verify the
+domain before signing as well.

--- a/packages/blue-sdk-viem/src/error.ts
+++ b/packages/blue-sdk-viem/src/error.ts
@@ -7,7 +7,7 @@ export class InvalidPermitDomainChainIdError extends Error {
   constructor(
     public readonly token: Address,
     public readonly expectedChainId: ChainId,
-    public readonly domainChainId: number | undefined,
+    public readonly domainChainId: number | bigint | undefined,
   ) {
     super(
       `Invalid permit domain chain ID for token "${token}": expected "${expectedChainId}", got "${domainChainId}"`,
@@ -23,6 +23,20 @@ export class InvalidPermitDomainVerifyingContractError extends Error {
   ) {
     super(
       `Invalid permit domain verifying contract: expected "${token}", got "${domainVerifyingContract}"`,
+    );
+  }
+}
+
+/**
+ * Thrown when a token's EIP-712 permit domain cannot be discovered: the token
+ * exposes neither EIP-5267 introspection nor a `DOMAIN_SEPARATOR()` matching
+ * any candidate domain. Consumers should fall back to another approval path
+ * (e.g. Permit2) rather than sign an unverified domain.
+ */
+export class UnverifiablePermitDomainError extends Error {
+  constructor(public readonly token: Address) {
+    super(
+      `Unverifiable permit domain for token "${token}": no EIP-5267 metadata and no candidate domain matched the on-chain DOMAIN_SEPARATOR. Use Permit2 or pass a verified domain explicitly.`,
     );
   }
 }

--- a/packages/blue-sdk-viem/src/signatures/permit.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit.ts
@@ -4,11 +4,22 @@ import {
   getChainAddresses,
   type Token,
 } from "@morpho-org/blue-sdk";
-import { isAddressEqual, type TypedDataDefinition } from "viem";
+import {
+  type Client,
+  domainSeparator,
+  erc20Abi,
+  isAddressEqual,
+  type TypedDataDefinition,
+  type TypedDataDomain,
+} from "viem";
+import { readContract } from "viem/actions";
+import { erc2612Abi } from "../abis.js";
 import {
   InvalidPermitDomainChainIdError,
   InvalidPermitDomainVerifyingContractError,
+  UnverifiablePermitDomainError,
 } from "../error.js";
+import type { FetchParameters } from "../types.js";
 
 export interface PermitArgs {
   erc20: Token;
@@ -30,45 +41,98 @@ const permitTypes = {
 } as const;
 
 /**
- * Permit signature for ERC20 tokens, following EIP-2612.
- * Fails closed when fetched EIP-5267 metadata is not bound to the token and chain.
- * Consumers should use another approval path instead of signing an unsafe domain.
+ * Asserts that an EIP-712 domain binds to the expected token and chain,
+ * throwing the dedicated typed errors otherwise. Used by both static
+ * (EIP-5267) and discovered (`DOMAIN_SEPARATOR`) domain paths so callers
+ * cannot accidentally sign a domain pointing to a different token/chain.
+ *
+ * @param token - The token whose permit will be signed.
+ * @param chainId - The expected chain id.
+ * @param domain - The candidate EIP-712 domain.
+ * @throws {InvalidPermitDomainChainIdError} if the domain chain does not match.
+ * @throws {InvalidPermitDomainVerifyingContractError} if the verifying contract is missing or differs from the token address.
+ */
+// biome-ignore lint/complexity/useMaxParams: triple is intentional: token, expected chainId, candidate domain
+const assertDomainBinds = (
+  token: Address,
+  chainId: ChainId,
+  domain: TypedDataDomain,
+): void => {
+  if (domain.chainId !== chainId) {
+    throw new InvalidPermitDomainChainIdError(token, chainId, domain.chainId);
+  }
+
+  if (
+    domain.verifyingContract == null ||
+    !isAddressEqual(domain.verifyingContract, token)
+  ) {
+    throw new InvalidPermitDomainVerifyingContractError(
+      token,
+      domain.verifyingContract,
+    );
+  }
+};
+
+export interface GetPermitTypedDataOptions {
+  /**
+   * A pre-verified EIP-712 domain. When provided it takes precedence over
+   * `erc20.eip5267Domain` and the function never falls back to guessing.
+   * Obtain one from {@link getVerifiedPermitDomain}.
+   */
+  domain?: TypedDataDomain;
+}
+
+/**
+ * Builds EIP-2612 permit typed data for an ERC-20 token. The signing domain
+ * comes from one of three sources, in order:
+ *
+ * 1. An explicit, pre-verified `options.domain` (preferred — see
+ *    {@link getVerifiedPermitDomain}).
+ * 2. The token's EIP-5267 metadata (`erc20.eip5267Domain.eip712Domain`).
+ *
+ * If neither is available the function fails closed with
+ * {@link UnverifiablePermitDomainError} rather than guessing a domain from
+ * ERC-20 metadata. Callers that need to support tokens without EIP-5267 must
+ * resolve the domain on-chain first via {@link getVerifiedPermitDomain}.
+ *
+ * @param args - Permit arguments (token, owner, spender, allowance, nonce, deadline).
+ * @param chainId - The chain on which the permit will be submitted.
+ * @param options - Optional pre-verified domain.
+ * @returns A `TypedDataDefinition` ready to pass to `signTypedData`.
+ * @throws {InvalidPermitDomainChainIdError} if a provided domain targets another chain.
+ * @throws {InvalidPermitDomainVerifyingContractError} if a provided domain targets another token.
+ * @throws {UnverifiablePermitDomainError} if no verified domain is available.
+ *
+ * @example
+ * ```ts
+ * import { getPermitTypedData, getVerifiedPermitDomain } from "@morpho-org/blue-sdk-viem";
+ *
+ * const domain = await getVerifiedPermitDomain(client, { token, chainId });
+ * if (domain == null) {
+ *   // Fall back to Permit2.
+ *   return;
+ * }
+ * const typedData = getPermitTypedData(args, chainId, { domain });
+ * ```
+ *
  * Docs: https://eips.ethereum.org/EIPS/eip-2612
  */
+// biome-ignore lint/complexity/useMaxParams: kept signature stable; verifier path uses `options`
 export const getPermitTypedData = (
   { deadline, owner, nonce, spender, erc20, allowance }: PermitArgs,
   chainId: ChainId,
+  options: GetPermitTypedDataOptions = {},
 ): TypedDataDefinition<typeof permitTypes, "Permit"> => {
-  const { usdc, eurc } = getChainAddresses(chainId);
+  const explicitDomain = options.domain;
+  const eip5267Domain = erc20.eip5267Domain?.eip712Domain;
 
-  const domain = erc20.eip5267Domain?.eip712Domain;
+  const permitDomain = explicitDomain ?? eip5267Domain;
 
-  if (domain != null) {
-    if (domain.chainId !== chainId) {
-      throw new InvalidPermitDomainChainIdError(
-        erc20.address,
-        chainId,
-        domain.chainId,
-      );
-    }
-
-    if (
-      domain.verifyingContract == null ||
-      !isAddressEqual(domain.verifyingContract, erc20.address)
-    ) {
-      throw new InvalidPermitDomainVerifyingContractError(
-        erc20.address,
-        domain.verifyingContract,
-      );
-    }
+  if (permitDomain == null) {
+    throw new UnverifiablePermitDomainError(erc20.address);
   }
 
-  const permitDomain = domain ?? {
-    name: erc20.name,
-    version: erc20.address === usdc || erc20.address === eurc ? "2" : "1",
-    chainId,
-    verifyingContract: erc20.address,
-  };
+  assertDomainBinds(erc20.address, chainId, permitDomain);
 
   return {
     domain: permitDomain,
@@ -82,6 +146,134 @@ export const getPermitTypedData = (
     },
     primaryType: "Permit",
   };
+};
+
+export interface PermitDomainCandidate {
+  /** EIP-712 `name` field of the candidate domain. */
+  name: string;
+  /** EIP-712 `version` field of the candidate domain. */
+  version: string;
+}
+
+export type GetVerifiedPermitDomainParameters = FetchParameters & {
+  /** The ERC-20 token address. */
+  token: Address;
+  /** The chain on which the permit will be submitted. */
+  chainId: ChainId;
+  /**
+   * Optional ERC-20 token name, e.g. fetched from a `Token` instance. When
+   * omitted the token name is read on-chain. Used to seed the default
+   * candidate set.
+   */
+  tokenName?: string;
+  /**
+   * Optional EIP-5267 domain already known for the token. When present and
+   * bound to the token+chain it is returned immediately, skipping the
+   * `DOMAIN_SEPARATOR()` discovery path.
+   */
+  knownDomain?: TypedDataDomain;
+  /**
+   * Extra `(name, version)` candidates to try when discovering the domain via
+   * `DOMAIN_SEPARATOR()`. Useful for tokens whose EIP-712 `name` field does not
+   * match the on-chain `name()` (e.g. legacy USDC: `"USD Coin"`).
+   * Tried after the default candidates derived from `tokenName`.
+   */
+  extraCandidates?: readonly PermitDomainCandidate[];
+};
+
+/**
+ * Default `version` strings tried against the on-chain `DOMAIN_SEPARATOR()`
+ * during permit domain discovery. Order matters: `"1"` is by far the most
+ * common, `"2"` covers tokens like USDC and EURC.
+ */
+export const DEFAULT_PERMIT_DOMAIN_VERSIONS = ["1", "2"] as const;
+
+/**
+ * Discovers an ERC-2612 token's EIP-712 permit domain in a fail-closed manner.
+ *
+ * - If a `knownDomain` (typically `Token.eip5267Domain.eip712Domain`) is
+ *   provided and binds to the token and chain, returns it directly.
+ * - Otherwise reads the token's `DOMAIN_SEPARATOR()` and tries each candidate
+ *   `(name, version)` pair, returning the first whose hash matches.
+ * - Returns `null` when neither path yields a match. Consumers must treat
+ *   `null` as "simple permit unsupported" and fall back to Permit2 or classic
+ *   approval; never sign a fabricated domain.
+ *
+ * The default candidate set is `(tokenName, version)` for each version in
+ * {@link DEFAULT_PERMIT_DOMAIN_VERSIONS}, where `tokenName` is the parameter,
+ * the on-chain `name()`, or both. Callers may extend the set via
+ * `extraCandidates` without touching this package.
+ *
+ * @param client - A viem client connected to the target chain.
+ * @param params - {@link GetVerifiedPermitDomainParameters}.
+ * @returns The verified domain or `null` when no candidate matched.
+ * @throws {InvalidPermitDomainChainIdError} if `knownDomain` targets another chain.
+ * @throws {InvalidPermitDomainVerifyingContractError} if `knownDomain` targets another token.
+ *
+ * @example
+ * ```ts
+ * import { getVerifiedPermitDomain } from "@morpho-org/blue-sdk-viem";
+ *
+ * const domain = await getVerifiedPermitDomain(client, {
+ *   token: usdc,
+ *   chainId: 1,
+ *   tokenName: "USDC",
+ *   extraCandidates: [{ name: "USD Coin", version: "2" }],
+ * });
+ * ```
+ */
+export const getVerifiedPermitDomain = async (
+  client: Client,
+  params: GetVerifiedPermitDomainParameters,
+): Promise<TypedDataDomain | null> => {
+  const { token, chainId, knownDomain, tokenName, extraCandidates, ...rest } =
+    params;
+
+  if (knownDomain != null) {
+    assertDomainBinds(token, chainId, knownDomain);
+    return knownDomain;
+  }
+
+  const onchainSeparator = await readContract(client, {
+    ...rest,
+    address: token,
+    abi: erc2612Abi,
+    functionName: "DOMAIN_SEPARATOR",
+  }).catch(() => undefined);
+
+  if (onchainSeparator == null) return null;
+
+  const resolvedName =
+    tokenName ??
+    (await readContract(client, {
+      ...rest,
+      address: token,
+      abi: erc20Abi,
+      functionName: "name",
+    }).catch(() => undefined));
+
+  const candidates: PermitDomainCandidate[] = [];
+  if (typeof resolvedName === "string" && resolvedName.length > 0) {
+    for (const version of DEFAULT_PERMIT_DOMAIN_VERSIONS) {
+      candidates.push({ name: resolvedName, version });
+    }
+  }
+  if (extraCandidates) candidates.push(...extraCandidates);
+
+  for (const candidate of candidates) {
+    const domain: TypedDataDomain = {
+      name: candidate.name,
+      version: candidate.version,
+      chainId,
+      verifyingContract: token,
+    };
+
+    if (domainSeparator({ domain }) === onchainSeparator) {
+      return domain;
+    }
+  }
+
+  return null;
 };
 
 export interface DaiPermitArgs {

--- a/packages/blue-sdk-viem/test/Permit.test.ts
+++ b/packages/blue-sdk-viem/test/Permit.test.ts
@@ -1,12 +1,28 @@
 import { ChainId, Eip5267Domain, Token } from "@morpho-org/blue-sdk";
 import { randomAddress } from "@morpho-org/test";
-import { zeroHash } from "viem";
+import {
+  type Address,
+  createClient,
+  custom,
+  domainSeparator,
+  type EIP1193RequestFn,
+  encodeAbiParameters,
+  type Hex,
+  type TypedDataDomain,
+  toHex,
+  zeroHash,
+} from "viem";
+import { mainnet } from "viem/chains";
 import { describe, expect, test } from "vitest";
 import {
   InvalidPermitDomainChainIdError,
   InvalidPermitDomainVerifyingContractError,
+  UnverifiablePermitDomainError,
 } from "../src/error.js";
-import { getPermitTypedData } from "../src/signatures/permit.js";
+import {
+  getPermitTypedData,
+  getVerifiedPermitDomain,
+} from "../src/signatures/permit.js";
 
 const owner = randomAddress();
 
@@ -54,6 +70,54 @@ describe("getPermitTypedData", () => {
       chainId: ChainId.EthMainnet,
       verifyingContract: token.address,
     });
+  });
+
+  test("uses an explicit verified domain over EIP-5267", () => {
+    const token = tokenWithDomain();
+    const explicit: TypedDataDomain = {
+      name: "Override",
+      version: "2",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token.address,
+    };
+
+    const typedData = getPermitTypedData(
+      permitArgs(token),
+      ChainId.EthMainnet,
+      { domain: explicit },
+    );
+
+    expect(typedData.domain).toStrictEqual(explicit);
+  });
+
+  test("throws UnverifiablePermitDomainError when no domain is available", () => {
+    const address = randomAddress();
+    const tokenWithoutDomain = new Token({ address, name: "Token" });
+
+    expect(() =>
+      getPermitTypedData(permitArgs(tokenWithoutDomain), ChainId.EthMainnet),
+    ).toThrow(new UnverifiablePermitDomainError(address));
+  });
+
+  test("throws when an explicit domain points to another token", () => {
+    const token = tokenWithDomain();
+    const verifyingContract = randomAddress();
+
+    expect(() =>
+      getPermitTypedData(permitArgs(token), ChainId.EthMainnet, {
+        domain: {
+          name: "Token",
+          version: "1",
+          chainId: ChainId.EthMainnet,
+          verifyingContract,
+        },
+      }),
+    ).toThrow(
+      new InvalidPermitDomainVerifyingContractError(
+        token.address,
+        verifyingContract,
+      ),
+    );
   });
 
   test("throws when fetched EIP-5267 domain points to another token", () => {
@@ -119,5 +183,232 @@ describe("getPermitTypedData", () => {
         undefined,
       ),
     );
+  });
+});
+
+const ERC20_NAME_SELECTOR = "0x06fdde03";
+const ERC2612_DOMAIN_SEPARATOR_SELECTOR = "0x3644e515";
+
+const encodeStringReturn = (value: string): Hex => {
+  return encodeAbiParameters([{ type: "string" }], [value]);
+};
+
+const mockTokenClient = (
+  token: Address,
+  responses: { domainSeparator: Hex; name?: string },
+) => {
+  const request = (async ({ method, params }) => {
+    if (method === "eth_chainId") return toHex(mainnet.id);
+    if (method === "eth_call") {
+      const [{ data, to }] = params as [{ data: Hex; to: Address }];
+      if (to.toLowerCase() !== token.toLowerCase())
+        throw new Error(`unexpected to: ${to}`);
+      if (data.startsWith(ERC2612_DOMAIN_SEPARATOR_SELECTOR))
+        return responses.domainSeparator;
+      if (data.startsWith(ERC20_NAME_SELECTOR)) {
+        if (responses.name == null) throw new Error("name() reverted");
+        return encodeStringReturn(responses.name);
+      }
+      throw new Error(`unexpected call: ${data}`);
+    }
+    throw new Error(`unexpected method: ${method}`);
+  }) as EIP1193RequestFn;
+
+  return createClient({
+    chain: mainnet,
+    transport: custom({ request }),
+  });
+};
+
+describe("getVerifiedPermitDomain", () => {
+  test("returns knownDomain immediately when bound to token and chain", async () => {
+    const token = randomAddress();
+    const knownDomain: TypedDataDomain = {
+      name: "Whatever",
+      version: "9",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token,
+    };
+
+    // Client is never called because knownDomain short-circuits the discovery.
+    const client = createClient({
+      chain: mainnet,
+      transport: custom({
+        request: async () => {
+          throw new Error("client should not be called");
+        },
+      }),
+    });
+
+    const domain = await getVerifiedPermitDomain(client, {
+      token,
+      chainId: ChainId.EthMainnet,
+      knownDomain,
+    });
+
+    expect(domain).toStrictEqual(knownDomain);
+  });
+
+  test("matches default candidate (name, version: '1') against on-chain DOMAIN_SEPARATOR", async () => {
+    const token = randomAddress();
+    const trueDomain: TypedDataDomain = {
+      name: "Random Token",
+      version: "1",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token,
+    };
+
+    const client = mockTokenClient(token, {
+      domainSeparator: domainSeparator({ domain: trueDomain }),
+      name: "Random Token",
+    });
+
+    const domain = await getVerifiedPermitDomain(client, {
+      token,
+      chainId: ChainId.EthMainnet,
+      tokenName: "Random Token",
+    });
+
+    expect(domain).toStrictEqual(trueDomain);
+  });
+
+  test("matches default candidate (name, version: '2') against on-chain DOMAIN_SEPARATOR", async () => {
+    const token = randomAddress();
+    const trueDomain: TypedDataDomain = {
+      name: "USDC",
+      version: "2",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token,
+    };
+
+    const client = mockTokenClient(token, {
+      domainSeparator: domainSeparator({ domain: trueDomain }),
+      name: "USDC",
+    });
+
+    const domain = await getVerifiedPermitDomain(client, {
+      token,
+      chainId: ChainId.EthMainnet,
+      tokenName: "USDC",
+    });
+
+    expect(domain).toStrictEqual(trueDomain);
+  });
+
+  test("matches an extra candidate when the on-chain name differs from the EIP-712 name", async () => {
+    const token = randomAddress();
+    const trueDomain: TypedDataDomain = {
+      name: "USD Coin",
+      version: "2",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token,
+    };
+
+    const client = mockTokenClient(token, {
+      domainSeparator: domainSeparator({ domain: trueDomain }),
+      name: "USDC",
+    });
+
+    const domain = await getVerifiedPermitDomain(client, {
+      token,
+      chainId: ChainId.EthMainnet,
+      tokenName: "USDC",
+      extraCandidates: [{ name: "USD Coin", version: "2" }],
+    });
+
+    expect(domain).toStrictEqual(trueDomain);
+  });
+
+  test("returns null when no candidate matches the on-chain DOMAIN_SEPARATOR", async () => {
+    const token = randomAddress();
+    const otherDomain: TypedDataDomain = {
+      name: "Other",
+      version: "3",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token,
+    };
+
+    const client = mockTokenClient(token, {
+      domainSeparator: domainSeparator({ domain: otherDomain }),
+      name: "Token",
+    });
+
+    const domain = await getVerifiedPermitDomain(client, {
+      token,
+      chainId: ChainId.EthMainnet,
+      tokenName: "Token",
+    });
+
+    expect(domain).toBeNull();
+  });
+
+  test("returns null when DOMAIN_SEPARATOR() reverts", async () => {
+    const token = randomAddress();
+
+    const client = createClient({
+      chain: mainnet,
+      transport: custom({
+        request: async ({ method }) => {
+          if (method === "eth_chainId") return toHex(mainnet.id);
+          throw new Error("DOMAIN_SEPARATOR reverted");
+        },
+      }),
+    });
+
+    const domain = await getVerifiedPermitDomain(client, {
+      token,
+      chainId: ChainId.EthMainnet,
+      tokenName: "Token",
+    });
+
+    expect(domain).toBeNull();
+  });
+
+  test("falls back to on-chain name() when tokenName is omitted", async () => {
+    const token = randomAddress();
+    const trueDomain: TypedDataDomain = {
+      name: "Discovered",
+      version: "1",
+      chainId: ChainId.EthMainnet,
+      verifyingContract: token,
+    };
+
+    const client = mockTokenClient(token, {
+      domainSeparator: domainSeparator({ domain: trueDomain }),
+      name: "Discovered",
+    });
+
+    const domain = await getVerifiedPermitDomain(client, {
+      token,
+      chainId: ChainId.EthMainnet,
+    });
+
+    expect(domain).toStrictEqual(trueDomain);
+  });
+
+  test("rejects a knownDomain bound to another chain", async () => {
+    const token = randomAddress();
+
+    const client = createClient({
+      chain: mainnet,
+      transport: custom({
+        request: async () => {
+          throw new Error("client should not be called");
+        },
+      }),
+    });
+
+    await expect(
+      getVerifiedPermitDomain(client, {
+        token,
+        chainId: ChainId.EthMainnet,
+        knownDomain: {
+          name: "Token",
+          version: "1",
+          chainId: ChainId.PolygonMainnet,
+          verifyingContract: token,
+        },
+      }),
+    ).rejects.toBeInstanceOf(InvalidPermitDomainChainIdError);
   });
 });

--- a/packages/bundler-sdk-viem/src/actions.ts
+++ b/packages/bundler-sdk-viem/src/actions.ts
@@ -13,6 +13,8 @@ import {
   getDaiPermitTypedData,
   getPermit2PermitTypedData,
   getPermitTypedData,
+  getVerifiedPermitDomain,
+  UnverifiablePermitDomainError,
 } from "@morpho-org/blue-sdk-viem";
 import { getValue, Time } from "@morpho-org/morpho-ts";
 import {
@@ -300,6 +302,16 @@ export const encodeOperation = (
                 signature,
               });
             } else {
+              const verifiedDomain = await getVerifiedPermitDomain(client, {
+                token: tokenData.address,
+                chainId,
+                tokenName: tokenData.name,
+                knownDomain: tokenData.eip5267Domain?.eip712Domain,
+              });
+              if (verifiedDomain == null) {
+                throw new UnverifiablePermitDomainError(tokenData.address);
+              }
+
               const typedData = getPermitTypedData(
                 {
                   erc20: tokenData,
@@ -310,6 +322,7 @@ export const encodeOperation = (
                   deadline,
                 },
                 chainId,
+                { domain: verifiedDomain },
               );
               signature = await signTypedData(client, {
                 ...typedData,

--- a/packages/migration-sdk-viem/src/positions/borrow/aaveV2.borrow.ts
+++ b/packages/migration-sdk-viem/src/positions/borrow/aaveV2.borrow.ts
@@ -9,6 +9,8 @@ import {
   blueAbi,
   getAuthorizationTypedData,
   getPermitTypedData,
+  getVerifiedPermitDomain,
+  UnverifiablePermitDomainError,
 } from "@morpho-org/blue-sdk-viem";
 import { type Action, ActionBundle } from "@morpho-org/bundler-sdk-viem";
 import { Time } from "@morpho-org/morpho-ts";
@@ -182,6 +184,16 @@ export class MigratableBorrowPosition_AaveV2
             let signature = permitAction.args[4];
             if (signature != null) return signature; // action is already signed
 
+            const verifiedDomain = await getVerifiedPermitDomain(client, {
+              token: aToken.address,
+              chainId,
+              tokenName: aToken.name,
+              knownDomain: aToken.eip5267Domain?.eip712Domain,
+            });
+            if (verifiedDomain == null) {
+              throw new UnverifiablePermitDomainError(aToken.address);
+            }
+
             const typedData = getPermitTypedData(
               {
                 erc20: aToken,
@@ -192,6 +204,7 @@ export class MigratableBorrowPosition_AaveV2
                 deadline,
               },
               chainId,
+              { domain: verifiedDomain },
             );
             signature = await signTypedData(client, {
               ...typedData,

--- a/packages/migration-sdk-viem/src/positions/borrow/aaveV3.borrow.ts
+++ b/packages/migration-sdk-viem/src/positions/borrow/aaveV3.borrow.ts
@@ -9,6 +9,8 @@ import {
   blueAbi,
   getAuthorizationTypedData,
   getPermitTypedData,
+  getVerifiedPermitDomain,
+  UnverifiablePermitDomainError,
 } from "@morpho-org/blue-sdk-viem";
 import { type Action, ActionBundle } from "@morpho-org/bundler-sdk-viem";
 import { Time } from "@morpho-org/morpho-ts";
@@ -183,6 +185,16 @@ export class MigratableBorrowPosition_AaveV3
             let signature = permitAction.args[4];
             if (signature != null) return signature; // action is already signed
 
+            const verifiedDomain = await getVerifiedPermitDomain(client, {
+              token: aToken.address,
+              chainId,
+              tokenName: aToken.name,
+              knownDomain: aToken.eip5267Domain?.eip712Domain,
+            });
+            if (verifiedDomain == null) {
+              throw new UnverifiablePermitDomainError(aToken.address);
+            }
+
             const typedData = getPermitTypedData(
               {
                 erc20: aToken,
@@ -193,6 +205,7 @@ export class MigratableBorrowPosition_AaveV3
                 deadline,
               },
               chainId,
+              { domain: verifiedDomain },
             );
             signature = await signTypedData(client, {
               ...typedData,

--- a/packages/migration-sdk-viem/src/positions/supply/aaveV2.supply.ts
+++ b/packages/migration-sdk-viem/src/positions/supply/aaveV2.supply.ts
@@ -1,5 +1,9 @@
 import { getChainAddresses, type Token } from "@morpho-org/blue-sdk";
-import { getPermitTypedData } from "@morpho-org/blue-sdk-viem";
+import {
+  getPermitTypedData,
+  getVerifiedPermitDomain,
+  UnverifiablePermitDomainError,
+} from "@morpho-org/blue-sdk-viem";
 import { type Action, ActionBundle } from "@morpho-org/bundler-sdk-viem";
 import { Time } from "@morpho-org/morpho-ts";
 import {
@@ -88,6 +92,16 @@ export class MigratableSupplyPosition_AaveV2
           let signature = permitAction.args[4];
           if (signature != null) return signature; // action is already signed
 
+          const verifiedDomain = await getVerifiedPermitDomain(client, {
+            token: aToken.address,
+            chainId,
+            tokenName: aToken.name,
+            knownDomain: aToken.eip5267Domain?.eip712Domain,
+          });
+          if (verifiedDomain == null) {
+            throw new UnverifiablePermitDomainError(aToken.address);
+          }
+
           const typedData = getPermitTypedData(
             {
               erc20: aToken,
@@ -98,6 +112,7 @@ export class MigratableSupplyPosition_AaveV2
               deadline,
             },
             chainId,
+            { domain: verifiedDomain },
           );
           signature = await signTypedData(client, {
             ...typedData,

--- a/packages/migration-sdk-viem/src/positions/supply/aaveV3.supply.ts
+++ b/packages/migration-sdk-viem/src/positions/supply/aaveV3.supply.ts
@@ -1,5 +1,9 @@
 import { getChainAddresses, type Token } from "@morpho-org/blue-sdk";
-import { getPermitTypedData } from "@morpho-org/blue-sdk-viem";
+import {
+  getPermitTypedData,
+  getVerifiedPermitDomain,
+  UnverifiablePermitDomainError,
+} from "@morpho-org/blue-sdk-viem";
 import { type Action, ActionBundle } from "@morpho-org/bundler-sdk-viem";
 import { Time } from "@morpho-org/morpho-ts";
 import {
@@ -88,6 +92,16 @@ export class MigratableSupplyPosition_AaveV3
           let signature = permitAction.args[4];
           if (signature != null) return signature; // action is already signed
 
+          const verifiedDomain = await getVerifiedPermitDomain(client, {
+            token: aToken.address,
+            chainId,
+            tokenName: aToken.name,
+            knownDomain: aToken.eip5267Domain?.eip712Domain,
+          });
+          if (verifiedDomain == null) {
+            throw new UnverifiablePermitDomainError(aToken.address);
+          }
+
           const typedData = getPermitTypedData(
             {
               erc20: aToken,
@@ -98,6 +112,7 @@ export class MigratableSupplyPosition_AaveV3
               deadline,
             },
             chainId,
+            { domain: verifiedDomain },
           );
           signature = await signTypedData(client, {
             ...typedData,

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
@@ -1,7 +1,13 @@
 import type { Address } from "@morpho-org/blue-sdk";
-import { fetchToken, getPermitTypedData } from "@morpho-org/blue-sdk-viem";
+import {
+  fetchToken,
+  getPermitTypedData,
+  getVerifiedPermitDomain,
+  type PermitDomainCandidate,
+  UnverifiablePermitDomainError,
+} from "@morpho-org/blue-sdk-viem";
 import { deepFreeze, Time } from "@morpho-org/morpho-ts";
-import { type Client, verifyTypedData } from "viem";
+import { type Client, type TypedDataDomain, verifyTypedData } from "viem";
 import { signTypedData } from "viem/actions";
 import {
   AddressMismatchError,
@@ -19,13 +25,32 @@ interface EncodeErc20PermitParams {
   chainId: number;
   nonce: bigint;
   supportDeployless?: boolean;
+  /**
+   * Pre-verified EIP-712 permit domain for the token. When provided it skips
+   * on-chain rediscovery; obtain one via {@link getVerifiedPermitDomain}.
+   */
+  verifiedDomain?: TypedDataDomain;
+  /**
+   * Extra `(name, version)` candidates to try when discovering the domain via
+   * `DOMAIN_SEPARATOR()` for tokens without EIP-5267 metadata.
+   */
+  extraDomainCandidates?: readonly PermitDomainCandidate[];
 }
 
 export const encodeErc20Permit = async (
   viemClient: Client,
   params: EncodeErc20PermitParams,
 ): Promise<Requirement> => {
-  const { token, spender, amount, chainId, nonce, supportDeployless } = params;
+  const {
+    token,
+    spender,
+    amount,
+    chainId,
+    nonce,
+    supportDeployless,
+    verifiedDomain,
+    extraDomainCandidates,
+  } = params;
 
   if (viemClient.chain?.id !== chainId) {
     throw new ChainIdMismatchError(viemClient.chain?.id, chainId);
@@ -37,6 +62,20 @@ export const encodeErc20Permit = async (
   const tokenData = await fetchToken(token, viemClient, {
     deployless: supportDeployless,
   });
+
+  const domain =
+    verifiedDomain ??
+    (await getVerifiedPermitDomain(viemClient, {
+      token,
+      chainId,
+      tokenName: tokenData.name,
+      knownDomain: tokenData.eip5267Domain?.eip712Domain,
+      extraCandidates: extraDomainCandidates,
+    }));
+
+  if (domain == null) {
+    throw new UnverifiablePermitDomainError(token);
+  }
 
   const action: PermitAction = {
     type: "permit",
@@ -66,6 +105,7 @@ export const encodeErc20Permit = async (
           deadline,
         },
         chainId,
+        { domain },
       );
 
       const signature = await signTypedData(client, {

--- a/packages/morpho-sdk/src/actions/requirements/getRequirements.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirements.ts
@@ -1,5 +1,9 @@
 import { type Address, getChainAddresses } from "@morpho-org/blue-sdk";
-import { fetchHolding } from "@morpho-org/blue-sdk-viem";
+import {
+  fetchHolding,
+  fetchToken,
+  getVerifiedPermitDomain,
+} from "@morpho-org/blue-sdk-viem";
 import { isDefined } from "@morpho-org/morpho-ts";
 import type { Client } from "viem";
 import {
@@ -83,14 +87,32 @@ export const getRequirements = async (
     const supportSimplePermit = isDefined(erc2612Nonce) && address !== dai;
 
     if (supportSimplePermit && useSimplePermit) {
-      return await getRequirementsPermit(viemClient, {
+      // Discover and verify the token's EIP-712 permit domain against its
+      // on-chain DOMAIN_SEPARATOR before committing to the simple-permit path.
+      // If verification fails (no EIP-5267 data and no candidate domain
+      // matches), fall back to Permit2 rather than sign a guessed domain that
+      // will revert at execution time.
+      const tokenData = await fetchToken(address, viemClient, {
+        deployless: params.supportDeployless,
+      });
+      const verifiedDomain = await getVerifiedPermitDomain(viemClient, {
         token: address,
         chainId,
-        args: { amount },
-        allowancesGeneralAdapter: erc20Allowances["bundler3.generalAdapter1"],
-        nonce: erc2612Nonce,
-        supportDeployless: params.supportDeployless,
+        tokenName: tokenData.name,
+        knownDomain: tokenData.eip5267Domain?.eip712Domain,
       });
+
+      if (verifiedDomain != null) {
+        return await getRequirementsPermit(viemClient, {
+          token: address,
+          chainId,
+          args: { amount },
+          allowancesGeneralAdapter: erc20Allowances["bundler3.generalAdapter1"],
+          nonce: erc2612Nonce,
+          supportDeployless: params.supportDeployless,
+          verifiedDomain,
+        });
+      }
     }
 
     if (permit2) {

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsPermit.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsPermit.ts
@@ -1,5 +1,5 @@
 import { getChainAddresses } from "@morpho-org/blue-sdk";
-import type { Address, Client } from "viem";
+import type { Address, Client, TypedDataDomain } from "viem";
 import { encodeErc20Permit } from "./encode/index.js";
 
 /**
@@ -28,6 +28,12 @@ export const getRequirementsPermit = async (
     allowancesGeneralAdapter: bigint;
     nonce: bigint;
     supportDeployless?: boolean;
+    /**
+     * EIP-712 domain already verified against the token's on-chain
+     * `DOMAIN_SEPARATOR()` (or read from EIP-5267). Forwarded to
+     * `encodeErc20Permit` to skip rediscovery.
+     */
+    verifiedDomain: TypedDataDomain;
   },
 ) => {
   const {
@@ -37,6 +43,7 @@ export const getRequirementsPermit = async (
     allowancesGeneralAdapter,
     nonce,
     supportDeployless,
+    verifiedDomain,
   } = params;
 
   const {
@@ -52,6 +59,7 @@ export const getRequirementsPermit = async (
         chainId,
         nonce,
         supportDeployless,
+        verifiedDomain,
       }),
     ];
   }


### PR DESCRIPTION
## Summary

Closes [SDK-120](https://linear.app/morpho-labs/issue/SDK-120/morp2-63low-fallback-permit-domain-guessing-mis-signs-valid-erc-2612) (Cantina MORP2-63).

The SDK previously fell back to a hand-maintained `(name, "1" | "2")` heuristic when an ERC-2612 token did not expose `eip712Domain()`, hard-coding USDC/EURC to version `"2"` and DAI to a separate path. Any other legitimate ERC-2612 token whose real EIP-712 domain differed from `(ERC20.name(), "1")` was still routed to simple permit, signed against a guessed domain, and reverted on-chain at `permit()` time — even though `verifyTypedData` succeeded locally.

This PR replaces that fragile heuristic with on-chain verification:

- **New `getVerifiedPermitDomain(client, params)`** in `@morpho-org/blue-sdk-viem` reads the token's on-chain `DOMAIN_SEPARATOR()` and compares it to candidate `(name, version)` domains (defaults: `(token.name, "1" | "2")`). Callers may pass `extraCandidates` for tokens whose EIP-712 `name` differs from the on-chain `name()` (e.g. legacy USDC `"USD Coin"`). Returns `null` when nothing matches.
- **`getPermitTypedData` fails closed** with the new `UnverifiablePermitDomainError` when neither EIP-5267 metadata nor a caller-supplied verified domain is available. The USDC/EURC version-`"2"` carve-out is removed.
- **`getRequirements` gates simple permit on verifiability**: if the domain cannot be proven on-chain it transparently falls back to Permit2 instead of producing a signature that would revert at execution time.
- **All permit signers updated**: `morpho-sdk/encodeErc20Permit`, `bundler-sdk-viem/actions.ts`, and the four `migration-sdk-viem` Aave V2/V3 borrow/supply paths now verify the domain before signing.

The result: the SDK either signs a domain it has cryptographic evidence for, or it refuses to sign. No more silent mis-signing, no more per-token allowlist to maintain.

## Test plan

- [x] `pnpm lint`
- [x] Source typecheck across `blue-sdk-viem`, `morpho-sdk`, `bundler-sdk-viem`, `migration-sdk-viem`
- [x] `pnpm build` for `blue-sdk-viem` and `morpho-sdk`
- [x] New unit tests in `packages/blue-sdk-viem/test/Permit.test.ts` (16 passing) covering: explicit domain override, fail-closed when no domain available, candidate-`"1"` match, candidate-`"2"` match, `extraCandidates` for legacy USDC-style names, no-match → `null`, `DOMAIN_SEPARATOR()` revert → `null`, on-chain `name()` fallback, `knownDomain` chain mismatch
- [ ] Fork tests (Anvil) — run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->