### PR TITLE
ci: harden release workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
-/.github/CODEOWNERS @morpho-org/security
-/.github/workflows/ @morpho-org/security
+/.github/ @morpho-org/security
+/.changeset/config.json @morpho-org/security
+/.changeset/pre.json @morpho-org/security
+/package.json @morpho-org/sdk-engineers
+/packages/*/package.json @morpho-org/sdk-engineers
+/pnpm-lock.yaml @morpho-org/sdk-engineers
+/pnpm-workspace.yaml @morpho-org/sdk-engineers
+/.npmrc @morpho-org/sdk-engineers
+/.nvmrc @morpho-org/sdk-engineers
+/scripts/ @morpho-org/sdk-engineers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,22 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    target-branch: dev
+    target-branch: main
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: main
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: next
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: next

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -10,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,17 @@ name: Lint
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   biome:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
@@ -75,9 +76,12 @@ jobs:
           exit 1
 
       - name: Publish packages
+        id: publish-packages
         if: steps.pending-changesets.outputs.has_changesets == 'false'
         shell: bash
         run: |
+          set -euo pipefail
+
           publish_tag="latest"
           if [ "${GITHUB_REF_NAME}" = "next" ]; then
             publish_tag="next"
@@ -85,21 +89,34 @@ jobs:
 
           before_tags="$(mktemp)"
           after_tags="$(mktemp)"
-          new_tags="$(mktemp)"
-          trap 'rm -f "$before_tags" "$after_tags" "$new_tags"' EXIT
+          new_tags="${RUNNER_TEMP}/new-package-tags.txt"
+          trap 'rm -f "$before_tags" "$after_tags"' EXIT
 
-          git tag --list | sort > "$before_tags"
+          git tag --list | LC_ALL=C sort > "$before_tags"
           pnpm release --tag "$publish_tag"
-          git tag --list | sort > "$after_tags"
+          git tag --list | LC_ALL=C sort > "$after_tags"
 
-          comm -13 "$before_tags" "$after_tags" > "$new_tags"
+          LC_ALL=C comm -13 "$before_tags" "$after_tags" > "$new_tags"
           if [ -s "$new_tags" ]; then
-            mapfile -t tags < "$new_tags"
-            refs=()
-
-            for tag in "${tags[@]}"; do
-              refs+=("refs/tags/${tag}")
-            done
-
-            git push --atomic origin "${refs[@]}"
+            echo "has_tags=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_tags=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Push package tags
+        if: steps.publish-packages.outputs.has_tags == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t tags < "${RUNNER_TEMP}/new-package-tags.txt"
+          refs=()
+
+          for tag in "${tags[@]}"; do
+            refs+=("refs/tags/${tag}")
+          done
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --atomic origin "${refs[@]}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,17 +13,32 @@ concurrency:
 
 jobs:
   lint:
+    permissions:
+      contents: read
+
     uses: ./.github/workflows/lint.yml
 
   build:
+    permissions:
+      contents: read
+
     uses: ./.github/workflows/build.yml
 
   test:
+    permissions:
+      contents: read
+
     uses: ./.github/workflows/test.yml
-    secrets: inherit
+    secrets:
+      MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+      BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
+      ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL }}
 
   version-pr:
     if: github.ref_name == 'main' || github.ref_name == 'next'
+
+    permissions:
+      contents: read
 
     needs:
       - lint
@@ -31,10 +46,16 @@ jobs:
       - test
 
     uses: ./.github/workflows/version-pr.yml
-    secrets: inherit
+    secrets:
+      VERSION_APP_ID: ${{ secrets.VERSION_APP_ID }}
+      VERSION_APP_PRIVATE_KEY: ${{ secrets.VERSION_APP_PRIVATE_KEY }}
 
   publish:
     if: github.ref_name == 'main' || github.ref_name == 'next'
+
+    permissions:
+      contents: write
+      id-token: write
 
     needs:
       - lint
@@ -43,4 +64,3 @@ jobs:
       - version-pr
 
     uses: ./.github/workflows/publish.yml
-    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     secrets:
       MAINNET_RPC_URL:
         required: true
+      BASE_RPC_URL:
+        required: true
+      ARBITRUM_RPC_URL:
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
   vitest:
@@ -12,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -2,6 +2,11 @@ name: Version PR
 
 on:
   workflow_call:
+    secrets:
+      VERSION_APP_ID:
+        required: true
+      VERSION_APP_PRIVATE_KEY:
+        required: true
 
 permissions:
   contents: read
@@ -23,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -88,13 +93,67 @@ jobs:
       - name: Push release branch
         id: version-commit
         if: steps.pending-changesets.outputs.has_changesets == 'true'
+        shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          set -euo pipefail
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git add .
+
+          is_allowed_version_path() {
+            [[ "$1" =~ ^packages/[^/]+/package\.json$ ]] ||
+            [[ "$1" =~ ^\.changeset/[^/]+\.md$ ]] ||
+            [[ "$1" == ".changeset/pre.json" ]]
+          }
+
+          allowed_changed=()
+          while IFS= read -r -d '' path; do
+            if is_allowed_version_path "$path"; then
+              allowed_changed+=("$path")
+            fi
+          done < <(git diff --name-only -z)
+
+          while IFS= read -r -d '' path; do
+            if is_allowed_version_path "$path"; then
+              allowed_changed+=("$path")
+            fi
+          done < <(git ls-files --others --exclude-standard -z)
+
+          if [ "${#allowed_changed[@]}" -gt 0 ]; then
+            git add -- "${allowed_changed[@]}"
+          fi
+
+          staged_violations=()
+          while IFS= read -r -d '' path; do
+            if ! is_allowed_version_path "$path"; then
+              staged_violations+=("$path")
+            fi
+          done < <(git diff --cached --name-only -z)
+
+          if [ "${#staged_violations[@]}" -gt 0 ]; then
+            echo "::error::Versioning staged files outside the release allowlist:"
+            printf '  %s\n' "${staged_violations[@]}"
+            exit 1
+          fi
+
+          unstaged=()
+          while IFS= read -r -d '' path; do
+            unstaged+=("$path")
+          done < <(git diff --name-only -z)
+
+          untracked=()
+          while IFS= read -r -d '' path; do
+            untracked+=("$path")
+          done < <(git ls-files --others --exclude-standard -z)
+
+          if [ "${#unstaged[@]}" -gt 0 ] || [ "${#untracked[@]}" -gt 0 ]; then
+            echo "::error::Versioning produced files outside the release allowlist:"
+            printf '  %s\n' "${unstaged[@]}" "${untracked[@]}"
+            exit 1
+          fi
 
           if git diff --cached --quiet; then
             echo "No version changes to commit."
@@ -103,15 +162,28 @@ jobs:
           fi
 
           git commit -m "chore: version packages"
-          git push --force origin "HEAD:refs/heads/${RELEASE_BRANCH}"
+
+          remote_release_ref="refs/heads/${RELEASE_BRANCH}"
+          local_release_ref="refs/remotes/origin/${RELEASE_BRANCH}"
+          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "+${remote_release_ref}:${local_release_ref}"
+            expected_sha="$(git rev-parse "${local_release_ref}")"
+            git push --force-with-lease="${remote_release_ref}:${expected_sha}" origin "HEAD:${remote_release_ref}"
+          else
+            git push origin "HEAD:${remote_release_ref}"
+          fi
+
           echo "has_version_changes=true" >> "$GITHUB_OUTPUT"
 
       - name: Open or update release PR
         if: steps.version-commit.outputs.has_version_changes == 'true'
+        shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_BRANCH: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+
           title="chore: version packages (${BASE_BRANCH})"
           body="$(cat <<BODY
           This PR applies the pending changesets for ${BASE_BRANCH}.
@@ -125,7 +197,7 @@ jobs:
             --head "${RELEASE_BRANCH}" \
             --state open \
             --json number \
-            --jq '.[0].number')"
+            --jq '.[0].number // empty')"
 
           if [ -n "${pr_number}" ]; then
             gh pr edit "${pr_number}" --title "${title}" --body "${body}"

--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,4 @@ link-workspace-packages=deep
 prefer-workspace-packages=true
 
 ignore-workspace-cycles=true
+minimum-release-age=4320


### PR DESCRIPTION
## Summary
Copy of #579, squashed into a single signed commit.

- narrow reusable workflow permissions and replace broad secret inheritance with explicit secrets
- harden release checkouts, tag-push credentials, Changesets version commit staging, release-branch pushes, and release PR creation
- expand release-critical CODEOWNERS, fix Dependabot target branch, add GitHub Actions updates, and delay consumption of newly published upstream packages by 3 days

Deferred:
- npm-publish environment gate and npm trusted-publisher environment matching are intentionally left for a later PR coordinated with repo/npm settings.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778069723631729)
<!-- slack-thread-ts:1778069723.631729 -->