### PR TITLE
feat(evm-simulation): expose per-call simulation results

### DIFF
--- a/.changeset/expose-per-call-simulation-results.md
+++ b/.changeset/expose-per-call-simulation-results.md
@@ -1,0 +1,15 @@
+---
+"@morpho-org/evm-simulation": minor
+---
+
+Expose per-call simulation results from `simulate()`.
+
+Adds `SimulateOptions.includeCallResults`. When set, the result includes a
+`callResults` array with one entry per simulated transaction (`data`,
+`gasUsed`, `logs`), aligned with `simulationTxs`. This forces the
+`eth_simulateV1` backend because Tenderly REST does not expose per-call
+return data; combining `includeCallResults: true` with `shareable: true`
+throws `SimulationValidationError`. Default behaviour is unchanged —
+`callResults` is omitted unless explicitly requested.
+
+New public types: `SimulationCallResult`, `SimulateOptions`.

--- a/packages/evm-simulation/src/index.ts
+++ b/packages/evm-simulation/src/index.ts
@@ -15,8 +15,10 @@ export { simulate } from "./simulate/index.js";
 // Types
 export type {
   ChainSimulationConfig,
+  SimulateOptions,
   SimulateParams,
   SimulationAuthorization,
+  SimulationCallResult,
   SimulationConfig,
   SimulationLogger,
   SimulationResult,

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.spec.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.spec.ts
@@ -276,4 +276,65 @@ describe.sequential("simulateV1", () => {
 
     expect(result.logs).toEqual([]);
   });
+
+  it("returns one callResult per input transaction with data, gasUsed, and per-call logs", async () => {
+    mockSimulateCalls.mockResolvedValueOnce({
+      results: [
+        {
+          status: "success",
+          data: "0xdead" as Hex,
+          gasUsed: 21_000n,
+          logs: [
+            {
+              address: USDC,
+              topics: ["0xaaaa" as Hex],
+              data: "0xdeadbeef" as Hex,
+            },
+          ],
+        },
+        {
+          status: "success",
+          data: "0xbeef" as Hex,
+          gasUsed: 42_000n,
+          logs: [
+            { address: USDC, topics: ["0xbbbb" as Hex], data: "0xabcd" as Hex },
+          ],
+        },
+      ],
+    });
+
+    const result = await simulateV1({
+      rpcUrl: "http://rpc.local",
+      chainId: 1,
+      transactions: [BASIC_TX, { from: USER, to: VAULT, data: "0x34" as Hex }],
+    });
+
+    expect(result.callResults).toHaveLength(2);
+    expect(result.callResults![0]).toEqual({
+      data: "0xdead",
+      gasUsed: 21_000n,
+      logs: [{ address: USDC, topics: ["0xaaaa"], data: "0xdeadbeef" }],
+    });
+    expect(result.callResults![1]).toEqual({
+      data: "0xbeef",
+      gasUsed: 42_000n,
+      logs: [{ address: USDC, topics: ["0xbbbb"], data: "0xabcd" }],
+    });
+    // Aggregated logs still drive transfer parsing.
+    expect(result.logs).toHaveLength(2);
+  });
+
+  it("defaults missing data to 0x and missing gasUsed to 0n in callResults", async () => {
+    mockSimulateCalls.mockResolvedValueOnce({
+      results: [{ status: "success" /* no data, no gasUsed, no logs */ }],
+    });
+
+    const result = await simulateV1({
+      rpcUrl: "http://rpc.local",
+      chainId: 1,
+      transactions: [BASIC_TX],
+    });
+
+    expect(result.callResults).toEqual([{ data: "0x", gasUsed: 0n, logs: [] }]);
+  });
 });

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
@@ -13,6 +13,7 @@ import {
 import type {
   RawLog,
   RawSimulationResult,
+  SimulationCallResult,
   SimulationTransaction,
 } from "../../types.js";
 
@@ -97,17 +98,26 @@ export async function simulateV1(params: {
     }
 
     const rawLogs: RawLog[] = [];
+    const callResults: SimulationCallResult[] = [];
     for (const r of results) {
+      const perCallLogs: RawLog[] = [];
       for (const log of r.logs ?? []) {
-        rawLogs.push({
+        const normalized: RawLog = {
           address: log.address,
           topics: [...log.topics],
           data: log.data ?? "0x",
-        });
+        };
+        rawLogs.push(normalized);
+        perCallLogs.push(normalized);
       }
+      callResults.push({
+        data: r.data ?? "0x",
+        gasUsed: r.gasUsed ?? 0n,
+        logs: perCallLogs,
+      });
     }
 
-    return { logs: rawLogs };
+    return { logs: rawLogs, callResults };
   } catch (error) {
     if (error instanceof SimulationRevertedError) throw error;
     if (error instanceof ExternalServiceError) throw error;

--- a/packages/evm-simulation/src/simulate/pipeline/execute-simulation.spec.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/execute-simulation.spec.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 import {
   ExternalServiceError,
   SimulationRevertedError,
+  SimulationValidationError,
   UnsupportedChainError,
 } from "../../errors.js";
 import type {
@@ -64,6 +65,7 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
       chainId: 1,
       transactions: txs,
       shareable: true,
+      includeCallResults: false,
     });
 
     expect(result.tenderlyUrl).toContain("dashboard.tenderly.co");
@@ -79,6 +81,7 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
       chainId: 1,
       transactions: txs,
       shareable: true,
+      includeCallResults: false,
     });
 
     expect(mockTenderlyRest.mock.calls[0]![0].shareable).toBe(true);
