### PR TITLE
test(bundler-sdk-viem): phase 6 — colocated tests for errors + ActionBundle

### DIFF
--- a/packages/bundler-sdk-viem/src/ActionBundle.test.ts
+++ b/packages/bundler-sdk-viem/src/ActionBundle.test.ts
@@ -1,0 +1,104 @@
+import { ChainId } from "@morpho-org/blue-sdk";
+import type { SimulationResult } from "@morpho-org/simulation-sdk";
+import type { Address, Hex } from "viem";
+import { describe, expect, test } from "vitest";
+import { ActionBundle, ActionBundleRequirements } from "./ActionBundle.js";
+import type {
+  Action,
+  SignatureRequirement,
+  TransactionRequirement,
+} from "./types/index.js";
+
+const ADDR = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
+const TX_DATA = "0xdeadbeef" as Hex;
+
+describe("ActionBundleRequirements", () => {
+  test("defaults to empty txs and signatures arrays", () => {
+    const r = new ActionBundleRequirements();
+    expect(r.txs).toEqual([]);
+    expect(r.signatures).toEqual([]);
+  });
+
+  test("preserves provided txs and signatures", () => {
+    const tx: TransactionRequirement = {
+      type: "erc20Approve",
+      args: [ADDR, ADDR, 1n],
+      tx: { to: ADDR, data: TX_DATA },
+    };
+    const sig: SignatureRequirement = {
+      action: { type: "permit", args: [ADDR, ADDR, 1n, 0n, null!] },
+      sign: async () => "0x" as Hex,
+    };
+    const r = new ActionBundleRequirements([tx], [sig]);
+    expect(r.txs).toEqual([tx]);
+    expect(r.signatures).toEqual([sig]);
+  });
+
+  test("sign aggregates async signatures from each requirement", async () => {
+    const sig1: SignatureRequirement = {
+      action: { type: "permit", args: [ADDR, ADDR, 1n, 0n, null!] },
+      sign: async () => "0x01" as Hex,
+    };
+    const sig2: SignatureRequirement = {
+      action: { type: "permit", args: [ADDR, ADDR, 1n, 0n, null!] },
+      sign: async () => "0x02" as Hex,
+    };
+    const r = new ActionBundleRequirements([], [sig1, sig2]);
+    // The client is just passed through to each requirement.sign; mock minimal shape.
+    const client = { account: { address: ADDR } } as never;
+    const sigs = await r.sign(client);
+    expect(sigs).toEqual(["0x01", "0x02"]);
+  });
+});
+
+describe("ActionBundle", () => {
+  test("uses chainId arg when constructed with a number", () => {
+    const b = new ActionBundle(ChainId.EthMainnet);
+    expect(b.chainId).toBe(ChainId.EthMainnet);
+    expect(b.actions).toEqual([]);
+    expect(b.steps).toBeUndefined();
+  });
+
+  test("derives chainId from steps[0] when constructed with a SimulationResult", () => {
+    const steps = [
+      { chainId: ChainId.BaseMainnet },
+    ] as unknown as SimulationResult;
+    const b = new ActionBundle(steps);
+    expect(b.chainId).toBe(ChainId.BaseMainnet);
+    expect(b.steps).toBe(steps);
+  });
+
+  test("preserves provided actions and requirements", () => {
+    const action: Action = {
+      type: "nativeTransfer",
+      args: [ADDR, ADDR, 100n],
+    };
+    const reqs = new ActionBundleRequirements();
+    const b = new ActionBundle(ChainId.EthMainnet, [action], reqs);
+    expect(b.actions).toEqual([action]);
+    expect(b.requirements).toBe(reqs);
+  });
+
+  test("tx() returns a transaction object built from the bundled actions", () => {
+    // Empty action list still produces a valid call to bundler3
+    const b = new ActionBundle(ChainId.EthMainnet);
+    const tx = b.tx();
+    expect(tx).toMatchObject({
+      to: expect.any(String),
+      data: expect.stringMatching(/^0x/),
+    });
+  });
+
+  test("txs() concatenates pre-requirement txs with the bundle tx", () => {
+    const requirementTx: TransactionRequirement = {
+      type: "erc20Approve",
+      args: [ADDR, ADDR, 1n],
+      tx: { to: ADDR, data: TX_DATA },
+    };
+    const reqs = new ActionBundleRequirements([requirementTx], []);
+    const b = new ActionBundle(ChainId.EthMainnet, [], reqs);
+    const txs = b.txs();
+    expect(txs.length).toBe(2);
+    expect(txs[0]).toEqual(requirementTx.tx);
+  });
+});

