### PR TITLE
test(blue-sdk-viem): phase 7 — colocated unit tests for utils, error, augment, fetchMarketParams

### DIFF
--- a/packages/blue-sdk-viem/src/augment/augment.test.ts
+++ b/packages/blue-sdk-viem/src/augment/augment.test.ts
@@ -1,0 +1,57 @@
+import {
+  Holding,
+  Market,
+  MarketParams,
+  Position,
+  Token,
+  User,
+  Vault,
+  VaultConfig,
+  VaultMarketAllocation,
+  VaultMarketConfig,
+  VaultMarketPublicAllocatorConfig,
+  VaultUser,
+} from "@morpho-org/blue-sdk";
+import { describe, expect, test } from "vitest";
+
+// Importing this barrel triggers the static augmentation of every blue-sdk class.
+import "./index.js";
+
+describe("blue-sdk augmentations", () => {
+  test("Market.fetch is wired", () => {
+    expect(typeof Market.fetch).toBe("function");
+  });
+  test("MarketParams.fetch is wired", () => {
+    expect(typeof MarketParams.fetch).toBe("function");
+  });
+  test("Token.fetch is wired", () => {
+    expect(typeof Token.fetch).toBe("function");
+  });
+  test("Position.fetch is wired", () => {
+    expect(typeof Position.fetch).toBe("function");
+  });
+  test("Holding.fetch is wired", () => {
+    expect(typeof Holding.fetch).toBe("function");
+  });
+  test("User.fetch is wired", () => {
+    expect(typeof User.fetch).toBe("function");
+  });
+  test("Vault.fetch is wired", () => {
+    expect(typeof Vault.fetch).toBe("function");
+  });
+  test("VaultConfig.fetch is wired", () => {
+    expect(typeof VaultConfig.fetch).toBe("function");
+  });
+  test("VaultMarketAllocation.fetch is wired", () => {
+    expect(typeof VaultMarketAllocation.fetch).toBe("function");
+  });
+  test("VaultMarketConfig.fetch is wired", () => {
+    expect(typeof VaultMarketConfig.fetch).toBe("function");
+  });
+  test("VaultMarketPublicAllocatorConfig.fetch is wired", () => {
+    expect(typeof VaultMarketPublicAllocatorConfig.fetch).toBe("function");
+  });
+  test("VaultUser.fetch is wired", () => {
+    expect(typeof VaultUser.fetch).toBe("function");
+  });
+});

