### PR TITLE
test(liquidation-sdk-viem): phase 8 — colocated tests for thresholds, helpers, sky, 1inch

### DIFF
--- a/packages/liquidation-sdk-viem/src/preLiquidation/helpers.test.ts
+++ b/packages/liquidation-sdk-viem/src/preLiquidation/helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { parseWithBigInt } from "./helpers.js";
+
+describe("parseWithBigInt", () => {
+  test("returns standard JSON values unchanged", () => {
+    expect(parseWithBigInt('{"a":1,"b":"x"}')).toEqual({ a: 1, b: "x" });
+  });
+
+  test("converts trailing-n strings to bigint", () => {
+    expect(parseWithBigInt('{"v":"123n"}')).toEqual({ v: 123n });
+  });
+
+  test("handles negative bigint strings", () => {
+    expect(parseWithBigInt('{"v":"-456n"}')).toEqual({ v: -456n });
+  });
+
+  test("handles bigints inside arrays", () => {
+    expect(parseWithBigInt('[1,"2n",3]')).toEqual([1, 2n, 3]);
+  });
+
+  test("nests through objects", () => {
+    expect(parseWithBigInt('{"a":{"b":"7n"}}')).toEqual({ a: { b: 7n } });
+  });
+
+  test("does not coerce strings that don't end in n", () => {
+    expect(parseWithBigInt('{"v":"123"}')).toEqual({ v: "123" });
+  });
+
+  test("does not coerce strings with non-digit content before n", () => {
+    expect(parseWithBigInt('{"v":"abcn"}')).toEqual({ v: "abcn" });
+    expect(parseWithBigInt('{"v":"12.3n"}')).toEqual({ v: "12.3n" });
+  });
+});

--- a/packages/liquidation-sdk-viem/src/swap/1inch.test.ts
+++ b/packages/liquidation-sdk-viem/src/swap/1inch.test.ts
@@ -1,0 +1,101 @@
+import nock from "nock";
+import { afterEach, describe, expect, test } from "vitest";
+import { OneInch } from "./1inch.js";
+import type { SwapParams } from "./types.js";
+
+const baseParams: SwapParams = {
+  src: "0x1111111111111111111111111111111111111111",
+  dst: "0x2222222222222222222222222222222222222222",
+  amount: "1000",
+  from: "0x3333333333333333333333333333333333333333",
+  origin: "0x3333333333333333333333333333333333333333",
+  slippage: "100",
+  chainId: 1,
+};
+
+describe("OneInch URL builders", () => {
+  test("getSwapApiPath builds /swap/v6.0/<chain>/swap", () => {
+    expect(OneInch.getSwapApiPath(1)).toBe("/swap/v6.0/1/swap");
+    expect(OneInch.getSwapApiPath(8453)).toBe("/swap/v6.0/8453/swap");
+  });
+
+  test("getSwapApiUrl appends to API_BASE_URL", () => {
+    expect(OneInch.getSwapApiUrl(1)).toBe(
+      "https://api.1inch.dev/swap/v6.0/1/swap",
+    );
+  });
+
+  test("API_BASE_URL is the canonical 1inch endpoint", () => {
+    expect(OneInch.API_BASE_URL).toBe("https://api.1inch.dev");
+  });
+});
+
+describe("OneInch.fetchSwap via nock", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("forwards search params and parses the response on 200", async () => {
+    nock("https://api.1inch.dev")
+      .get("/swap/v6.0/1/swap")
+      .query(true)
+      .reply(200, { dstAmount: "1000", tx: { to: "0xfeed" } });
+
+    const res = await OneInch.fetchSwap(baseParams, "test-key");
+    expect(res.dstAmount).toBe("1000");
+  });
+
+  test("converts slippage from basis points to percentage in the URL", async () => {
+    let observedSlippage: string | null = null;
+    nock("https://api.1inch.dev")
+      .get("/swap/v6.0/1/swap")
+      .query((q) => {
+        observedSlippage = q.slippage as string;
+        return true;
+      })
+      .reply(200, { dstAmount: "1" });
+
+    await OneInch.fetchSwap({ ...baseParams, slippage: "100" }, "k");
+    expect(observedSlippage).toBe("1"); // 100 bps -> 1%
+  });
+
+  test("throws when the upstream returns a non-OK status", async () => {
+    nock("https://api.1inch.dev")
+      .get("/swap/v6.0/1/swap")
+      .query(true)
+      .reply(500, "internal");
+
+    await expect(OneInch.fetchSwap(baseParams, "k")).rejects.toThrow();
+  });
+
+  test("sends the Authorization header with the api key", async () => {
+    let observedAuth: string | undefined;
+    nock("https://api.1inch.dev", {
+      reqheaders: {
+        authorization: (val) => {
+          observedAuth = val;
+          return true;
+        },
+      },
+    })
+      .get("/swap/v6.0/1/swap")
+      .query(true)
+      .reply(200, { dstAmount: "1" });
+
+    await OneInch.fetchSwap(baseParams, "abc123");
+    expect(observedAuth).toBe("Bearer abc123");
+  });
+
+  test("skips null/undefined params", async () => {
+    nock("https://api.1inch.dev")
+      .get("/swap/v6.0/1/swap")
+      .query((q) => {
+        // optional `fee` (set to undefined) must not appear in the query.
+        return q.fee == null;
+      })
+      .reply(200, { dstAmount: "1" });
+
+    const res = await OneInch.fetchSwap({ ...baseParams, fee: undefined }, "k");
+    expect(res.dstAmount).toBe("1");
+  });
+});