@@ -97,6 +100,7 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
         chainId: 1,
         transactions: txs,
         shareable: false,
+        includeCallResults: false,
       });
 
       // Tenderly's AbortSignal.timeout was called with floor(10000 * 0.6) = 6000.
@@ -117,6 +121,7 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
       chainId: 1,
       transactions: txs,
       shareable: false,
+      includeCallResults: false,
     });
 
     expect(result.tenderlyUrl).toBeUndefined();
@@ -134,6 +139,7 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
         chainId: 1,
         transactions: txs,
         shareable: false,
+        includeCallResults: false,
       }),
     ).rejects.toThrow(SimulationRevertedError);
 
@@ -152,6 +158,7 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
         chainId: 1,
         transactions: txs,
         shareable: false,
+        includeCallResults: false,
       }),
     ).rejects.toThrow(ExternalServiceError);
   });
@@ -170,6 +177,7 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
       chainId: 1,
       transactions: txs,
       shareable: false,
+      includeCallResults: false,
     });
 
     expect(result).toBeDefined();
@@ -190,6 +198,7 @@ describe.sequential("executeSimulation — Tenderly only (no simulateV1Url for c
       chainId: 1,
       transactions: txs,
       shareable: false,
+      includeCallResults: false,
     });
     expect(result).toBeDefined();
     expect(mockSimulateV1).not.toHaveBeenCalled();
@@ -205,6 +214,7 @@ describe.sequential("executeSimulation — Tenderly only (no simulateV1Url for c
         chainId: 1,
         transactions: txs,
         shareable: false,
+        includeCallResults: false,
       }),
     ).rejects.toThrow(ExternalServiceError);
     expect(mockSimulateV1).not.toHaveBeenCalled();
@@ -227,6 +237,7 @@ describe.sequential("executeSimulation — simulateV1 only (chain not in Tenderl
       chainId: 1,
       transactions: txs,
       shareable: false,
+      includeCallResults: false,
     });
     expect(mockTenderlyRest).not.toHaveBeenCalled();
     expect(mockSimulateV1).toHaveBeenCalledTimes(1);
@@ -241,7 +252,81 @@ describe.sequential("executeSimulation — no backend available", () => {
         chainId: 1,
         transactions: txs,
         shareable: false,
+        includeCallResults: false,
       }),
     ).rejects.toThrow(UnsupportedChainError);