--- a/packages/bundler-sdk-viem/src/errors.test.ts
+++ b/packages/bundler-sdk-viem/src/errors.test.ts
@@ -1,0 +1,65 @@
+import type {
+  OperationType,
+  SimulationResult,
+} from "@morpho-org/simulation-sdk";
+import type { Address } from "viem";
+import { describe, expect, test } from "vitest";
+import { BundlerErrors } from "./errors.js";
+import type { ActionType, InputBundlerOperation } from "./types/index.js";
+
+const ADDRESS = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
+
+describe("BundlerErrors namespace", () => {
+  test("Bundle wraps an underlying error and preserves index, op, steps", () => {
+    const inner = new Error("boom");
+    const inputOp = {} as InputBundlerOperation;
+    const steps = [] as unknown as SimulationResult;
+    const err = new BundlerErrors.Bundle(inner, 3, inputOp, steps);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    expect(err.error).toBe(inner);
+    expect(err.index).toBe(3);
+    expect(err.inputOperation).toBe(inputOp);
+    expect(err.steps).toBe(steps);
+    expect(err.stack).toBe(inner.stack);
+  });
+
+  test("MissingSignature has the right message", () => {
+    const err = new BundlerErrors.MissingSignature();
+    expect(err.message).toBe("missing signature");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  test("MissingSwapData has the right message", () => {
+    expect(new BundlerErrors.MissingSwapData().message).toBe(
+      "missing swap data",
+    );
+  });
+
+  test("UnexpectedAction includes type and chainId in the message", () => {
+    const err = new BundlerErrors.UnexpectedAction(
+      "erc20Transfer" as ActionType,
+      1,
+    );
+    expect(err.message).toContain("erc20Transfer");
+    expect(err.message).toContain('"1"');
+  });
+
+  test("UnexpectedSignature includes the spender address", () => {
+    const err = new BundlerErrors.UnexpectedSignature(ADDRESS);
+    expect(err.message).toContain(ADDRESS);
+  });
+
+  test("MissingSkimHandler includes the operation type", () => {
+    const err = new BundlerErrors.MissingSkimHandler(
+      "Blue_Supply" as OperationType,
+    );
+    expect(err.message).toContain("Blue_Supply");
+  });
+
+  test("UnskimedToken includes the token address", () => {
+    const err = new BundlerErrors.UnskimedToken(ADDRESS);
+    expect(err.message).toContain(ADDRESS);
+  });
+});

--- a/packages/bundler-sdk-viem/tsconfig.build.cjs.json
+++ b/packages/bundler-sdk-viem/tsconfig.build.cjs.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/cjs",
     "tsBuildInfoFile": "tsconfig.cjs.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/bundler-sdk-viem/tsconfig.build.esm.json
+++ b/packages/bundler-sdk-viem/tsconfig.build.esm.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/esm",
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -97,7 +97,10 @@ export default defineConfig({
         extends: true,
         test: {
           name: "bundler-sdk-viem",
-          include: ["packages/bundler-sdk-viem/test/**/*.test.ts"],
+          include: [
+            "packages/bundler-sdk-viem/test/**/*.test.ts",
+            "packages/bundler-sdk-viem/src/**/*.test.ts",
+          ],
           environment: "happy-dom",
           testTimeout: 60_000,
         },


### PR DESCRIPTION
Implements **Phase 6** of TIB-2026-04-27 (#556). Stacked on Phase 5 (#591).

## What lands

- `src/errors.test.ts` — every `BundlerErrors` class (`Bundle`, `MissingSignature`, `MissingSwapData`, `UnexpectedAction`, `UnexpectedSignature`, `MissingSkimHandler`, `UnskimedToken`).
- `src/ActionBundle.test.ts` — `ActionBundleRequirements` (defaults, `sign` aggregation), `ActionBundle` (chainId branch, `SimulationResult` branch, `tx()`/`txs()` shape).
- Config: vitest union, tsconfig.build excludes.

## Out of scope

`BundlerAction.ts` (2,346 LOC, dozens of encoders) and `operations.ts`/`actions.ts` need extensive ABI round-trip suites — they can land in follow-up commits on this branch or a separate PR. The errors and small classes here are the easy wins.

## Test plan
- [x] `pnpm test --project bundler-sdk-viem --run packages/bundler-sdk-viem/src` → 2 files, 15 tests pass.
- [x] `pnpm --filter @morpho-org/bundler-sdk-viem build` succeeds.
- [x] `find packages/bundler-sdk-viem/lib -name "*.test.*"` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->