--- a/packages/liquidation-sdk-viem/src/thresholds.test.ts
+++ b/packages/liquidation-sdk-viem/src/thresholds.test.ts
@@ -1,0 +1,33 @@
+import { ChainId } from "@morpho-org/blue-sdk";
+import { parseEther } from "viem";
+import { describe, expect, test } from "vitest";
+import { collateralUsdThreshold } from "./thresholds.js";
+
+describe("collateralUsdThreshold", () => {
+  test("EthMainnet threshold is $1,000 (in WAD)", () => {
+    expect(collateralUsdThreshold[ChainId.EthMainnet]).toBe(parseEther("1000"));
+  });
+
+  test("BaseMainnet threshold is $2 (in WAD)", () => {
+    expect(collateralUsdThreshold[ChainId.BaseMainnet]).toBe(parseEther("2"));
+  });
+
+  test("PolygonMainnet threshold is $2 (in WAD)", () => {
+    expect(collateralUsdThreshold[ChainId.PolygonMainnet]).toBe(
+      parseEther("2"),
+    );
+  });
+
+  test("ArbitrumMainnet threshold is $2 (in WAD)", () => {
+    expect(collateralUsdThreshold[ChainId.ArbitrumMainnet]).toBe(
+      parseEther("2"),
+    );
+  });
+
+  test("all entries are non-negative bigints", () => {
+    for (const v of Object.values(collateralUsdThreshold)) {
+      expect(typeof v).toBe("bigint");
+      expect(v).toBeGreaterThan(0n);
+    }
+  });
+});

--- a/packages/liquidation-sdk-viem/src/tokens/sky.test.ts
+++ b/packages/liquidation-sdk-viem/src/tokens/sky.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+// importing the index causes registerCustomAddresses to run, populating
+// the mainnetAddresses (sky/usds/dai/mkr) used by the helpers below.
+import "../addresses.js";
+import { mainnetAddresses } from "../addresses.js";
+import { Sky } from "./sky.js";
+
+describe("Sky.getAlternativeToken", () => {
+  test("usds <-> dai", () => {
+    expect(Sky.getAlternativeToken(mainnetAddresses.usds!)).toBe(
+      mainnetAddresses.dai,
+    );
+    expect(Sky.getAlternativeToken(mainnetAddresses.dai!)).toBe(
+      mainnetAddresses.usds,
+    );
+  });
+  test("sky <-> mkr", () => {
+    expect(Sky.getAlternativeToken(mainnetAddresses.sky!)).toBe(
+      mainnetAddresses.mkr,
+    );
+    expect(Sky.getAlternativeToken(mainnetAddresses.mkr!)).toBe(
+      mainnetAddresses.sky,
+    );
+  });
+  test("throws for unsupported tokens", () => {
+    expect(() =>
+      Sky.getAlternativeToken("0x0000000000000000000000000000000000000001"),
+    ).toThrow(/Unsupported token/);
+  });
+});
+
+describe("Sky.isTokenPair", () => {
+  test("returns false when either side is missing", () => {
+    expect(Sky.isTokenPair(undefined, mainnetAddresses.dai)).toBe(false);
+    expect(Sky.isTokenPair(mainnetAddresses.dai, undefined)).toBe(false);
+  });
+  test("recognizes the four canonical pairs (both directions)", () => {
+    expect(Sky.isTokenPair(mainnetAddresses.usds, mainnetAddresses.dai)).toBe(
+      true,
+    );
+    expect(Sky.isTokenPair(mainnetAddresses.dai, mainnetAddresses.usds)).toBe(
+      true,
+    );
+    expect(Sky.isTokenPair(mainnetAddresses.sky, mainnetAddresses.mkr)).toBe(
+      true,
+    );
+    expect(Sky.isTokenPair(mainnetAddresses.mkr, mainnetAddresses.sky)).toBe(
+      true,
+    );
+  });
+  test("returns false for unrelated pairs", () => {
+    expect(Sky.isTokenPair(mainnetAddresses.dai, mainnetAddresses.sky)).toBe(
+      false,
+    );
+    expect(Sky.isTokenPair(mainnetAddresses.mkr, mainnetAddresses.dai)).toBe(
+      false,
+    );
+  });
+});
+
+describe("Sky.isSkyToken", () => {
+  test("returns true for the four sky/maker tokens", () => {
+    expect(Sky.isSkyToken(mainnetAddresses.mkr!)).toBe(true);
+    expect(Sky.isSkyToken(mainnetAddresses.sky!)).toBe(true);
+    expect(Sky.isSkyToken(mainnetAddresses.usds!)).toBe(true);
+    expect(Sky.isSkyToken(mainnetAddresses.dai!)).toBe(true);
+  });
+  test("returns false for unrelated addresses", () => {
+    expect(Sky.isSkyToken("0x0000000000000000000000000000000000000001")).toBe(
+      false,
+    );
+  });
+});
+
+describe("Sky.getConversionFunction", () => {
+  test("usds -> dai", () => {
+    expect(
+      Sky.getConversionFunction(mainnetAddresses.usds!, mainnetAddresses.dai!),
+    ).toBe("usdsToDai");
+  });
+  test("dai -> usds", () => {
+    expect(
+      Sky.getConversionFunction(mainnetAddresses.dai!, mainnetAddresses.usds!),
+    ).toBe("daiToUsds");
+  });
+  test("sky -> mkr", () => {
+    expect(
+      Sky.getConversionFunction(mainnetAddresses.sky!, mainnetAddresses.mkr!),
+    ).toBe("skyToMkr");
+  });
+  test("mkr -> sky", () => {
+    expect(
+      Sky.getConversionFunction(mainnetAddresses.mkr!, mainnetAddresses.sky!),
+    ).toBe("mkrToSky");
+  });
+  test("throws on unsupported conversion", () => {
+    expect(() =>
+      Sky.getConversionFunction(mainnetAddresses.dai!, mainnetAddresses.sky!),
+    ).toThrow(/Unsupported token conversion/);
+  });
+});