+  });
+});
+
+describe.sequential("executeSimulation — includeCallResults", () => {
+  it("bypasses Tenderly and routes to simulateV1 even when both backends are configured", async () => {
+    mockSimulateV1.mockResolvedValueOnce({
+      logs: [],
+      callResults: [{ data: "0x", gasUsed: 0n, logs: [] }],
+    });
+
+    const result = await executeSimulation({
+      config: bothBackends(),
+      chainId: 1,
+      transactions: txs,
+      shareable: false,
+      includeCallResults: true,
+    });
+
+    expect(mockTenderlyRest).not.toHaveBeenCalled();
+    expect(mockSimulateV1).toHaveBeenCalledTimes(1);
+    expect(result.callResults).toHaveLength(1);
+  });
+
+  it("forwards the full timeoutMs to simulateV1 (no Tenderly budget split)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    try {
+      mockSimulateV1.mockResolvedValueOnce({ logs: [], callResults: [] });
+
+      await executeSimulation({
+        config: bothBackends(10_000),
+        chainId: 1,
+        transactions: txs,
+        shareable: false,
+        includeCallResults: true,
+      });
+
+      expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  it("throws UnsupportedChainError when chain has no simulateV1Url", async () => {
+    const tenderlyOnly: SimulationConfig = {
+      ...bothBackends(),
+      chains: new Map([[1, {}]]),
+    };
+
+    await expect(
+      executeSimulation({
+        config: tenderlyOnly,
+        chainId: 1,
+        transactions: txs,
+        shareable: false,
+        includeCallResults: true,
+      }),
+    ).rejects.toThrow(UnsupportedChainError);
+    expect(mockTenderlyRest).not.toHaveBeenCalled();
+    expect(mockSimulateV1).not.toHaveBeenCalled();
+  });
+
+  it("rejects shareable: true with includeCallResults: true via SimulationValidationError", async () => {
+    await expect(
+      executeSimulation({
+        config: bothBackends(),
+        chainId: 1,
+        transactions: txs,
+        shareable: true,
+        includeCallResults: true,
+      }),
+    ).rejects.toThrow(SimulationValidationError);
+    expect(mockTenderlyRest).not.toHaveBeenCalled();
+    expect(mockSimulateV1).not.toHaveBeenCalled();
   });
 });

--- a/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
@@ -1,5 +1,9 @@
 import type { BlockTag } from "viem";
-import { ExternalServiceError, UnsupportedChainError } from "../../errors.js";
+import {
+  ExternalServiceError,
+  SimulationValidationError,
+  UnsupportedChainError,
+} from "../../errors.js";
 import type {
   RawSimulationResult,
   SimulationConfig,
@@ -40,6 +44,13 @@ const FALLBACK_MIN_BUDGET_MS = 1500;
  *
  * `shareable` is Tenderly-only: when true, the backend persists the simulation and
  * returns a shareable URL. `eth_simulateV1` ignores it (no persistence concept).
+ *
+ * `includeCallResults` forces the `eth_simulateV1` backend regardless of Tenderly
+ * support — Tenderly's REST shape does not expose per-call return data reliably.
+ * When the chain has no `simulateV1Url`, throws `UnsupportedChainError`. Combining
+ * `shareable: true` with `includeCallResults: true` is rejected as
+ * `SimulationValidationError` because shareable simulations are Tenderly-specific
+ * and would silently drop call results.
  */
 export async function executeSimulation(params: {
   config: SimulationConfig;
@@ -47,11 +58,38 @@ export async function executeSimulation(params: {
   transactions: SimulationTransaction[];
   blockNumber?: bigint | BlockTag;
   shareable: boolean;
+  includeCallResults: boolean;
 }): Promise<RawSimulationResult> {
-  const { config, chainId, transactions, blockNumber, shareable } = params;
+  const {
+    config,
+    chainId,
+    transactions,
+    blockNumber,
+    shareable,
+    includeCallResults,
+  } = params;
+
+  if (shareable && includeCallResults) {
+    throw new SimulationValidationError(
+      "shareable and includeCallResults cannot both be true: shareable simulations run on Tenderly, which does not expose per-call return data",
+      ["shareable", "includeCallResults"],
+    );
+  }
+
   const chain = resolveChain(config, chainId);
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
+
+  if (includeCallResults) {
+    if (!chain.simulateV1Url) throw new UnsupportedChainError(chainId);
+    return await simulateV1({
+      rpcUrl: chain.simulateV1Url,
+      chainId,
+      transactions,
+      blockNumber,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  }
 
   if (chain.tenderlySupported && config.tenderlyRest) {
     const tenderlyTimeout = Math.floor(timeoutMs * TENDERLY_BUDGET_RATIO);

--- a/packages/evm-simulation/src/simulate/simulate.spec.ts
+++ b/packages/evm-simulation/src/simulate/simulate.spec.ts
@@ -434,6 +434,54 @@ describe.sequential("simulate — validation", () => {
   });
 });
 
+describe.sequential("simulate — includeCallResults", () => {
+  it("does not return callResults by default", async () => {
+    mockTenderlyRest.mockResolvedValueOnce(makeSuccessResult([]));
+
+    const result = await simulate(makeConfig(), makeParams());
+
+    expect(result.callResults).toBeUndefined();
+  });
+
+  it("returns one call result per simulationTx in order when opted in", async () => {
+    const auths: SimulationAuthorization[] = [
+      { type: "signature", token: USDC, spender: SPENDER },
+    ];
+    // Two input txs (1 prepended approve + 1 main) → expect 2 callResults.
+    mockSimulateV1.mockResolvedValueOnce({
+      logs: [],
+      callResults: [
+        { data: "0x01" as Hex, gasUsed: 21_000n, logs: [] },
+        { data: "0x02" as Hex, gasUsed: 100_000n, logs: [] },
+      ],
+    });
+
+    const result = await simulate(
+      makeConfig(),
+      makeParams({ authorizations: auths }),
+      { includeCallResults: true },
+    );
+
+    expect(result.simulationTxs).toHaveLength(2);
+    expect(result.callResults).toHaveLength(2);
+    expect(result.callResults![0]!.data).toBe("0x01");
+    expect(result.callResults![1]!.data).toBe("0x02");
+    // Tenderly is bypassed when call results are requested.
+    expect(mockTenderlyRest).not.toHaveBeenCalled();
+  });
+
+  it("rejects shareable: true with includeCallResults: true via SimulationValidationError", async () => {
+    await expect(
+      simulate(makeConfig(), makeParams(), {
+        shareable: true,
+        includeCallResults: true,
+      }),
+    ).rejects.toThrow(SimulationValidationError);
+    expect(mockTenderlyRest).not.toHaveBeenCalled();
+    expect(mockSimulateV1).not.toHaveBeenCalled();
+  });
+});
+
 describe.sequential("simulate — timeout", () => {
   it("throws ExternalServiceError when simulation exceeds timeoutMs", async () => {
     mockTenderlyRest.mockImplementationOnce(async () => {

--- a/packages/evm-simulation/src/simulate/simulate.ts
+++ b/packages/evm-simulation/src/simulate/simulate.ts
@@ -1,4 +1,5 @@
 import type {
+  SimulateOptions,
   SimulateParams,
   SimulationConfig,
   SimulationResult,
@@ -33,16 +34,9 @@ import {
 export async function simulate(
   config: SimulationConfig,
   params: SimulateParams,
-  options: {
-    /**
-     * When true, persist the simulation in Tenderly and return a shareable
-     * `tenderlyUrl` in the result. Only honored when the Tenderly backend runs
-     * (not the `eth_simulateV1` fallback). Defaults to `false`.
-     */
-    shareable?: boolean;
-  } = {},
+  options: SimulateOptions = {},
 ): Promise<SimulationResult> {
-  const { shareable = false } = options;
+  const { shareable = false, includeCallResults = false } = options;
 
   validateInput(params);
 
@@ -53,6 +47,7 @@ export async function simulate(
     transactions: simulationTxs,
     blockNumber: params.blockNumber,
     shareable,
+    includeCallResults,
   });
   const transfers = parseTransfers(result.logs, config.logger);
 
@@ -67,5 +62,6 @@ export async function simulate(
     transfers,
     tenderlyUrl: result.tenderlyUrl,
     assetChanges: result.rawAssetChanges,
+    ...(includeCallResults ? { callResults: result.callResults } : {}),
   };
 }

--- a/packages/evm-simulation/src/types.ts
+++ b/packages/evm-simulation/src/types.ts
@@ -89,6 +89,44 @@ export interface Transfer {
 }
 
 /**
+ * Per-call output of `eth_simulateV1` for a single transaction in the bundle.
+ * Returned only when the caller passes `includeCallResults: true` to
+ * `simulate()`. Indexes line up exactly with `SimulationResult.simulationTxs`.
+ */
+export interface SimulationCallResult {
+  /** Raw return data from the call. `0x` for calls that produce no output. */
+  data: Hex;
+  /** Gas consumed by this individual call. */
+  gasUsed: bigint;
+  /** Logs emitted by this individual call (also aggregated into transfer parsing). */
+  logs: RawLog[];
+}
+
+/**
+ * Per-call options for `simulate`.
+ *
+ * - `shareable` is Tenderly-only: persists the simulation and returns a `tenderlyUrl`.
+ * - `includeCallResults` returns one `SimulationCallResult` per simulated transaction
+ *   in `SimulationResult.callResults`, in input order. The two flags are mutually
+ *   exclusive — see `simulate()` for the rejection rule.
+ */
+export interface SimulateOptions {
+  /**
+   * When true, persist the simulation in Tenderly and return a shareable
+   * `tenderlyUrl` in the result. Only honored when the Tenderly backend runs
+   * (not the `eth_simulateV1` fallback). Defaults to `false`.
+   */
+  shareable?: boolean;
+  /**
+   * When true, return per-call output (return data, gas used, logs) for every
+   * simulated transaction. Forces the `eth_simulateV1` backend because Tenderly's
+   * REST shape does not expose per-call return data reliably. Mutually exclusive
+   * with `shareable: true`. Defaults to `false`.
+   */
+  includeCallResults?: boolean;
+}
+
+/**
  * Happy-path return of `simulate`. All failures throw typed errors. The same shape is
  * returned regardless of `options.shareable` — fields unused by your use case can be
  * ignored:
@@ -99,7 +137,9 @@ export interface Transfer {
  *
  * `tenderlyUrl` is set only when `shareable: true` AND the Tenderly backend ran
  * successfully (not the `eth_simulateV1` fallback). `assetChanges` is Tenderly-only
- * raw data.
+ * raw data. `callResults` is set only when `includeCallResults: true` was passed; in
+ * that case `callResults.length === simulationTxs.length` and the entries are aligned
+ * by index.
  */
 export interface SimulationResult {
   /** The full resolved transaction list (including prepended authorization txs). */
@@ -110,6 +150,11 @@ export interface SimulationResult {
   tenderlyUrl?: string;
   /** Raw Tenderly `asset_changes` payload. Opaque `unknown` — do not destructure without validation. */
   assetChanges?: unknown;
+  /**
+   * Per-call simulation outputs in `simulationTxs` order. Present only when
+   * `includeCallResults: true` was passed to `simulate()`.
+   */
+  callResults?: SimulationCallResult[];
 }
 
 /** Minimal structured logger the package calls for warnings and info. */
@@ -140,6 +185,12 @@ export interface RawSimulationResult {
   logs: RawLog[];
   tenderlyUrl?: string;
   rawAssetChanges?: unknown;
+  /**
+   * Optional per-call outputs aligned with the input transactions. Set by
+   * backends that can produce them (currently only `simulateV1`) when the
+   * caller opts in via `includeCallResults`.
+   */
+  callResults?: SimulationCallResult[];
 }
 
 export interface RawLog {


### PR DESCRIPTION
## Summary

- Adds opt-in `SimulateOptions.includeCallResults`. When set, `simulate()` returns `callResults` aligned with `simulationTxs`, each entry exposing the call's raw return `data`, `gasUsed`, and `logs`.
- Forces the `eth_simulateV1` backend when call results are requested (Tenderly REST does not expose per-call return data reliably) and rejects `shareable: true` + `includeCallResults: true` with `SimulationValidationError`.
- Default behaviour is unchanged: `callResults` is omitted unless explicitly requested. New public types: `SimulationCallResult`, `SimulateOptions`.

## Test plan

- [x] `pnpm --filter @morpho-org/evm-simulation test` (206 tests pass)
- [x] `pnpm --filter @morpho-org/evm-simulation build` (typecheck + dual ESM/CJS build)
- [x] `pnpm exec biome check packages/evm-simulation` (clean)
- [x] New unit tests:
  - Backend maps `data`/`gasUsed`/per-call logs from `eth_simulateV1` results.
  - Pipeline bypasses Tenderly when `includeCallResults: true`, hands the full timeout to `simulateV1`, and throws `UnsupportedChainError` if no `simulateV1Url`.
  - `shareable: true` + `includeCallResults: true` rejected with `SimulationValidationError` at both pipeline and `simulate()` entry points.
  - Default `simulate()` call still omits `callResults`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->