### PR TITLE
test(liquidity-sdk-viem): phase 5 — colocated unit tests + nock GraphQL pattern

### DIFF
--- a/packages/liquidity-sdk-viem/src/api/index.test.ts
+++ b/packages/liquidity-sdk-viem/src/api/index.test.ts
@@ -1,0 +1,86 @@
+import { BLUE_API_GRAPHQL_URL } from "@morpho-org/morpho-ts";
+import { GraphQLClient } from "graphql-request";
+import nock from "nock";
+import { afterEach, describe, expect, test } from "vitest";
+import { ApiTypes, apiSdk } from "./index.js";
+
+describe("apiSdk", () => {
+  test("exposes a getMarkets method", () => {
+    expect(typeof apiSdk.getMarkets).toBe("function");
+  });
+
+  test("ApiTypes is re-exported as a namespace", () => {
+    expect(ApiTypes).toBeDefined();
+    expect(typeof ApiTypes).toBe("object");
+  });
+});
+
+describe("apiSdk.getMarkets via nock", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("posts a GraphQL query to BLUE_API_GRAPHQL_URL and parses the response", async () => {
+    const fixture = {
+      data: {
+        markets: {
+          items: [
+            {
+              uniqueKey: "0xdeadbeef",
+              targetBorrowUtilization: "900000000000000000",
+              publicAllocatorSharedLiquidity: [],
+              supplyingVaults: [],
+            },
+          ],
+        },
+      },
+    };
+    nock(new URL(BLUE_API_GRAPHQL_URL).origin)
+      .post("/graphql")
+      .reply(200, fixture);
+
+    const result = await apiSdk.getMarkets({
+      chainId: 1,
+      marketIds: ["0xdeadbeef"],
+    });
+    expect(result.markets.items).toHaveLength(1);
+    expect(result.markets.items?.[0]?.uniqueKey).toBe("0xdeadbeef");
+  });
+
+  test("handles empty items array", async () => {
+    nock(new URL(BLUE_API_GRAPHQL_URL).origin)
+      .post("/graphql")
+      .reply(200, { data: { markets: { items: [] } } });
+
+    const result = await apiSdk.getMarkets({ chainId: 1, marketIds: [] });
+    expect(result.markets.items).toEqual([]);
+  });
+
+  test("propagates GraphQL errors", async () => {
+    nock(new URL(BLUE_API_GRAPHQL_URL).origin)
+      .post("/graphql")
+      .reply(200, { errors: [{ message: "boom" }] });
+
+    await expect(
+      apiSdk.getMarkets({ chainId: 1, marketIds: [] }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("getSdk + GraphQLClient end-to-end", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("works with a custom GraphQLClient (different endpoint)", async () => {
+    const customUrl = "https://custom.example.com/graphql";
+    nock("https://custom.example.com")
+      .post("/graphql")
+      .reply(200, { data: { markets: { items: [] } } });
+
+    const { getSdk } = await import("./sdk.js");
+    const sdk = getSdk(new GraphQLClient(customUrl));
+    const result = await sdk.getMarkets({ chainId: 1, marketIds: [] });
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/liquidity-sdk-viem/src/loader.test.ts
+++ b/packages/liquidity-sdk-viem/src/loader.test.ts
@@ -1,3 +1,4 @@
+import type { MarketId } from "@morpho-org/blue-sdk";
 import { createMockClient } from "@morpho-org/test/mock";
 import { describe, expect, test } from "vitest";
 import { LiquidityLoader } from "./loader.js";
@@ -39,7 +40,7 @@ describe("LiquidityLoader (constructor + public API)", () => {
     const { client } = createMockClient();
     const loader = new LiquidityLoader(client);
     const result = loader.fetch(
-      "0x0000000000000000000000000000000000000000000000000000000000000001",
+      "0x0000000000000000000000000000000000000000000000000000000000000001" as MarketId,
     );
     expect(result).toBeInstanceOf(Promise);
     // We don't await — the underlying RPC call is unmocked and would throw,
@@ -51,8 +52,8 @@ describe("LiquidityLoader (constructor + public API)", () => {
 
   test("accepts maxWithdrawalUtilization override map", () => {
     const { client } = createMockClient();
-    const overrides = {
-      "0x0000000000000000000000000000000000000000000000000000000000000001":
+    const overrides: Record<MarketId, bigint> = {
+      ["0x0000000000000000000000000000000000000000000000000000000000000001" as MarketId]:
         800000000000000000n,
     };
     const loader = new LiquidityLoader(client, {

--- a/packages/liquidity-sdk-viem/src/loader.test.ts
+++ b/packages/liquidity-sdk-viem/src/loader.test.ts
@@ -1,0 +1,63 @@
+import { createMockClient } from "@morpho-org/test/mock";
+import { describe, expect, test } from "vitest";
+import { LiquidityLoader } from "./loader.js";
+
+describe("LiquidityLoader (constructor + public API)", () => {
+  test("stores the client", () => {
+    const { client } = createMockClient();
+    const loader = new LiquidityLoader(client);
+    expect(loader.client).toBe(client);
+  });
+
+  test("uses an empty parameters record by default", () => {
+    const { client } = createMockClient();
+    const loader = new LiquidityLoader(client);
+    expect(loader.parameters).toEqual({});
+  });
+
+  test("preserves the parameters record verbatim", () => {
+    const { client } = createMockClient();
+    const params = {
+      delay: 3600n,
+      defaultMaxWithdrawalUtilization: 950000000000000000n,
+    };
+    const loader = new LiquidityLoader(client, params);
+    expect(loader.parameters).toBe(params);
+    expect(loader.parameters.delay).toBe(3600n);
+    expect(loader.parameters.defaultMaxWithdrawalUtilization).toBe(
+      950000000000000000n,
+    );
+  });
+
+  test("exposes a fetch method", () => {
+    const { client } = createMockClient();
+    const loader = new LiquidityLoader(client);
+    expect(typeof loader.fetch).toBe("function");
+  });
+
+  test("fetch returns a Promise", () => {
+    const { client } = createMockClient();
+    const loader = new LiquidityLoader(client);
+    const result = loader.fetch(
+      "0x0000000000000000000000000000000000000000000000000000000000000001",
+    );
+    expect(result).toBeInstanceOf(Promise);
+    // We don't await — the underlying RPC call is unmocked and would throw,
+    // but the Promise itself is created synchronously.
+    result.catch(() => {
+      /* swallow unhandled rejection */
+    });
+  });
+
+  test("accepts maxWithdrawalUtilization override map", () => {
+    const { client } = createMockClient();
+    const overrides = {
+      "0x0000000000000000000000000000000000000000000000000000000000000001":
+        800000000000000000n,
+    };
+    const loader = new LiquidityLoader(client, {
+      maxWithdrawalUtilization: overrides,
+    });
+    expect(loader.parameters.maxWithdrawalUtilization).toBe(overrides);
+  });
+});

--- a/packages/liquidity-sdk-viem/tsconfig.build.cjs.json
+++ b/packages/liquidity-sdk-viem/tsconfig.build.cjs.json
@@ -8,5 +8,12 @@
     "tsBuildInfoFile": "tsconfig.cjs.tsbuildinfo"
   },
   "include": ["src"],
-  "files": []
+  "files": [],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/liquidity-sdk-viem/tsconfig.build.esm.json
+++ b/packages/liquidity-sdk-viem/tsconfig.build.esm.json
@@ -8,5 +8,12 @@
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
   "include": ["src"],
-  "files": []
+  "files": [],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/test/src/mock.ts
+++ b/packages/test/src/mock.ts
@@ -4,6 +4,7 @@ import {
   type Chain,
   type Client,
   type ContractFunctionName,
+  type CustomTransport,
   type Hex,
   createClient,
   custom,
@@ -31,7 +32,7 @@ export type RpcHandler = (call: {
  * inspect call history, override per-test, or swap implementations on the fly.
  */
 export interface MockClientHandle<chain extends Chain = Chain> {
-  client: Client;
+  client: Client<CustomTransport, chain>;
   request: Mock<RpcHandler>;
   chain: chain;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -114,7 +114,10 @@ export default defineConfig({
         extends: true,
         test: {
           name: "liquidity-sdk-viem",
-          include: ["packages/liquidity-sdk-viem/test/**/*.test.ts"],
+          include: [
+            "packages/liquidity-sdk-viem/test/**/*.test.ts",
+            "packages/liquidity-sdk-viem/src/**/*.test.ts",
+          ],
         },
       },
       {


### PR DESCRIPTION
Implements **Phase 5** of TIB-2026-04-27 (#556). Stacked on Phase 4 (#590).

## What lands

- **`src/api/index.test.ts`** — `apiSdk` shape, `getMarkets` via `nock` (success / empty / GraphQL error). Establishes the canonical nock pattern for GraphQL mocking.
- **`src/loader.test.ts`** — `LiquidityLoader` constructor, parameters preservation, `fetch` returns Promise. Uses `createMockClient` from `@morpho-org/test/mock` (Phase 2 primitive).
- Config: `vitest.config.ts` union, `tsconfig.build.{cjs,esm}.json` excludes.
- Type fix in `packages/test/src/mock.ts` (`Client` → `Client<CustomTransport, chain>`) so mock clients slot into typed SDK signatures.

The existing `test/loader.test.ts` (fork-based) is left untouched.

## Test plan
- [x] `pnpm test --project liquidity-sdk-viem --run packages/liquidity-sdk-viem/src` → 2 files, 12 tests pass.
- [x] `pnpm --filter @morpho-org/liquidity-sdk-viem build` succeeds.
- [x] `find packages/liquidity-sdk-viem/lib -name "*.test.*"` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->