### PR TITLE
refactor(morpho-sdk): drop useSimplePermit from vaultV1 migrateToV2

### DIFF
--- a/.changeset/morpho-sdk-vaultv1-migrate-drop-use-simple-permit.md
+++ b/.changeset/morpho-sdk-vaultv1-migrate-drop-use-simple-permit.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": major
+---
+
+`MorphoVaultV1.migrateToV2().getRequirements()` no longer accepts a `useSimplePermit` parameter. The migration permit is always issued against the V1 vault shares, which implement EIP-2612, so the Permit2 fallback path was unreachable in practice. Callers passing `{ useSimplePermit: true | false }` should drop the argument.

--- a/.changeset/morpho-sdk-vaultv1-migrate-drop-use-simple-permit.md
+++ b/.changeset/morpho-sdk-vaultv1-migrate-drop-use-simple-permit.md
@@ -1,5 +1,0 @@
----
-"@morpho-org/morpho-sdk": major
----
-
-`MorphoVaultV1.migrateToV2().getRequirements()` no longer accepts a `useSimplePermit` parameter. The migration permit is always issued against the V1 vault shares, which implement EIP-2612, so the Permit2 fallback path was unreachable in practice. Callers passing `{ useSimplePermit: true | false }` should drop the argument.

--- a/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
@@ -109,9 +109,6 @@ export interface VaultV1Actions {
    * Redeems all V1 shares and atomically deposits the resulting assets into V2
    * via bundler3. Computes slippage-protected share prices for both legs.
    *
-   * The permit is signed against the V1 vault shares, which always implement
-   * EIP-2612, so `getRequirements` always uses simple permit (no opt-out).
-   *
    * @param {Object} params - The migration parameters.
    * @param {Address} params.userAddress - User address initiating the migration.
    * @param {AccrualVault} params.sourceVault - Pre-fetched V1 vault data.
@@ -373,6 +370,7 @@ export class MorphoVaultV1 implements VaultV1Actions {
           chainId: this.chainId,
           supportSignature: this.client.options.supportSignature,
           supportDeployless: this.client.options.supportDeployless,
+          // V1 shares always implement EIP-2612.
           useSimplePermit: true,
           args: {
             amount: shares,

--- a/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
@@ -109,6 +109,9 @@ export interface VaultV1Actions {
    * Redeems all V1 shares and atomically deposits the resulting assets into V2
    * via bundler3. Computes slippage-protected share prices for both legs.
    *
+   * The permit is signed against the V1 vault shares, which always implement
+   * EIP-2612, so `getRequirements` always uses simple permit (no opt-out).
+   *
    * @param {Object} params - The migration parameters.
    * @param {Address} params.userAddress - User address initiating the migration.
    * @param {AccrualVault} params.sourceVault - Pre-fetched V1 vault data.

--- a/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
@@ -127,9 +127,9 @@ export interface VaultV1Actions {
     buildTx: (
       requirementSignature?: RequirementSignature,
     ) => Readonly<Transaction<VaultV1MigrateToV2Action>>;
-    getRequirements: (params?: {
-      useSimplePermit?: boolean;
-    }) => Promise<(Readonly<Transaction<ERC20ApprovalAction>> | Requirement)[]>;
+    getRequirements: () => Promise<
+      (Readonly<Transaction<ERC20ApprovalAction>> | Requirement)[]
+    >;
   };
 }
 
@@ -364,13 +364,13 @@ export class MorphoVaultV1 implements VaultV1Actions {
     );
 
     return {
-      getRequirements: async (params?: { useSimplePermit?: boolean }) =>
+      getRequirements: async () =>
         await getRequirements(this.client.viemClient, {
           address: this.vault,
           chainId: this.chainId,
           supportSignature: this.client.options.supportSignature,
           supportDeployless: this.client.options.supportDeployless,
-          useSimplePermit: params?.useSimplePermit,
+          useSimplePermit: true,
           args: {
             amount: shares,
             from: userAddress,

--- a/packages/morpho-sdk/test/actions/vaultV1/migrateToV2.test.ts
+++ b/packages/morpho-sdk/test/actions/vaultV1/migrateToV2.test.ts
@@ -1,4 +1,3 @@
-import { addressesRegistry, MathLib } from "@morpho-org/blue-sdk";
 import { isHex, parseUnits } from "viem";
 import { mainnet } from "viem/chains";
 import { describe, expect } from "vitest";
@@ -163,9 +162,7 @@ describe("MigrateToV2 VaultV1", () => {
           shares,
         });
 
-        const requirements = await migrate.getRequirements({
-          useSimplePermit: true,
-        });
+        const requirements = await migrate.getRequirements();
 
         if (!isRequirementSignature(requirements[0])) {
           throw new Error("Requirement is not a signature requirement");
@@ -186,105 +183,6 @@ describe("MigrateToV2 VaultV1", () => {
         expect(requirementSignature.args.deadline).toBeGreaterThan(
           BigInt(Math.floor(Date.now() / 1000)),
         );
-
-        const tx = migrate.buildTx(requirementSignature);
-        await client.sendTransaction(tx);
-      },
-    });
-
-    // V1: all shares should be gone
-    expect(v1Final.userSharesBalance).toBe(0n);
-
-    // V2: user should have received shares
-    expect(v2Final.userSharesBalance).toBeGreaterThan(
-      v2Initial.userSharesBalance,
-    );
-
-    // User's underlying asset balance should be unchanged
-    expect(v1Final.userAssetBalance).toEqual(v1Initial.userAssetBalance);
-  });
-
-  test("should migrate with permit2 for V1 shares", async ({ client }) => {
-    const {
-      permit2,
-      bundler3: { generalAdapter1 },
-    } = addressesRegistry[mainnet.id];
-
-    const shares = parseUnits("1000", 18);
-    await client.deal({
-      erc20: SteakhouseUsdcVaultV1.address,
-      amount: shares,
-    });
-
-    const {
-      vaults: {
-        SteakhouseUsdcVaultV1: { initialState: v1Initial, finalState: v1Final },
-        KeyrockUsdcVaultV2: { initialState: v2Initial, finalState: v2Final },
-      },
-    } = await testInvariants({
-      client,
-      params: {
-        vaults: { SteakhouseUsdcVaultV1, KeyrockUsdcVaultV2 },
-      },
-      actionFn: async () => {
-        const morpho = new MorphoClient(client, { supportSignature: true });
-        const vaultV1 = morpho.vaultV1(
-          SteakhouseUsdcVaultV1.address,
-          mainnet.id,
-        );
-        const vaultV2 = morpho.vaultV2(KeyrockUsdcVaultV2.address, mainnet.id);
-
-        const sourceVault = await vaultV1.getData();
-        const targetVault = await vaultV2.getData();
-
-        const migrate = vaultV1.migrateToV2({
-          userAddress: client.account.address,
-          sourceVault,
-          targetVault,
-          shares,
-        });
-
-        const requirements = await migrate.getRequirements({
-          useSimplePermit: false,
-        });
-
-        expect(requirements.length).toBe(2);
-
-        const approvalPermit2 = requirements[0];
-        if (!isRequirementApproval(approvalPermit2)) {
-          throw new Error("Approval requirement not found");
-        }
-
-        expect(approvalPermit2.action.args.spender).toBe(permit2);
-        expect(approvalPermit2.action.args.amount).toBe(MathLib.MAX_UINT_160);
-        expect(approvalPermit2.action.type).toBe("erc20Approval");
-
-        const permit2Requirement = requirements[1];
-
-        if (!isRequirementSignature(permit2Requirement)) {
-          throw new Error("Requirement is not a signature requirement");
-        }
-
-        expect(permit2Requirement.action.type).toBe("permit2");
-        expect(permit2Requirement.action.args.spender).toBe(generalAdapter1);
-        expect(permit2Requirement.action.args.amount).toBe(shares);
-
-        const requirementSignature = await permit2Requirement.sign(
-          client,
-          client.account.address,
-        );
-
-        expect(requirementSignature.args.owner).toEqual(client.account.address);
-        expect(isHex(requirementSignature.args.signature)).toBe(true);
-        expect(requirementSignature.args.signature.length).toBe(132);
-        expect(requirementSignature.args.asset).toBe(
-          SteakhouseUsdcVaultV1.address,
-        );
-        expect(requirementSignature.args.deadline).toBeGreaterThan(
-          BigInt(Math.floor(Date.now() / 1000)),
-        );
-
-        await client.sendTransaction(approvalPermit2);
 
         const tx = migrate.buildTx(requirementSignature);
         await client.sendTransaction(tx);


### PR DESCRIPTION
## Summary

- `MorphoVaultV1.migrateToV2().getRequirements()` no longer accepts `useSimplePermit`. V1 vault shares always implement EIP-2612, so the Permit2 fallback was unreachable on this code path.
- Hardcodes `useSimplePermit: true` in the underlying `getRequirements` call.
- Drops the now-unreachable permit2 entity test; updates the simple-permit test to call `getRequirements()` with no args.

Scope: only the vaultV1 → V2 migration entity. `vaultV1.deposit`, `vaultV2.deposit`, and `marketV1` paths still expose `useSimplePermit` because they operate on underlying assets (USDC, WETH, …) that may not implement EIP-2612.