### PR TITLE
ci: Slack PR notifications for #sdks-reviews

### DIFF
--- a/.github/actions/extract-linear-id/action.yml
+++ b/.github/actions/extract-linear-id/action.yml
@@ -1,0 +1,101 @@
+name: Extract Linear Issue ID
+description: Extracts a Linear issue ID from a PR body or branch name
+
+inputs:
+  pr-body:
+    description: The PR body text
+    required: false
+    default: ''
+  branch-name:
+    description: The branch name (e.g., feature/apps-123-description)
+    required: false
+    default: ''
+  commits-json:
+    description: JSON array of commit objects from pulls.listCommits() — each must have a .commit.message field
+    required: false
+    default: ''
+
+outputs:
+  found:
+    description: Whether a Linear issue ID was found
+    value: ${{ steps.extract.outputs.found }}
+  issue_id:
+    description: The Linear issue ID (e.g., APPS-123)
+    value: ${{ steps.extract.outputs.issue_id }}
+  url:
+    description: The full Linear issue URL
+    value: ${{ steps.extract.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Extract Linear ID
+      id: extract
+      shell: bash
+      # PR body is passed via env var (not interpolated into the script)
+      # to avoid injection from PR bodies containing special characters.
+      env:
+        PR_BODY: ${{ inputs.pr-body }}
+        BRANCH_NAME: ${{ inputs.branch-name }}
+        COMMITS_JSON: ${{ inputs.commits-json }}
+      run: |
+        ISSUE_ID=""
+        URL=""
+
+        # 1. Check for existing Linear URL in PR body (most reliable)
+        #    Linear URLs use lowercase IDs, so match case-insensitively and uppercase afterward
+        if [[ "$PR_BODY" =~ https://linear\.app/([^[:space:]/]+)/issue/([A-Za-z]{2,10}-[0-9]+) ]]; then
+          ISSUE_ID=$(echo "${BASH_REMATCH[2]}" | tr '[:lower:]' '[:upper:]')
+          URL="${BASH_REMATCH[0]}"
+        fi
+
+        # 2. Check branch name (e.g., feature/crtr-1892-description)
+        if [[ -z "$ISSUE_ID" && -n "$BRANCH_NAME" ]]; then
+          SEGMENT="${BRANCH_NAME##*/}"
+          UPPER_SEGMENT=$(echo "$SEGMENT" | tr '[:lower:]' '[:upper:]')
+          EXCLUDED="^(ERC|EIP|BIP|BEP|SIP|KIP|SEP|RFC|CIP|AIP|PIP|MIP|ADR|TIB)-"
+          if [[ "$UPPER_SEGMENT" =~ ^([A-Z]{2,10}-[0-9]+) ]]; then
+            CANDIDATE="${BASH_REMATCH[1]}"
+            if [[ ! "$CANDIDATE" =~ $EXCLUDED ]]; then
+              ISSUE_ID="$CANDIDATE"
+            fi
+          fi
+        fi
+
+        # 3. Check commit messages for Linear ID
+        if [[ -z "$ISSUE_ID" && -n "$COMMITS_JSON" ]]; then
+          EXCLUDED="^(ERC|EIP|BIP|BEP|SIP|KIP|SEP|RFC|CIP|AIP|PIP|MIP|ADR|TIB)-"
+          while IFS= read -r CANDIDATE; do
+            if [[ -n "$CANDIDATE" && ! "$CANDIDATE" =~ $EXCLUDED ]]; then
+              ISSUE_ID="$CANDIDATE"
+              break
+            fi
+          done < <(echo "$COMMITS_JSON" | jq -r '.[].commit.message' 2>/dev/null \
+            | grep -oE '\b[A-Z]{2,10}-[0-9]+\b')
+        fi
+
+        # 4. Check PR body for raw Linear ID, excluding common non-Linear prefixes
+        #    (e.g., ERC-4626, EIP-1559 are standard identifiers, not Linear tickets)
+        #    This is the least reliable check, so it runs last.
+        if [[ -z "$ISSUE_ID" ]]; then
+          EXCLUDED="^(ERC|EIP|BIP|BEP|SIP|KIP|SEP|RFC|CIP|AIP|PIP|MIP|ADR|TIB)-"
+          while IFS= read -r CANDIDATE; do
+            if [[ -n "$CANDIDATE" && ! "$CANDIDATE" =~ $EXCLUDED ]]; then
+              ISSUE_ID="$CANDIDATE"
+              break
+            fi
+          done < <(echo "$PR_BODY" | grep -oE '\b[A-Z]{2,10}-[0-9]+\b')
+        fi
+
+        # Build URL if we found an ID without a URL
+        if [[ -n "$ISSUE_ID" && -z "$URL" ]]; then
+          URL="https://linear.app/morpho-labs/issue/${ISSUE_ID}"
+        fi
+
+        if [[ -n "$ISSUE_ID" ]]; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "issue_id=$ISSUE_ID" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/extract-slack-ts/action.yml
+++ b/.github/actions/extract-slack-ts/action.yml
@@ -1,0 +1,74 @@
+name: Extract Slack Thread Timestamps
+description: Fetches a PR body via the GitHub API and extracts Slack thread markers from it
+
+inputs:
+  pr-number:
+    description: The PR number to fetch the body for
+    required: true
+  github-token:
+    description: GitHub token used to fetch the PR body
+    required: true
+
+outputs:
+  thread_ts:
+    description: The main Slack thread timestamp
+    value: ${{ steps.extract.outputs.thread_ts }}
+  found:
+    description: Whether a main thread timestamp was found
+    value: ${{ steps.extract.outputs.found }}
+  quick_win_channel:
+    description: The quick-win DM channel ID
+    value: ${{ steps.extract.outputs.quick_win_channel }}
+  quick_win_ts:
+    description: The quick-win DM thread timestamp
+    value: ${{ steps.extract.outputs.quick_win_ts }}
+  quick_win_found:
+    description: Whether a quick-win DM timestamp was found
+    value: ${{ steps.extract.outputs.quick_win_found }}
+
+runs:
+  using: composite
+  steps:
+    # Always fetch the body via the api rather than using
+    # `github.event.pull_request.body` — the event payload is frozen at
+    # webhook delivery time, which loses the `slack-thread-ts` marker if
+    # another event's `notify-pr-ready` wrote it after this event's
+    # payload was captured.
+    - name: Fetch PR body
+      id: fetch
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      env:
+        PR_NUMBER: ${{ inputs.pr-number }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        result-encoding: string
+        script: |
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: parseInt(process.env.PR_NUMBER, 10),
+          });
+          return pr.body || '';
+
+    - name: Extract timestamps
+      id: extract
+      shell: bash
+      # PR body is passed via env var (not interpolated into the script)
+      # to avoid injection from PR bodies containing special characters.
+      env:
+        PR_BODY: ${{ steps.fetch.outputs.result }}
+      run: |
+        if [[ "$PR_BODY" =~ \<\!--\ slack-thread-ts:([0-9.]+)\ --\> ]]; then
+          echo "thread_ts=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        if [[ "$PR_BODY" =~ \<\!--\ slack-quick-win-dm:([^:]+):([0-9.]+)\ --\> ]]; then
+          echo "quick_win_channel=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          echo "quick_win_ts=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+          echo "quick_win_found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "quick_win_found=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/find-slack-thread/action.yml
+++ b/.github/actions/find-slack-thread/action.yml
@@ -1,0 +1,66 @@
+name: Find Existing Slack Thread
+description: Searches Slack channel history for an existing thread about a PR
+
+inputs:
+  slack-token:
+    description: Slack bot token for API access
+    required: true
+  channel-id:
+    description: Slack channel ID to search
+    required: true
+  pr-url:
+    description: The GitHub PR URL to search for in message text
+    required: true
+
+outputs:
+  found:
+    description: Whether an existing thread was found
+    value: ${{ steps.search.outputs.found }}
+  thread_ts:
+    description: The timestamp of the existing Slack message
+    value: ${{ steps.search.outputs.thread_ts }}
+
+runs:
+  using: composite
+  steps:
+    - name: Search Slack channel for existing PR thread
+      id: search
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      env:
+        SLACK_TOKEN: ${{ inputs.slack-token }}
+        CHANNEL_ID: ${{ inputs.channel-id }}
+        PR_URL: ${{ inputs.pr-url }}
+      with:
+        script: |
+          const res = await fetch(
+            `https://slack.com/api/conversations.history?channel=${encodeURIComponent(process.env.CHANNEL_ID)}&limit=50`,
+            {
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_TOKEN}`,
+                'Content-Type': 'application/json'
+              }
+            }
+          );
+          const data = await res.json();
+
+          if (!data.ok) {
+            core.warning(`Slack conversations.history failed: ${data.error}`);
+            core.setOutput('found', 'false');
+            core.setOutput('thread_ts', '');
+            return;
+          }
+
+          const prUrl = process.env.PR_URL;
+          const match = (data.messages || []).find(
+            msg => msg.text && msg.text.includes(prUrl)
+          );
+
+          if (match) {
+            core.info(`Found existing Slack thread for ${prUrl}: ts=${match.ts}`);
+            core.setOutput('found', 'true');
+            core.setOutput('thread_ts', match.ts);
+          } else {
+            core.info(`No existing Slack thread found for ${prUrl}`);
+            core.setOutput('found', 'false');
+            core.setOutput('thread_ts', '');
+          }

--- a/.github/actions/map-pr-emoji/action.yml
+++ b/.github/actions/map-pr-emoji/action.yml
@@ -1,0 +1,57 @@
+name: Map PR Title to Emoji
+description: Maps a PR title to a scope/type-based Slack emoji
+
+inputs:
+  pr-title:
+    description: The PR title (following the title convention)
+    required: true
+
+outputs:
+  emoji:
+    description: The Slack emoji code (e.g., :bank:, :sparkles:)
+    value: ${{ steps.map.outputs.emoji }}
+
+runs:
+  using: composite
+  steps:
+    - name: Map title to emoji
+      id: map
+      shell: bash
+      env:
+        PR_TITLE: ${{ inputs.pr-title }}
+      run: |
+        SCOPE_RE='^([a-zA-Z]+)\(([^)]+)\)'
+        TYPE_RE='^([a-zA-Z]+):'
+        if [[ "$PR_TITLE" =~ $SCOPE_RE ]]; then
+          TYPE="${BASH_REMATCH[1]}"
+          SCOPE="${BASH_REMATCH[2]}"
+        elif [[ "$PR_TITLE" =~ $TYPE_RE ]]; then
+          TYPE="${BASH_REMATCH[1]}"
+          SCOPE=""
+        else
+          TYPE=""
+          SCOPE=""
+        fi
+
+        # Scope-specific emoji (takes priority)
+        case "$SCOPE" in
+          curator|curator-v2|cv1|cv2) echo "emoji=:bank:" >> $GITHUB_OUTPUT; exit 0 ;;
+          markets|markets-v2) echo "emoji=:bar_chart:" >> $GITHUB_OUTPUT; exit 0 ;;
+          liquidation) echo "emoji=:droplet:" >> $GITHUB_OUTPUT; exit 0 ;;
+          delegate) echo "emoji=:handshake:" >> $GITHUB_OUTPUT; exit 0 ;;
+          web3) echo "emoji=:link:" >> $GITHUB_OUTPUT; exit 0 ;;
+          ui) echo "emoji=:art:" >> $GITHUB_OUTPUT; exit 0 ;;
+        esac
+
+        # Type-based emoji fallback
+        case "$TYPE" in
+          feat) echo "emoji=:sparkles:" >> $GITHUB_OUTPUT ;;
+          fix) echo "emoji=:bug:" >> $GITHUB_OUTPUT ;;
+          refactor) echo "emoji=:recycle:" >> $GITHUB_OUTPUT ;;
+          chore) echo "emoji=:broom:" >> $GITHUB_OUTPUT ;;
+          docs) echo "emoji=:memo:" >> $GITHUB_OUTPUT ;;
+          test) echo "emoji=:test_tube:" >> $GITHUB_OUTPUT ;;
+          ci) echo "emoji=:gear:" >> $GITHUB_OUTPUT ;;
+          perf) echo "emoji=:zap:" >> $GITHUB_OUTPUT ;;
+          *) echo "emoji=:rocket:" >> $GITHUB_OUTPUT ;;
+        esac

--- a/.github/team-members.json
+++ b/.github/team-members.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Maps GitHub team slugs → member GitHub handles → Slack user IDs. Used by PR notification workflows to route Slack DMs. Team slugs must match @morpho-org/<slug> on GitHub.",
+  "teams": {
+    "curator-team": {
+      "cashd": "U08B2J6D788",
+      "BZahory": "U0AAGS3BJ5D",
+      "haydenshively": "U089XEG69E2"
+    },
+    "markets-team": {
+      "garethfuller": "U08ASENTN3T",
+      "rfviolato": "U08KZ95UW5B",
+      "haydenshively": "U089XEG69E2",
+      "spennyp": "U06QKE1VBA7"
+    },
+    "apps-admins": {
+      "garethfuller": "U08ASENTN3T",
+      "tarikbellamine": "U09CFDG26VA",
+      "0xbulma": "U06BS7VN03W"
+    },
+    "marketing-team": {
+      "zouloux": "U07SMN7425U",
+      "remiroyc": "U08B2J6LCHW",
+      "0xbulma": "U06BS7VN03W"
+    },
+    "product-apps-team": {
+      "batteer": "U05FB0XEM7Y",
+      "100-dro": "U07P4F10L3B"
+    },
+    "apps-tech-leads": {
+      "cashd": "U08B2J6D788",
+      "spennyp": "U06QKE1VBA7",
+      "0xbulma": "U06BS7VN03W"
+    },
+    "apps-maintainers": {
+      "garethfuller": "U08ASENTN3T",
+      "cashd": "U08B2J6D788",
+      "haydenshively": "U089XEG69E2",
+      "spennyp": "U06QKE1VBA7",
+      "0xbulma": "U06BS7VN03W"
+    },
+    "integration-apps-team": {
+      "tomrpl": "U03TC9S0CE4"
+    },
+    "vvrm-team": {
+      "alexbensimon": "U08D4PDSDBQ",
+      "remiroyc": "U08B2J6LCHW",
+      "Foulks-Plb": "U07G2B1ANLW",
+      "0xbulma": "U06BS7VN03W"
+    }
+  },
+  "members": {
+    "batteer": "U05FB0XEM7Y",
+    "rfviolato": "U08KZ95UW5B",
+    "garethfuller": "U08ASENTN3T",
+    "haydenshively": "U089XEG69E2",
+    "Jean-Grimal": "U05A615L5DX",
+    "jonator": "U0AB9SSMSKH",
+    "BZahory": "U0AAGS3BJ5D",
+    "cashd": "U08B2J6D788",
+    "spennyp": "U06QKE1VBA7",
+    "remiroyc": "U08B2J6LCHW",
+    "PierreMorpho": "U08CWP0JQ23",
+    "Foulks-Plb": "U07G2B1ANLW",
+    "alexbensimon": "U08D4PDSDBQ",
+    "zouloux": "U07SMN7425U",
+    "0xbulma": "U06BS7VN03W",
+    "the-real-chrizzo": "U0AGM5D0YAG",
+    "tomrpl": "U03TC9S0CE4",
+    "100-dro": "U07P4F10L3B",
+    "tarikbellamine": "U09CFDG26VA"
+  }
+}

--- a/.github/team-members.json
+++ b/.github/team-members.json
@@ -9,7 +9,7 @@
     "tomrpl": "U03TC9S0CE4",
     "alexbensimon": "U08D4PDSDBQ",
     "remiroyc": "U08B2J6LCHW",
-    "oumar-fall": null,
-    "Rubilmax": null
+    "oumar-fall": "U02NMGCRVGA",
+    "Rubilmax": "U03L0SC1JUR"
   }
 }

--- a/.github/team-members.json
+++ b/.github/team-members.json
@@ -1,73 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$comment": "Maps GitHub team slugs → member GitHub handles → Slack user IDs. Used by PR notification workflows to route Slack DMs. Team slugs must match @morpho-org/<slug> on GitHub.",
-  "teams": {
-    "curator-team": {
-      "cashd": "U08B2J6D788",
-      "BZahory": "U0AAGS3BJ5D",
-      "haydenshively": "U089XEG69E2"
-    },
-    "markets-team": {
-      "garethfuller": "U08ASENTN3T",
-      "rfviolato": "U08KZ95UW5B",
-      "haydenshively": "U089XEG69E2",
-      "spennyp": "U06QKE1VBA7"
-    },
-    "apps-admins": {
-      "garethfuller": "U08ASENTN3T",
-      "tarikbellamine": "U09CFDG26VA",
-      "0xbulma": "U06BS7VN03W"
-    },
-    "marketing-team": {
-      "zouloux": "U07SMN7425U",
-      "remiroyc": "U08B2J6LCHW",
-      "0xbulma": "U06BS7VN03W"
-    },
-    "product-apps-team": {
-      "batteer": "U05FB0XEM7Y",
-      "100-dro": "U07P4F10L3B"
-    },
-    "apps-tech-leads": {
-      "cashd": "U08B2J6D788",
-      "spennyp": "U06QKE1VBA7",
-      "0xbulma": "U06BS7VN03W"
-    },
-    "apps-maintainers": {
-      "garethfuller": "U08ASENTN3T",
-      "cashd": "U08B2J6D788",
-      "haydenshively": "U089XEG69E2",
-      "spennyp": "U06QKE1VBA7",
-      "0xbulma": "U06BS7VN03W"
-    },
-    "integration-apps-team": {
-      "tomrpl": "U03TC9S0CE4"
-    },
-    "vvrm-team": {
-      "alexbensimon": "U08D4PDSDBQ",
-      "remiroyc": "U08B2J6LCHW",
-      "Foulks-Plb": "U07G2B1ANLW",
-      "0xbulma": "U06BS7VN03W"
-    }
-  },
+  "$comment": "Maps GitHub handles → Slack user IDs for SDK contributors. Used by the PR Slack notification workflow to route DMs. Entries with a null Slack ID are skipped (no DM sent).",
+  "teams": {},
   "members": {
-    "batteer": "U05FB0XEM7Y",
-    "rfviolato": "U08KZ95UW5B",
-    "garethfuller": "U08ASENTN3T",
-    "haydenshively": "U089XEG69E2",
     "Jean-Grimal": "U05A615L5DX",
-    "jonator": "U0AB9SSMSKH",
-    "BZahory": "U0AAGS3BJ5D",
-    "cashd": "U08B2J6D788",
-    "spennyp": "U06QKE1VBA7",
-    "remiroyc": "U08B2J6LCHW",
-    "PierreMorpho": "U08CWP0JQ23",
     "Foulks-Plb": "U07G2B1ANLW",
-    "alexbensimon": "U08D4PDSDBQ",
-    "zouloux": "U07SMN7425U",
     "0xbulma": "U06BS7VN03W",
-    "the-real-chrizzo": "U0AGM5D0YAG",
     "tomrpl": "U03TC9S0CE4",
-    "100-dro": "U07P4F10L3B",
-    "tarikbellamine": "U09CFDG26VA"
+    "alexbensimon": "U08D4PDSDBQ",
+    "remiroyc": "U08B2J6LCHW",
+    "oumar-fall": null,
+    "Rubilmax": null
   }
 }

--- a/.github/workflows/pr-slack-notify.yml
+++ b/.github/workflows/pr-slack-notify.yml
@@ -1,0 +1,957 @@
+name: PR Slack Notifications
+
+# Sends PR lifecycle updates to the #sdks-reviews Slack channel.
+#
+# Setup (one-time, repo settings):
+#   - secrets.SLACK_BOT_TOKEN — bot token for the Slack app posting messages.
+#     The bot must be invited to #sdks-reviews and needs scopes:
+#       chat:write, channels:history, reactions:write, im:write.
+#   - vars.SLACK_CHANNEL_ID — channel ID for #sdks-reviews
+#     (right-click the channel → "View channel details" → copy the ID at the bottom).
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to test notification'
+        required: true
+        type: number
+  pull_request:
+    types: [opened, ready_for_review, review_requested, closed, labeled, unlabeled, edited]
+  pull_request_review:
+    types: [submitted]
+
+env:
+  SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+
+jobs:
+  notify-pr-ready:
+    # Fires on:
+    # - PR opened (non-draft)
+    # - PR transitions from draft → ready for review
+    # - Reviewer assigned (safety net — CODEOWNERS auto-assignment can land
+    #   AFTER `opened` / `ready_for_review` fires, leaving the script with
+    #   zero reviewers; the next `review_requested` event then catches it)
+    # - Manual dispatch (testing)
+    #
+    # Duplicate-send protection: the script checks for the
+    # `<!-- slack-thread-ts:<ts> -->` marker in the PR body before posting,
+    # so subsequent events on the same PR no-op. The check uses a regex
+    # that requires the numeric timestamp payload; a bare HTML comment or
+    # a PR description that *mentions* the marker (e.g. this workflow's
+    # own docs/PRs) must not trip the guard.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       (github.event.action == 'opened' ||
+        github.event.action == 'ready_for_review' ||
+        github.event.action == 'review_requested'))
+    concurrency:
+      group: slack-notify-${{ github.event.pull_request.number || inputs.pr_number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/team-members.json
+          sparse-checkout-cone-mode: false
+
+      - name: Load GitHub → Slack mapping
+        run: |
+          echo "GITHUB_TO_SLACK_MAPPING=$(jq -c '.members | with_entries(select(.value != null))' .github/team-members.json)" >> "$GITHUB_ENV"
+          echo "GITHUB_TEAMS=$(jq -c '.teams' .github/team-members.json)" >> "$GITHUB_ENV"
+
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          MAPPING: ${{ env.GITHUB_TO_SLACK_MAPPING }}
+          TEAMS: ${{ env.GITHUB_TEAMS }}
+        with:
+          script: |
+            const prNumber = context.eventName === 'workflow_dispatch'
+              ? ${{ inputs.pr_number || 0 }}
+              : context.payload.pull_request.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // Get reviewers who have already submitted reviews
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            // Fetch requested reviewers from the dedicated endpoint —
+            // `pulls.get` returns an empty `requested_teams` array under
+            // the workflow's GITHUB_TOKEN even when teams are actually
+            // requested, so team expansion must go through
+            // `listRequestedReviewers` instead.
+            const requested = await github.rest.pulls.listRequestedReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // Collect unique reviewers from both requested and those who have reviewed
+            const reviewerLogins = new Set();
+            (requested.data.users || []).filter(r => r.type !== 'Bot').forEach(r => reviewerLogins.add(r.login));
+            reviews.data.forEach(r => {
+              if (r.user.login !== pr.user.login && r.user.type !== 'Bot') {
+                reviewerLogins.add(r.user.login);
+              }
+            });
+
+            // Expand team review requests into individual members
+            const teams = JSON.parse(process.env.TEAMS);
+            let unexpandedTeams = 0;
+            for (const team of (requested.data.teams || [])) {
+              const members = teams[team.slug];
+              if (members) {
+                for (const login of Object.keys(members)) {
+                  if (login !== pr.user.login) reviewerLogins.add(login);
+                }
+              } else {
+                unexpandedTeams++;
+              }
+            }
+
+            const totalReviewers = reviewerLogins.size + unexpandedTeams;
+
+            // Skip checks for manual dispatch (testing)
+            if (context.eventName !== 'workflow_dispatch') {
+              if (pr.draft || totalReviewers < 1) {
+                core.setOutput('skip', 'true');
+                return;
+              }
+              if (pr.body && /<!-- slack-thread-ts:[0-9.]+ -->/.test(pr.body)) {
+                core.setOutput('skip', 'true');
+                return;
+              }
+            }
+
+            // Map users to Slack IDs
+            const mapping = JSON.parse(process.env.MAPPING);
+
+            const authorSlackId = mapping[pr.user.login];
+            const author = authorSlackId ? `<@${authorSlackId}>` : pr.user.login;
+
+            const reviewerMentions = [...reviewerLogins].join(', ');
+
+            const reviewerDmTargets = [...reviewerLogins]
+              .map(login => ({ login, slackId: mapping[login] }))
+              .filter(t => t.slackId);
+
+            // Extract criticality label
+            const criticalityLabel = (pr.labels || [])
+              .map(l => l.name)
+              .find(n => n.toLowerCase().startsWith('criticality:')) || '';
+            const criticality = criticalityLabel.replace(/^criticality:/i, '');
+
+            // Escape backslashes and double quotes so the title is safe
+            // inside YAML double-quoted strings (YAML will un-escape them).
+            const safeTitle = pr.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+            // Fetch commits for Linear ID extraction from commit messages
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            core.setOutput('skip', 'false');
+            core.setOutput('number', pr.number);
+            core.setOutput('title', safeTitle);
+            core.setOutput('raw_title', pr.title);
+            core.setOutput('html_url', pr.html_url);
+            core.setOutput('author', author);
+
+            core.setOutput('branch_ref', pr.head.ref);
+            core.setOutput('body', pr.body || '');
+            core.setOutput('commits_json', JSON.stringify(commits.data));
+            core.setOutput('reviewers', reviewerMentions);
+            core.setOutput('reviewer_dm_targets', JSON.stringify(reviewerDmTargets));
+            core.setOutput('criticality', criticality);
+
+      - name: Map PR title to emoji
+        if: steps.pr.outputs.skip != 'true'
+        id: emoji
+        uses: ./.github/actions/map-pr-emoji
+        with:
+          pr-title: ${{ steps.pr.outputs.title }}
+
+      - name: Extract Linear issue ID
+        if: steps.pr.outputs.skip != 'true'
+        id: linear
+        uses: ./.github/actions/extract-linear-id
+        with:
+          pr-body: ${{ steps.pr.outputs.body }}
+          branch-name: ${{ steps.pr.outputs.branch_ref }}
+          commits-json: ${{ steps.pr.outputs.commits_json }}
+
+      - name: Check Slack for existing thread
+        if: steps.pr.outputs.skip != 'true'
+        id: slack-check
+        uses: ./.github/actions/find-slack-thread
+        with:
+          slack-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          pr-url: ${{ steps.pr.outputs.html_url }}
+
+      - name: Backfill PR body with existing thread reference
+        if: steps.pr.outputs.skip != 'true' && steps.slack-check.outputs.found == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const ts = '${{ steps.slack-check.outputs.thread_ts }}';
+            const channelId = '${{ env.SLACK_CHANNEL_ID }}';
+            const prNumber = ${{ steps.pr.outputs.number }};
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const body = pr.body || '';
+
+            if (!/<!-- slack-thread-ts:[0-9.]+ -->/.test(body)) {
+              const slackLink = `https://morpho-labs.slack.com/archives/${channelId}/p${ts.replace('.', '')}`;
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                body: body + `\n\n[View Slack thread](${slackLink})\n<!-- slack-thread-ts:${ts} -->`
+              });
+              core.info(`Backfilled PR body with existing Slack thread ts=${ts}`);
+            }
+
+      - name: Send Slack notification
+        if: steps.pr.outputs.skip != 'true' && steps.slack-check.outputs.found != 'true'
+        id: slack
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            unfurl_links: false
+            unfurl_media: false
+            text: "${{ steps.emoji.outputs.emoji }} <${{ steps.pr.outputs.html_url }}|${{ steps.pr.outputs.title }}>\n\nBy: ${{ steps.pr.outputs.author }}${{ steps.pr.outputs.reviewers && format('\nReviewers: {0}', steps.pr.outputs.reviewers) || '' }}${{ steps.pr.outputs.criticality && format('\nCriticality: `{0}`', steps.pr.outputs.criticality) || '' }}${{ steps.linear.outputs.url && format('\nTicket: <{0}|{1}>', steps.linear.outputs.url, steps.linear.outputs.issue_id) || '' }}"
+
+      - name: Update PR with Slack thread reference
+        if: steps.pr.outputs.skip != 'true' && steps.slack-check.outputs.found != 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          # There can be a race condition between job executions (e.g. due to concurrent github events)
+          # which will cause this step to overwrite the PR body and remove existing thread references.
+          # To mitigate this, we first fetch the current PR body and append to it (and only if the reference is not already present!).
+          script: |
+            const ts = '${{ fromJSON(steps.slack.outputs.response).ts }}';
+            const channelId = '${{ env.SLACK_CHANNEL_ID }}';
+            const prNumber = ${{ steps.pr.outputs.number }};
+
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const body = pr.data.body || '';
+
+            if (!/<!-- slack-thread-ts:[0-9.]+ -->/.test(body)) {
+              const slackLink = `https://morpho-labs.slack.com/archives/${channelId}/p${ts.replace('.', '')}`;
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                body: body + `\n\n[View Slack thread](${slackLink})\n<!-- slack-thread-ts:${ts} -->`
+              });
+            }
+
+      - name: Send reviewer DMs
+        if: steps.pr.outputs.skip != 'true' && steps.slack-check.outputs.found != 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: ${{ env.SLACK_CHANNEL_ID }}
+          DM_TARGETS: ${{ steps.pr.outputs.reviewer_dm_targets }}
+          SLACK_RESPONSE: ${{ steps.slack.outputs.response }}
+          PR_URL: ${{ steps.pr.outputs.html_url }}
+          PR_TITLE: ${{ steps.pr.outputs.raw_title }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+        with:
+          script: |
+            const targets = JSON.parse(process.env.DM_TARGETS);
+            if (!targets.length) return;
+
+            const ts = JSON.parse(process.env.SLACK_RESPONSE).ts;
+            const channelId = process.env.CHANNEL_ID;
+            const threadLink = `https://morpho-labs.slack.com/archives/${channelId}/p${ts.replace('.', '')}`;
+
+            for (const { slackId } of targets) {
+              const res = await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.SLACK_TOKEN}`,
+                  'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                  channel: slackId,
+                  unfurl_links: false,
+                  unfurl_media: false,
+                  text: `${process.env.AUTHOR} requested your review on <${process.env.PR_URL}|${process.env.PR_TITLE}>.\n<${threadLink}|View Slack thread>`
+                })
+              });
+              const data = await res.json();
+              if (!data.ok) core.warning(`Slack DM failed for ${slackId}: ${data.error}`);
+            }
+
+  notify-review:
+    if: github.event_name == 'pull_request_review' && github.event.review.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Extract Slack thread timestamps from PR body
+        id: get-ts
+        uses: ./.github/actions/extract-slack-ts
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get reviewer name
+        if: steps.get-ts.outputs.found == 'true'
+        id: reviewer
+        env:
+          REVIEWER_LOGIN: ${{ github.event.review.user.login }}
+        run: echo "name=$REVIEWER_LOGIN" >> $GITHUB_OUTPUT
+
+      - name: Determine review status emoji and text
+        if: steps.get-ts.outputs.found == 'true'
+        id: review-status
+        env:
+          REVIEW_STATE: ${{ github.event.review.state }}
+        run: |
+          case "$REVIEW_STATE" in
+            "approved")
+              echo "emoji=:white_check_mark:" >> $GITHUB_OUTPUT
+              echo "text=approved" >> $GITHUB_OUTPUT
+              ;;
+            "changes_requested")
+              echo "emoji=:warning:" >> $GITHUB_OUTPUT
+              echo "text=requested changes" >> $GITHUB_OUTPUT
+              ;;
+            "commented")
+              echo "emoji=:speech_balloon:" >> $GITHUB_OUTPUT
+              echo "text=commented" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "emoji=:eyes:" >> $GITHUB_OUTPUT
+              echo "text=reviewed" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Send review update to Slack thread
+        if: steps.get-ts.outputs.found == 'true'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.get-ts.outputs.thread_ts }}"
+            text: "${{ steps.review-status.outputs.emoji }} ${{ steps.reviewer.outputs.name }} <${{ github.event.review.html_url }}|${{ steps.review-status.outputs.text }}>"
+
+      - name: Send review update to quick-win DM thread
+        if: steps.get-ts.outputs.found == 'true' && steps.get-ts.outputs.quick_win_found == 'true'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ steps.get-ts.outputs.quick_win_channel }}
+            thread_ts: "${{ steps.get-ts.outputs.quick_win_ts }}"
+            text: "${{ steps.review-status.outputs.emoji }} ${{ steps.reviewer.outputs.name }} <${{ github.event.review.html_url }}|${{ steps.review-status.outputs.text }}>"
+
+  notify-re-review-requested:
+    if: github.event_name == 'pull_request' && github.event.action == 'review_requested'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/team-members.json
+          sparse-checkout-cone-mode: false
+
+      - name: Load GitHub → Slack mapping
+        run: |
+          echo "GITHUB_TO_SLACK_MAPPING=$(jq -c '.members | with_entries(select(.value != null))' .github/team-members.json)" >> "$GITHUB_ENV"
+          echo "GITHUB_TEAMS=$(jq -c '.teams' .github/team-members.json)" >> "$GITHUB_ENV"
+
+      - name: Check if this is a re-review request
+        id: check-re-review
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          MAPPING: ${{ env.GITHUB_TO_SLACK_MAPPING }}
+          TEAMS: ${{ env.GITHUB_TEAMS }}
+        with:
+          script: |
+            const mapping = JSON.parse(process.env.MAPPING);
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            // Case 1: Individual reviewer re-requested
+            const requestedReviewer = context.payload.requested_reviewer?.login;
+            if (requestedReviewer) {
+              const hasReviewedBefore = reviews.data.some(
+                review => review.user.login === requestedReviewer
+              );
+              if (!hasReviewedBefore) {
+                core.setOutput('is_re_review', 'false');
+                return;
+              }
+              const slackId = mapping[requestedReviewer];
+              core.setOutput('is_re_review', 'true');
+              core.setOutput('name', requestedReviewer);
+              core.setOutput('slack_id', slackId || '');
+              core.setOutput('is_team', 'false');
+              return;
+            }
+
+            // Case 2: Team re-requested — check if any member has reviewed before
+            const requestedTeam = context.payload.requested_team;
+            if (requestedTeam) {
+              const teams = JSON.parse(process.env.TEAMS);
+              const members = teams[requestedTeam.slug];
+              if (!members) {
+                core.setOutput('is_re_review', 'false');
+                return;
+              }
+
+              const authorLogin = context.payload.pull_request.user.login;
+              const reviewerLogins = reviews.data.map(r => r.user.login);
+              const reReviewTargets = Object.keys(members)
+                .filter(login => login !== authorLogin && reviewerLogins.includes(login))
+                .map(login => ({ login, slackId: mapping[login] }))
+                .filter(t => t.slackId);
+
+              if (reReviewTargets.length === 0) {
+                core.setOutput('is_re_review', 'false');
+                return;
+              }
+
+              core.setOutput('is_re_review', 'true');
+              core.setOutput('is_team', 'true');
+              core.setOutput('team_name', requestedTeam.slug);
+              core.setOutput('team_dm_targets', JSON.stringify(reReviewTargets));
+              return;
+            }
+
+            core.setOutput('is_re_review', 'false');
+
+      - name: Extract Slack thread timestamp from PR body
+        if: steps.check-re-review.outputs.is_re_review == 'true'
+        id: get-ts
+        uses: ./.github/actions/extract-slack-ts
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Send re-review request to Slack thread
+        if: steps.check-re-review.outputs.is_re_review == 'true' && steps.get-ts.outputs.found == 'true' && steps.check-re-review.outputs.is_team != 'true'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.get-ts.outputs.thread_ts }}"
+            text: ":eyes: ${{ steps.check-re-review.outputs.name }} re-review requested"
+
+      - name: Send re-review DM
+        if: steps.check-re-review.outputs.is_re_review == 'true' && steps.get-ts.outputs.found == 'true' && steps.check-re-review.outputs.is_team != 'true' && steps.check-re-review.outputs.slack_id != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: ${{ env.SLACK_CHANNEL_ID }}
+          REVIEWER_SLACK_ID: ${{ steps.check-re-review.outputs.slack_id }}
+          THREAD_TS: ${{ steps.get-ts.outputs.thread_ts }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        with:
+          script: |
+            const channelId = process.env.CHANNEL_ID;
+            const threadLink = `https://morpho-labs.slack.com/archives/${channelId}/p${process.env.THREAD_TS.replace('.', '')}`;
+
+            const res = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_TOKEN}`,
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                channel: process.env.REVIEWER_SLACK_ID,
+                unfurl_links: false,
+                unfurl_media: false,
+                text: `:eyes: Re-review requested on <${process.env.PR_URL}|${process.env.PR_TITLE}>.\n<${threadLink}|View Slack thread>`
+              })
+            });
+            const data = await res.json();
+            if (!data.ok) core.warning(`Slack DM failed: ${data.error}`);
+
+      - name: Send team re-review request to Slack thread
+        if: steps.check-re-review.outputs.is_re_review == 'true' && steps.get-ts.outputs.found == 'true' && steps.check-re-review.outputs.is_team == 'true'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.get-ts.outputs.thread_ts }}"
+            text: ":eyes: ${{ steps.check-re-review.outputs.team_name }} re-review requested"
+
+      - name: Send team re-review DMs
+        if: steps.check-re-review.outputs.is_re_review == 'true' && steps.get-ts.outputs.found == 'true' && steps.check-re-review.outputs.is_team == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: ${{ env.SLACK_CHANNEL_ID }}
+          TEAM_DM_TARGETS: ${{ steps.check-re-review.outputs.team_dm_targets }}
+          THREAD_TS: ${{ steps.get-ts.outputs.thread_ts }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        with:
+          script: |
+            const targets = JSON.parse(process.env.TEAM_DM_TARGETS);
+            const channelId = process.env.CHANNEL_ID;
+            const threadLink = `https://morpho-labs.slack.com/archives/${channelId}/p${process.env.THREAD_TS.replace('.', '')}`;
+
+            for (const { slackId } of targets) {
+              const res = await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.SLACK_TOKEN}`,
+                  'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                  channel: slackId,
+                  unfurl_links: false,
+                  unfurl_media: false,
+                  text: `:eyes: Re-review requested on <${process.env.PR_URL}|${process.env.PR_TITLE}>.\n<${threadLink}|View Slack thread>`
+                })
+              });
+              const data = await res.json();
+              if (!data.ok) core.warning(`Slack DM failed for ${slackId}: ${data.error}`);
+            }
+
+  notify-pr-closed:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Extract Slack thread timestamps from PR body
+        id: get-ts
+        uses: ./.github/actions/extract-slack-ts
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Send notification to Slack thread
+        if: steps.get-ts.outputs.found == 'true'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.get-ts.outputs.thread_ts }}"
+            text: "${{ github.event.pull_request.merged && ':merged: PR merged!' || ':x: PR closed' }}"
+
+      - name: Add reaction to original message
+        if: steps.get-ts.outputs.found == 'true'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: reactions.add
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            timestamp: "${{ steps.get-ts.outputs.thread_ts }}"
+            name: "${{ github.event.pull_request.merged && 'white_check_mark' || 'x' }}"
+
+      - name: Send notification to quick-win DM thread
+        if: steps.get-ts.outputs.quick_win_found == 'true'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ steps.get-ts.outputs.quick_win_channel }}
+            thread_ts: "${{ steps.get-ts.outputs.quick_win_ts }}"
+            text: "${{ github.event.pull_request.merged && ':merged: PR merged!' || ':x: PR closed' }}"
+
+      - name: Add reaction to quick-win DM
+        if: steps.get-ts.outputs.quick_win_found == 'true'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: reactions.add
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ steps.get-ts.outputs.quick_win_channel }}
+            timestamp: "${{ steps.get-ts.outputs.quick_win_ts }}"
+            name: "${{ github.event.pull_request.merged && 'white_check_mark' || 'x' }}"
+
+  # review_requested: updates parent message with new reviewer list
+  # (notify-re-review-requested handles the thread reply for re-reviews)
+  notify-pr-updated:
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'edited' && github.event.changes.title != null) ||
+        ((github.event.action == 'labeled' || github.event.action == 'unlabeled') && startsWith(github.event.label.name, 'criticality:')) ||
+        github.event.action == 'review_requested'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/team-members.json
+          sparse-checkout-cone-mode: false
+
+      - name: Load GitHub → Slack mapping
+        run: |
+          echo "GITHUB_TO_SLACK_MAPPING=$(jq -c '.members | with_entries(select(.value != null))' .github/team-members.json)" >> "$GITHUB_ENV"
+          echo "GITHUB_TEAMS=$(jq -c '.teams' .github/team-members.json)" >> "$GITHUB_ENV"
+
+      - name: Extract Slack thread timestamp from PR body
+        id: get-ts
+        uses: ./.github/actions/extract-slack-ts
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get PR details
+        if: steps.get-ts.outputs.found == 'true'
+        id: pr
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          MAPPING: ${{ env.GITHUB_TO_SLACK_MAPPING }}
+          TEAMS: ${{ env.GITHUB_TEAMS }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const mapping = JSON.parse(process.env.MAPPING);
+
+            const authorSlackId = mapping[pr.user.login];
+            const author = authorSlackId ? `<@${authorSlackId}>` : pr.user.login;
+
+            // Get reviewers who have already submitted reviews
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number
+            });
+
+            // Fetch requested reviewers from the dedicated endpoint —
+            // the event payload's `requested_teams` is empty under the
+            // workflow's GITHUB_TOKEN even when teams are actually
+            // requested.
+            const requested = await github.rest.pulls.listRequestedReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            // Collect unique reviewers from both requested and those who have reviewed
+            const reviewerLogins = new Set();
+            (requested.data.users || []).filter(r => r.type !== 'Bot').forEach(r => reviewerLogins.add(r.login));
+            reviews.data.forEach(r => {
+              if (r.user.login !== pr.user.login && r.user.type !== 'Bot') {
+                reviewerLogins.add(r.user.login);
+              }
+            });
+
+            // Expand team review requests into individual members
+            const teams = JSON.parse(process.env.TEAMS);
+            for (const team of (requested.data.teams || [])) {
+              const members = teams[team.slug];
+              if (members) {
+                for (const login of Object.keys(members)) {
+                  if (login !== pr.user.login) reviewerLogins.add(login);
+                }
+              }
+            }
+
+            const reviewerMentions = [...reviewerLogins].join(', ');
+
+            const criticalityLabel = (pr.labels || [])
+              .map(l => l.name)
+              .find(n => n.toLowerCase().startsWith('criticality:')) || '';
+            const criticality = criticalityLabel.replace(/^criticality:/i, '');
+
+            const safeTitle = pr.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+            // Fetch commits for Linear ID extraction from commit messages
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            core.setOutput('title', safeTitle);
+            core.setOutput('raw_title', pr.title);
+            core.setOutput('html_url', pr.html_url);
+            core.setOutput('number', pr.number);
+
+            core.setOutput('commits_json', JSON.stringify(commits.data));
+            core.setOutput('author', author);
+            core.setOutput('reviewers', reviewerMentions);
+            core.setOutput('criticality', criticality);
+
+      - name: Map PR title to emoji
+        if: steps.get-ts.outputs.found == 'true'
+        id: emoji
+        uses: ./.github/actions/map-pr-emoji
+        with:
+          pr-title: ${{ steps.pr.outputs.title }}
+
+      - name: Extract Linear issue ID
+        if: steps.get-ts.outputs.found == 'true'
+        id: linear
+        uses: ./.github/actions/extract-linear-id
+        with:
+          pr-body: ${{ github.event.pull_request.body }}
+          branch-name: ${{ github.event.pull_request.head.ref }}
+          commits-json: ${{ steps.pr.outputs.commits_json }}
+
+      - name: Update Slack message
+        if: steps.get-ts.outputs.found == 'true'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            ts: "${{ steps.get-ts.outputs.thread_ts }}"
+            unfurl_links: false
+            unfurl_media: false
+            text: "${{ steps.emoji.outputs.emoji }} <${{ steps.pr.outputs.html_url }}|${{ steps.pr.outputs.title }}>\n\nBy: ${{ steps.pr.outputs.author }}${{ steps.pr.outputs.reviewers && format('\nReviewers: {0}', steps.pr.outputs.reviewers) || '' }}${{ steps.pr.outputs.criticality && format('\nCriticality: `{0}`', steps.pr.outputs.criticality) || '' }}${{ steps.linear.outputs.url && format('\nTicket: <{0}|{1}>', steps.linear.outputs.url, steps.linear.outputs.issue_id) || '' }}"
+
+      - name: Send DM for new reviewer assignment
+        if: steps.get-ts.outputs.found == 'true' && github.event.action == 'review_requested' && github.event.requested_reviewer
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          MAPPING: ${{ env.GITHUB_TO_SLACK_MAPPING }}
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: ${{ env.SLACK_CHANNEL_ID }}
+          THREAD_TS: ${{ steps.get-ts.outputs.thread_ts }}
+          PR_URL: ${{ steps.pr.outputs.html_url }}
+          PR_TITLE: ${{ steps.pr.outputs.raw_title }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+        with:
+          script: |
+            const requestedLogin = context.payload.requested_reviewer.login;
+            const mapping = JSON.parse(process.env.MAPPING);
+            const slackId = mapping[requestedLogin];
+            if (!slackId) return;
+
+            // Skip if this is a re-review (notify-re-review-requested handles those)
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const hasReviewedBefore = reviews.data.some(
+              review => review.user.login === requestedLogin
+            );
+            if (hasReviewedBefore) return;
+
+            const channelId = process.env.CHANNEL_ID;
+            const threadLink = `https://morpho-labs.slack.com/archives/${channelId}/p${process.env.THREAD_TS.replace('.', '')}`;
+
+            const res = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_TOKEN}`,
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                channel: slackId,
+                unfurl_links: false,
+                unfurl_media: false,
+                text: `${process.env.AUTHOR} requested your review on <${process.env.PR_URL}|${process.env.PR_TITLE}>.\n<${threadLink}|View Slack thread>`
+              })
+            });
+            const data = await res.json();
+            if (!data.ok) core.warning(`Slack DM failed for ${slackId}: ${data.error}`);
+
+      - name: Send DMs for new team reviewer assignment
+        if: steps.get-ts.outputs.found == 'true' && github.event.action == 'review_requested' && github.event.requested_team
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          TEAMS: ${{ env.GITHUB_TEAMS }}
+          MAPPING: ${{ env.GITHUB_TO_SLACK_MAPPING }}
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: ${{ env.SLACK_CHANNEL_ID }}
+          THREAD_TS: ${{ steps.get-ts.outputs.thread_ts }}
+          PR_URL: ${{ steps.pr.outputs.html_url }}
+          PR_TITLE: ${{ steps.pr.outputs.raw_title }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+        with:
+          script: |
+            const teams = JSON.parse(process.env.TEAMS);
+            const mapping = JSON.parse(process.env.MAPPING);
+            const teamSlug = context.payload.requested_team.slug;
+            const members = teams[teamSlug];
+            if (!members) return;
+
+            // Skip members who have already reviewed — notify-re-review-requested handles those
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const previousReviewers = new Set(reviews.data.map(r => r.user.login));
+
+            const authorLogin = context.payload.pull_request.user.login;
+            const channelId = process.env.CHANNEL_ID;
+            const threadLink = `https://morpho-labs.slack.com/archives/${channelId}/p${process.env.THREAD_TS.replace('.', '')}`;
+
+            for (const login of Object.keys(members)) {
+              if (login === authorLogin) continue;
+              if (previousReviewers.has(login)) continue;
+              const slackId = mapping[login];
+              if (!slackId) continue;
+
+              const res = await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.SLACK_TOKEN}`,
+                  'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                  channel: slackId,
+                  unfurl_links: false,
+                  unfurl_media: false,
+                  text: `${process.env.AUTHOR} requested your review on <${process.env.PR_URL}|${process.env.PR_TITLE}>.\n<${threadLink}|View Slack thread>`
+                })
+              });
+              const data = await res.json();
+              if (!data.ok) core.warning(`Slack DM failed for ${slackId}: ${data.error}`);
+            }
+
+  notify-quick-win:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'quick win'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .github/team-members.json
+          sparse-checkout-cone-mode: false
+
+      - name: Load GitHub → Slack mapping
+        run: |
+          echo "GITHUB_TO_SLACK_MAPPING=$(jq -c '.members | with_entries(select(.value != null))' .github/team-members.json)" >> "$GITHUB_ENV"
+          echo "GITHUB_TEAMS=$(jq -c '.teams' .github/team-members.json)" >> "$GITHUB_ENV"
+
+      # This job intentionally uses raw fetch() instead of the Slack GitHub Action.
+      # The DM send + PR body update must be atomic (single github-script step) to
+      # avoid race conditions where concurrent events overwrite the PR body between
+      # separate steps.
+      - name: Select random reviewer and send DM
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          MAPPING: ${{ env.GITHUB_TO_SLACK_MAPPING }}
+          SUBMITTER: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: |
+            const reviewers = context.payload.pull_request.requested_reviewers || [];
+            if (reviewers.length === 0) return;
+
+            const randomReviewer = reviewers[Math.floor(Math.random() * reviewers.length)];
+            const mapping = JSON.parse(process.env.MAPPING);
+            const slackId = mapping[randomReviewer.login];
+            if (!slackId) return;
+
+            const submitterSlackId = mapping[process.env.SUBMITTER];
+            const submitterMention = submitterSlackId ? `<@${submitterSlackId}>` : process.env.SUBMITTER;
+
+            const res = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_TOKEN}`,
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                channel: slackId,
+                unfurl_links: false,
+                unfurl_media: false,
+                text: `${submitterMention} needs a quick-win review on <${process.env.PR_URL}|${process.env.PR_TITLE}>.`
+              })
+            });
+
+            const data = await res.json();
+            if (!data.ok || !data.ts) return;
+
+            // Re-fetch the PR body to avoid race conditions with concurrent events
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const body = pr.data.body || '';
+
+            if (!/<!-- slack-quick-win-dm:[^\s]+:[0-9.]+ -->/.test(body)) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                body: body + `\n<!-- slack-quick-win-dm:${slackId}:${data.ts} -->`
+              });
+            }


