### PR TITLE
test(morpho-test): phase 4 — colocated fixture validation tests

### DIFF
--- a/packages/morpho-test/src/fixtures/markets.test.ts
+++ b/packages/morpho-test/src/fixtures/markets.test.ts
@@ -1,0 +1,86 @@
+import { ChainId, MarketParams } from "@morpho-org/blue-sdk";
+import { isAddress } from "viem";
+import { describe, expect, test } from "vitest";
+import { markets, randomMarket } from "./markets.js";
+
+describe("markets fixture registry", () => {
+  test("has entries for all four supported chains", () => {
+    expect(markets[ChainId.EthMainnet]).toBeDefined();
+    expect(markets[ChainId.BaseMainnet]).toBeDefined();
+    expect(markets[ChainId.ArbitrumMainnet]).toBeDefined();
+    expect(markets[ChainId.PolygonMainnet]).toBeDefined();
+  });
+
+  test("every entry is a MarketParams instance with valid addresses", () => {
+    for (const chainMarkets of Object.values(markets)) {
+      for (const [name, m] of Object.entries(chainMarkets)) {
+        expect(m, `markets entry ${name}`).toBeInstanceOf(MarketParams);
+        expect(isAddress(m.loanToken)).toBe(true);
+        expect(isAddress(m.collateralToken)).toBe(true);
+        expect(isAddress(m.oracle)).toBe(true);
+        expect(isAddress(m.irm)).toBe(true);
+      }
+    }
+  });
+
+  test("idle markets have ZERO_ADDRESS oracle/irm and lltv=0", () => {
+    const ethIdle = markets[ChainId.EthMainnet].eth_idle;
+    expect(ethIdle.oracle).toBe("0x0000000000000000000000000000000000000000");
+    expect(ethIdle.irm).toBe("0x0000000000000000000000000000000000000000");
+    expect(ethIdle.lltv).toBe(0n);
+  });
+
+  test("market id is the canonical hash of params (deterministic)", () => {
+    const ethWst = markets[ChainId.EthMainnet].eth_wstEth;
+    const recomputed = new MarketParams({
+      loanToken: ethWst.loanToken,
+      collateralToken: ethWst.collateralToken,
+      oracle: ethWst.oracle,
+      irm: ethWst.irm,
+      lltv: ethWst.lltv,
+    });
+    expect(recomputed.id).toBe(ethWst.id);
+  });
+
+  test("non-idle markets have a non-zero LLTV", () => {
+    for (const chainMarkets of Object.values(markets)) {
+      for (const [name, m] of Object.entries(chainMarkets)) {
+        if (name.includes("idle")) continue;
+        expect(m.lltv, `${name}.lltv`).toBeGreaterThan(0n);
+      }
+    }
+  });
+});
+
+describe("randomMarket", () => {
+  test("returns a MarketParams with random valid addresses", () => {
+    const m = randomMarket();
+    expect(m).toBeInstanceOf(MarketParams);
+    expect(isAddress(m.loanToken)).toBe(true);
+    expect(isAddress(m.collateralToken)).toBe(true);
+    expect(isAddress(m.oracle)).toBe(true);
+    expect(isAddress(m.irm)).toBe(true);
+  });
+
+  test("default LLTV is 80% (parseEther('0.80'))", () => {
+    expect(randomMarket().lltv).toBe(800_000_000_000_000_000n);
+  });
+
+  test("accepts a partial override (loanToken)", () => {
+    const m = randomMarket({
+      loanToken: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+    });
+    expect(m.loanToken).toBe("0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa");
+  });
+
+  test("accepts a custom lltv override", () => {
+    const m = randomMarket({ lltv: 900_000_000_000_000_000n });
+    expect(m.lltv).toBe(900_000_000_000_000_000n);
+  });
+
+  test("two consecutive randomMarket() calls produce different ids", () => {
+    const a = randomMarket();
+    const b = randomMarket();
+    expect(a.id).not.toBe(b.id);
+  });
+});