--- a/packages/liquidation-sdk-viem/tsconfig.build.cjs.json
+++ b/packages/liquidation-sdk-viem/tsconfig.build.cjs.json
@@ -8,5 +8,12 @@
     "tsBuildInfoFile": "tsconfig.cjs.tsbuildinfo"
   },
   "include": ["src"],
-  "files": []
+  "files": [],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/packages/liquidation-sdk-viem/tsconfig.build.esm.json
+++ b/packages/liquidation-sdk-viem/tsconfig.build.esm.json
@@ -8,5 +8,12 @@
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
   "include": ["src"],
-  "files": []
+  "files": [],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/__test-utils__/**",
+    "src/**/__mocks__/**",
+    "src/**/__fixtures__/**"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -112,7 +112,10 @@ export default defineConfig({
         extends: true,
         test: {
           name: "liquidation-sdk-viem",
-          include: ["packages/liquidation-sdk-viem/test/**/*.test.ts"],
+          include: [
+            "packages/liquidation-sdk-viem/test/**/*.test.ts",
+            "packages/liquidation-sdk-viem/src/**/*.test.ts",
+          ],
           testTimeout: 90_000,
         },
       },


### PR DESCRIPTION
Implements **Phase 8** of TIB-2026-04-27 (#556) — final phase. Stacked on Phase 7 (#593).

## What lands

- `src/thresholds.test.ts` — `collateralUsdThreshold` per chain.
- `src/preLiquidation/helpers.test.ts` — `parseWithBigInt` (trailing-n coercion, negatives, arrays, nested, non-matching).
- `src/swap/1inch.test.ts` — URL builders + `fetchSwap` end-to-end via `nock` (success, slippage bps→%, Authorization header, 5xx error path, optional-param skipping).
- `src/tokens/sky.test.ts` — `getAlternativeToken`, `isTokenPair`, `isSkyToken`, `getConversionFunction` (every branch).
- Config: vitest union, tsconfig.build excludes.

## Out of scope for this PR

`LiquidationEncoder.ts` (1,001 LOC, the big one), `swap/paraswap.ts`, `flashbots.ts`, and the token-specific encoders (`midas.ts`, `pendle.ts`, `spectra.ts`) need extensive follow-up tests. The canonical `nock` pattern is established here so they're easy to add.

## Test plan
- [x] `pnpm test --project liquidation-sdk-viem --run packages/liquidation-sdk-viem/src` → 4 files, 33 tests pass.
- [x] `pnpm --filter @morpho-org/liquidation-sdk-viem build` succeeds.
- [x] `find packages/liquidation-sdk-viem/lib -name "*.test.*"` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->