### PR DESCRIPTION
## Summary

Ports the PR → Slack notification system from `morpho-org/morpho-apps` into this repo, targeting the `#sdks-reviews` channel.

What lands:
- `.github/workflows/pr-slack-notify.yml` — 6 jobs covering opened / ready_for_review / review_requested / review submitted / re-review / closed / merged / title-or-label edits / quick-win label.
- `.github/actions/{extract-slack-ts,find-slack-thread,extract-linear-id,map-pr-emoji}/action.yml` — composite actions reused across jobs.
- `.github/team-members.json` — GitHub handle → Slack user-ID mapping (copied verbatim from morpho-apps).

Same logic as morpho-apps:
- Deduplication via `<!-- slack-thread-ts:<ts> -->` marker in the PR body, with a Slack `conversations.history` fallback for missing markers.
- Parent Slack message is `chat.update`d when the PR title, criticality label, or reviewer set changes.
- Thread replies for new review / re-review / merge / close.
- Direct DMs to mapped reviewers, including team-expansion via `team-members.json`.
- Linear issue ID extraction from PR body / branch name / commit messages.

Differences vs morpho-apps:
- `runs-on: ubuntu-latest` (this repo does not use Depot).
- Channel ID read from `vars.SLACK_CHANNEL_ID` instead of being hardcoded — so the channel can be wired up without a code change.