--- a/packages/morpho-test/src/fixtures/tokens.test.ts
+++ b/packages/morpho-test/src/fixtures/tokens.test.ts
@@ -1,0 +1,41 @@
+import { ChainId, addressesRegistry } from "@morpho-org/blue-sdk";
+import { isAddress } from "viem";
+import { describe, expect, test } from "vitest";
+import { withSimplePermit } from "./tokens.js";
+
+describe("withSimplePermit registry", () => {
+  test("has entries for EthMainnet and BaseMainnet", () => {
+    expect(withSimplePermit[ChainId.EthMainnet]).toBeDefined();
+    expect(withSimplePermit[ChainId.BaseMainnet]).toBeDefined();
+  });
+
+  test("every listed token is a valid address", () => {
+    for (const set of Object.values(withSimplePermit)) {
+      for (const addr of set) {
+        expect(isAddress(addr)).toBe(true);
+      }
+    }
+  });
+
+  test("EthMainnet set contains the expected canonical permit tokens", () => {
+    const ethSet = withSimplePermit[ChainId.EthMainnet]!;
+    expect(ethSet.has(addressesRegistry[ChainId.EthMainnet].wstEth)).toBe(true);
+    expect(ethSet.has(addressesRegistry[ChainId.EthMainnet].dai)).toBe(true);
+    expect(ethSet.has(addressesRegistry[ChainId.EthMainnet].usdc)).toBe(true);
+  });
+
+  test("BaseMainnet set contains usdc and verUsdc", () => {
+    const baseSet = withSimplePermit[ChainId.BaseMainnet]!;
+    expect(baseSet.has(addressesRegistry[ChainId.BaseMainnet].usdc)).toBe(true);
+    expect(baseSet.has(addressesRegistry[ChainId.BaseMainnet].verUsdc)).toBe(
+      true,
+    );
+  });
+
+  test("each chain's set contains no duplicates", () => {
+    for (const [chainId, set] of Object.entries(withSimplePermit)) {
+      const arr = Array.from(set);
+      expect(arr.length, `chain ${chainId}`).toBe(new Set(arr).size);
+    }
+  });
+});

--- a/packages/morpho-test/src/fixtures/vaults.test.ts
+++ b/packages/morpho-test/src/fixtures/vaults.test.ts
@@ -1,0 +1,61 @@
+import { ChainId, VaultConfig } from "@morpho-org/blue-sdk";
+import { isAddress } from "viem";
+import { describe, expect, test } from "vitest";
+import { randomVault, vaults } from "./vaults.js";
+
+describe("vaults fixture registry", () => {
+  test("has entries for EthMainnet", () => {
+    expect(vaults[ChainId.EthMainnet]).toBeDefined();
+  });
+
+  test("every entry is a VaultConfig instance with valid asset address", () => {
+    for (const v of Object.values(vaults[ChainId.EthMainnet])) {
+      expect(v).toBeInstanceOf(VaultConfig);
+      expect(isAddress(v.address)).toBe(true);
+      expect(isAddress(v.asset)).toBe(true);
+    }
+  });
+
+  test("vault decimals are forced to 18 (vault token convention)", () => {
+    for (const v of Object.values(vaults[ChainId.EthMainnet])) {
+      expect(v.decimals).toBe(18);
+    }
+  });
+
+  test("decimalsOffset is a valid bigint", () => {
+    for (const v of Object.values(vaults[ChainId.EthMainnet])) {
+      expect(typeof v.decimalsOffset).toBe("bigint");
+      expect(v.decimalsOffset).toBeGreaterThanOrEqual(0n);
+    }
+  });
+
+  test("steakUsdc fixture has the expected decimalsOffset", () => {
+    expect(vaults[ChainId.EthMainnet].steakUsdc.decimalsOffset).toBe(12n);
+  });
+});
+
+describe("randomVault", () => {
+  test("returns a VaultConfig with random valid addresses", () => {
+    const v = randomVault();
+    expect(v).toBeInstanceOf(VaultConfig);
+    expect(isAddress(v.address)).toBe(true);
+    expect(isAddress(v.asset)).toBe(true);
+  });
+
+  test("accepts a partial config override", () => {
+    const asset = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
+    const v = randomVault({ asset, decimalsOffset: 12n });
+    expect(v.asset).toBe(asset);
+    expect(v.decimalsOffset).toBe(12n);
+  });
+
+  test("default symbol is 'TEST' and name is 'Test vault'", () => {
+    const v = randomVault();
+    expect(v.symbol).toBe("TEST");
+    expect(v.name).toBe("Test vault");
+  });
+
+  test("decimalsOffset defaults to 0n", () => {
+    expect(randomVault().decimalsOffset).toBe(0n);
+  });
+});

--- a/packages/morpho-test/tsconfig.build.cjs.json
+++ b/packages/morpho-test/tsconfig.build.cjs.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/cjs",
     "tsBuildInfoFile": "tsconfig.cjs.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/morpho-test/tsconfig.build.esm.json
+++ b/packages/morpho-test/tsconfig.build.esm.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/esm",
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -127,6 +127,13 @@ export default defineConfig({
           ],
         },
       },
+      {
+        extends: true,
+        test: {
+          name: "morpho-test",
+          include: ["packages/morpho-test/src/**/*.test.ts"],
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
Implements **Phase 4** of TIB-2026-04-27 (#556). Stacked on Phase 3 (#587).

Adds the `morpho-test` package as a new vitest project (was previously unrun) and 3 colocated test files validating the canonical fixtures (markets, vaults, tokens).

24 tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->