### PR TITLE
ci(slack): skip Slack notifications on fork PRs

### DIFF
--- a/.github/workflows/pr-slack-notify.yml
+++ b/.github/workflows/pr-slack-notify.yml
@@ -40,9 +40,13 @@ jobs:
     # that requires the numeric timestamp payload; a bare HTML comment or
     # a PR description that *mentions* the marker (e.g. this workflow's
     # own docs/PRs) must not trip the guard.
+    # Skip fork PRs: secrets/vars aren't passed to workflows triggered from
+    # forks, so SLACK_BOT_TOKEN/SLACK_CHANNEL_ID would be empty and the Slack
+    # action would fail. Use pull_request_target if you want to support forks.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        (github.event.action == 'opened' ||
         github.event.action == 'ready_for_review' ||
         github.event.action == 'review_requested'))
@@ -317,7 +321,10 @@ jobs:
             }
 
   notify-review:
-    if: github.event_name == 'pull_request_review' && github.event.review.user.type != 'Bot'
+    if: |
+      github.event_name == 'pull_request_review' &&
+      github.event.review.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -390,7 +397,10 @@ jobs:
             text: "${{ steps.review-status.outputs.emoji }} ${{ steps.reviewer.outputs.name }} <${{ github.event.review.html_url }}|${{ steps.review-status.outputs.text }}>"
 
   notify-re-review-requested:
-    if: github.event_name == 'pull_request' && github.event.action == 'review_requested'
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'review_requested' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -568,7 +578,10 @@ jobs:
             }
 
   notify-pr-closed:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -637,6 +650,7 @@ jobs:
   notify-pr-updated:
     if: |
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (
         (github.event.action == 'edited' && github.event.changes.title != null) ||
         ((github.event.action == 'labeled' || github.event.action == 'unlabeled') && startsWith(github.event.label.name, 'criticality:')) ||
@@ -880,7 +894,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'quick win'
+      github.event.label.name == 'quick win' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fix the `PR Slack Notifications` workflow which was failing red on fork PRs (e.g. #605 from `jinmel`).

### Why CI was red

When a PR is opened from a **fork** (`isCrossRepository: true`), GitHub Actions deliberately **does not pass `secrets.*` or `vars.*`** to the workflow runner. This is a security guarantee: otherwise any external contributor could open a PR with a malicious workflow change and exfiltrate the repo's secrets.

Concretely, on PR #605 the workflow ran with `secrets.SLACK_BOT_TOKEN = ""` and `vars.SLACK_CHANNEL_ID = ""`, so the `slackapi/slack-github-action` step crashed with:

```
SlackError: Missing input! A token must be provided to use the method decided.
```

### What this PR does

Adds a `github.event.pull_request.head.repo.full_name == github.repository` guard to each job. Fork PRs now skip the Slack notification jobs cleanly instead of failing CI red.

### Trade-off

External contributors won't get a Slack thread in `#sdks-reviews` for their PR. **Recommendation: open PRs directly against `morpho-org/sdks` (with a branch on the org repo) rather than from a fork** whenever possible — this also keeps Linear linking, criticality labels, and review DMs working end-to-end.

If we ever want fork PRs to notify Slack too, the path is to migrate the trigger from `pull_request` to `pull_request_target` — but that comes with its own security caveats (must never checkout fork code with elevated permissions) so it's out of scope here.

## Test plan

- [ ] Workflow still runs and posts to `#sdks-reviews` for an internal (non-fork) PR — this PR itself is the test
- [ ] Next fork PR no longer turns CI red on `PR Slack Notifications`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778065938273739)
<!-- slack-thread-ts:1778065938.273739 -->