## Required setup before this works

1. Add repo secret `SLACK_BOT_TOKEN` (scopes: `chat:write`, `channels:history`, `reactions:write`, `im:write`).
2. Add repo variable `SLACK_CHANNEL_ID` set to the `#sdks-reviews` channel ID.
3. Invite the Slack bot to `#sdks-reviews`.

## Test plan

- [ ] Repo secret + variable configured, bot invited to the channel.
- [ ] Open a non-draft PR with a reviewer assigned → message posted to `#sdks-reviews`, PR body backfilled with `slack-thread-ts` marker, reviewer receives a DM.
- [ ] Submit a review on that PR → reply in the Slack thread with the correct emoji.
- [ ] Re-request the same reviewer → `:eyes:` re-review thread reply + DM.
- [ ] Edit the PR title or toggle a `criticality:*` label → parent Slack message updates.
- [ ] Merge the PR → `:merged:` reply + reaction. Close (no merge) → `:x:` reply + reaction.
- [ ] `workflow_dispatch` with an existing PR number → message posts even when guards would otherwise skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[View Slack thread](https://morpho-labs.slack.com/archives//p)
<!-- slack-thread-ts: -->

[View Slack thread](https://morpho-labs.slack.com/archives//p)
<!-- slack-thread-ts: -->

[View Slack thread](https://morpho-labs.slack.com/archives//p)
<!-- slack-thread-ts: -->

[View Slack thread](https://morpho-labs.slack.com/archives//p)
<!-- slack-thread-ts: -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1777972199288709)
<!-- slack-thread-ts:1777972199.288709 -->