--- a/packages/blue-sdk-viem/src/error.test.ts
+++ b/packages/blue-sdk-viem/src/error.test.ts
@@ -1,0 +1,77 @@
+import { BaseError, ContractFunctionRevertedError } from "viem";
+import { describe, expect, test } from "vitest";
+import { isUnknownOfFactoryError } from "./error.js";
+
+describe("isUnknownOfFactoryError", () => {
+  test("returns false for a plain Error", () => {
+    expect(isUnknownOfFactoryError(new Error("oops"))).toBe(false);
+  });
+
+  test("returns false for a non-Error value", () => {
+    expect(isUnknownOfFactoryError("error")).toBe(false);
+    expect(isUnknownOfFactoryError(null)).toBe(false);
+    expect(isUnknownOfFactoryError(undefined)).toBe(false);
+    expect(isUnknownOfFactoryError(42)).toBe(false);
+  });
+
+  test("returns false for a BaseError without a ContractFunctionRevertedError in the chain", () => {
+    expect(
+      isUnknownOfFactoryError(
+        new BaseError("nope", { details: "no revert here" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("returns true for a ContractFunctionRevertedError with errorName 'UnknownOfFactory'", () => {
+    const err = new ContractFunctionRevertedError({
+      abi: [
+        {
+          type: "error",
+          name: "UnknownOfFactory",
+          inputs: [{ type: "address" }],
+        },
+      ],
+      data: "0x" as `0x${string}`,
+      functionName: "test",
+    });
+    // Force the data shape the helper checks
+    Object.defineProperty(err, "data", {
+      value: { errorName: "UnknownOfFactory" },
+      configurable: true,
+    });
+    expect(isUnknownOfFactoryError(err)).toBe(true);
+  });
+
+  test("returns false for a ContractFunctionRevertedError with a different errorName", () => {
+    const err = new ContractFunctionRevertedError({
+      abi: [
+        {
+          type: "error",
+          name: "SomethingElse",
+          inputs: [],
+        },
+      ],
+      data: "0x" as `0x${string}`,
+      functionName: "test",
+    });
+    Object.defineProperty(err, "data", {
+      value: { errorName: "SomethingElse" },
+      configurable: true,
+    });
+    expect(isUnknownOfFactoryError(err)).toBe(false);
+  });
+
+  test("walks nested error causes (BaseError wrapping ContractFunctionRevertedError)", () => {
+    const inner = new ContractFunctionRevertedError({
+      abi: [{ type: "error", name: "UnknownOfFactory", inputs: [] }],
+      data: "0x" as `0x${string}`,
+      functionName: "test",
+    });
+    Object.defineProperty(inner, "data", {
+      value: { errorName: "UnknownOfFactory" },
+      configurable: true,
+    });
+    const outer = new BaseError("wrapper", { cause: inner });
+    expect(isUnknownOfFactoryError(outer)).toBe(true);
+  });
+});

--- a/packages/blue-sdk-viem/src/fetch/MarketParams.test.ts
+++ b/packages/blue-sdk-viem/src/fetch/MarketParams.test.ts
@@ -1,0 +1,70 @@
+import { ChainId, MarketParams } from "@morpho-org/blue-sdk";
+import { randomMarket } from "@morpho-org/morpho-test";
+import { createMockClient, mockRead } from "@morpho-org/test/mock";
+import { describe, expect, test } from "vitest";
+import { blueAbi } from "../abis.js";
+import { fetchMarketParams } from "./MarketParams.js";
+
+describe("fetchMarketParams", () => {
+  test("returns the cached MarketParams when one was previously constructed (cache hit)", async () => {
+    // Constructing a MarketParams seeds MarketParams._CACHE.
+    const params = randomMarket({ lltv: 800000000000000000n });
+    const { client } = createMockClient();
+
+    const result = await fetchMarketParams(params.id, client);
+
+    expect(result).toBeInstanceOf(MarketParams);
+    expect(result.id).toBe(params.id);
+    expect(result.loanToken).toBe(params.loanToken);
+    expect(result.collateralToken).toBe(params.collateralToken);
+    expect(result.lltv).toBe(params.lltv);
+  });
+
+  test("respects an explicit chainId when fetching from chain (cache miss path is reachable)", async () => {
+    // Construct a MarketParams to obtain a known id, then drop it from cache.
+    const params = randomMarket();
+    // Force a cache miss by using a fresh id that's never been seeded.
+    const freshId =
+      "0xdead000000000000000000000000000000000000000000000000000000000001" as typeof params.id;
+
+    const handle = createMockClient();
+    mockRead(handle, {
+      address: "0xBBBbbbbBbbBBBBbBBbBBBbBbBBBbBbBbBBBbbBBb",
+      abi: blueAbi,
+      functionName: "idToMarketParams",
+      result: [
+        params.loanToken,
+        params.collateralToken,
+        params.oracle,
+        params.irm,
+        params.lltv,
+      ],
+    });
+
+    // Note: the mockRead address is arbitrary here; the real call uses the
+    // morpho address from getChainAddresses(chainId). Use chainId=EthMainnet
+    // and program the canonical morpho address.
+    const { addressesRegistry } = await import("@morpho-org/blue-sdk");
+    const morpho = addressesRegistry[ChainId.EthMainnet].morpho;
+    mockRead(handle, {
+      address: morpho,
+      abi: blueAbi,
+      functionName: "idToMarketParams",
+      result: [
+        params.loanToken,
+        params.collateralToken,
+        params.oracle,
+        params.irm,
+        params.lltv,
+      ],
+    });
+
+    const result = await fetchMarketParams(freshId, handle.client, {
+      chainId: ChainId.EthMainnet,
+    });
+    expect(result).toBeInstanceOf(MarketParams);
+    expect(result.loanToken).toBe(params.loanToken);
+    expect(result.collateralToken).toBe(params.collateralToken);
+    expect(result.lltv).toBe(params.lltv);
+  });
+});

--- a/packages/blue-sdk-viem/src/utils.test.ts
+++ b/packages/blue-sdk-viem/src/utils.test.ts
@@ -1,0 +1,126 @@
+import { parseAbi, parseUnits } from "viem";
+import { describe, expect, test } from "vitest";
+import {
+  restructure,
+  safeGetAddress,
+  safeParseNumber,
+  safeParseUnits,
+} from "./utils.js";
+
+describe("safeParseNumber", () => {
+  test("parses an integer", () => {
+    expect(safeParseNumber(1)).toBe(parseUnits("1", 18));
+  });
+
+  test("parses a decimal at default 18 decimals", () => {
+    expect(safeParseNumber(1.5)).toBe(parseUnits("1.5", 18));
+  });
+
+  test("respects explicit decimals", () => {
+    expect(safeParseNumber(1, 6)).toBe(parseUnits("1", 6));
+    expect(safeParseNumber(1.5, 4)).toBe(parseUnits("1.5", 4));
+  });
+
+  test("avoids scientific notation for small values", () => {
+    // 0.0000001 parsed at 8 decimals should yield 10
+    expect(safeParseNumber(0.0000001, 8)).toBe(10n);
+  });
+
+  test("avoids scientific notation for large values", () => {
+    expect(safeParseNumber(1e20, 0)).toBe(100_000_000_000_000_000_000n);
+  });
+
+  test("handles zero", () => {
+    expect(safeParseNumber(0)).toBe(0n);
+  });
+
+  test("handles negatives", () => {
+    expect(safeParseNumber(-1)).toBe(-parseUnits("1", 18));
+  });
+});
+
+describe("safeParseUnits", () => {
+  test("parses a normal decimal string", () => {
+    expect(safeParseUnits("1.5", 18)).toBe(parseUnits("1.5", 18));
+  });
+
+  test("truncates extra fractional digits beyond decimals", () => {
+    // "1.123456789" at decimals=4 -> "1.1234"
+    expect(safeParseUnits("1.123456789", 4)).toBe(parseUnits("1.1234", 4));
+  });
+
+  test("handles whole numbers", () => {
+    expect(safeParseUnits("42", 6)).toBe(parseUnits("42", 6));
+  });
+
+  test("treats leading dot as 0.x", () => {
+    expect(safeParseUnits(".5", 4)).toBe(parseUnits("0.5", 4));
+  });
+
+  test("throws on completely invalid strings", () => {
+    expect(() => safeParseUnits("abc")).toThrow(/invalid number/);
+    expect(() => safeParseUnits("")).toThrow(/invalid number/);
+  });
+
+  test("handles negative numbers", () => {
+    expect(safeParseUnits("-1.5", 18)).toBe(-parseUnits("1.5", 18));
+  });
+});
+
+describe("safeGetAddress", () => {
+  test("returns the EIP-55 checksum form for any input case", () => {
+    expect(safeGetAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")).toBe(
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    );
+    expect(safeGetAddress("0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48")).toBe(
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    );
+  });
+
+  test("throws on a non-address string", () => {
+    expect(() => safeGetAddress("0xnotanaddress")).toThrow();
+  });
+});
+
+describe("restructure", () => {
+  const namedAbi = parseAbi([
+    "function getMarket() view returns (uint128 totalSupplyAssets, uint128 totalSupplyShares, uint128 totalBorrowAssets, uint128 totalBorrowShares, uint128 lastUpdate, uint128 fee)",
+  ]);
+
+  test("converts a positional tuple into an object using named ABI outputs", () => {
+    const tuple = [1n, 2n, 3n, 4n, 5n, 6n] as const;
+    const r = restructure(tuple, {
+      abi: namedAbi,
+      name: "getMarket",
+      args: [],
+    });
+    expect(r).toEqual({
+      totalSupplyAssets: 1n,
+      totalSupplyShares: 2n,
+      totalBorrowAssets: 3n,
+      totalBorrowShares: 4n,
+      lastUpdate: 5n,
+      fee: 6n,
+    });
+  });
+
+  test("throws when the function does not exist in the abi", () => {
+    expect(() =>
+      restructure([] as never, {
+        abi: namedAbi,
+        // @ts-expect-error - intentional bad input
+        name: "doesNotExist",
+        args: [],
+      }),
+    ).toThrow();
+  });
+
+  test("throws when ABI outputs lack names", () => {
+    const unnamedAbi = parseAbi([
+      "function foo() view returns (uint256, uint256)",
+    ]);
+    expect(() =>
+      restructure([1n, 2n], { abi: unnamedAbi, name: "foo", args: [] }),
+    ).toThrow(/lacking names/);
+  });
+});

--- a/packages/blue-sdk-viem/tsconfig.build.cjs.json
+++ b/packages/blue-sdk-viem/tsconfig.build.cjs.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/cjs",
     "tsBuildInfoFile": "tsconfig.cjs.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/blue-sdk-viem/tsconfig.build.esm.json
+++ b/packages/blue-sdk-viem/tsconfig.build.esm.json
@@ -7,5 +7,12 @@
     "outDir": "./lib/esm",
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,7 +51,10 @@ export default defineConfig({
         extends: true,
         test: {
           name: "blue-sdk-viem",
-          include: ["packages/blue-sdk-viem/test/**/*.test.ts"],
+          include: [
+            "packages/blue-sdk-viem/test/**/*.test.ts",
+            "packages/blue-sdk-viem/src/**/*.test.ts",
+          ],
           testTimeout: 60_000,
         },
       },


### PR DESCRIPTION
Implements **Phase 7** of TIB-2026-04-27 (#556). Stacked on Phase 6 (#592).

## What lands

- `src/error.test.ts` — `isUnknownOfFactoryError` predicate (every branch).
- `src/utils.test.ts` — `safeParseNumber`, `safeParseUnits`, `safeGetAddress`, `restructure`.
- `src/augment/augment.test.ts` — every augmented blue-sdk class has a static `fetch` wired.
- `src/fetch/MarketParams.test.ts` — first colocated test using `createMockClient` + `mockRead` from `@morpho-org/test/mock` (Phase 2 primitives). Demonstrates cache-hit (no RPC) and cache-miss (RPC mocked at the morpho contract address) paths.
- Config: vitest union, tsconfig.build excludes.

## Out of scope for this PR

`MetaMorphoAction.ts` (332 LOC of encoders) and the rest of `fetch/*` / `queries/*` need extensive ABI round-trip tests. Easily landed in follow-ups now that the canonical mock pattern is established here.

## Test plan
- [x] `pnpm test --project blue-sdk-viem --run packages/blue-sdk-viem/src` → 4 files, 38 tests pass.
- [x] `pnpm --filter @morpho-org/blue-sdk-viem build` succeeds.
- [x] `find packages/blue-sdk-viem/lib -name "*.test.*"` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->