### PR TITLE
chore(release): roll up unreleased changes across SDK packages

### DIFF
--- a/.changeset/blue-sdk-viem-permit-domain-validation.md
+++ b/.changeset/blue-sdk-viem-permit-domain-validation.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk-viem": patch
+---
+
+Validate permit domain (chainId, verifyingContract) against the token's onchain EIP-2612 domain before signing

--- a/.changeset/migration-sdk-viem-residual-sweep.md
+++ b/.changeset/migration-sdk-viem-residual-sweep.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/migration-sdk-viem": patch
+---
+
+Always sweep residual destination loan tokens to the user after the source repay, and set `skipRevert=true` only on the morphoRepay cleanup so unrelated steps still surface failures

--- a/.changeset/morpho-sdk-1.2.0.md
+++ b/.changeset/morpho-sdk-1.2.0.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": minor
+---
+
+Validate `marketParams.id` at the factory boundary, refetch the target market in `getReallocationData`, enforce asset equality in the raw `vaultV1MigrateToV2` builder, drop `useSimplePermit` from `vaultV1MigrateToV2`, and add JSDoc to the tier-1 surface

--- a/.changeset/simulation-sdk-reallocatable-vaults-case.md
+++ b/.changeset/simulation-sdk-reallocatable-vaults-case.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/simulation-sdk": patch
+---
+
+Match `reallocatableVaults` addresses case-insensitively so reallocation simulation no longer misses checksummed entries (SDK-144)

--- a/.changeset/test-anvil-fork-retry.md
+++ b/.changeset/test-anvil-fork-retry.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/test": patch
+---
+
+Retry anvil fork startup in CI to absorb flaky port allocation, and stabilize the vitest fork helper


### PR DESCRIPTION
## Summary

Add per-package changesets for every `@morpho-org/*` package in `packages/*` that has source-affecting commits merged on `main` since its last npm publish (last `@morpho-org/<pkg>-v<version>` git tag) without a changeset. Once this PR is merged, `version-pr.yml` will open `changeset-release/main` versioning every affected package; merging that PR triggers `publish.yml` and ships them to npm with the `latest` tag.

## Changesets

| Package | Bump | From → To | Source |
| --- | --- | --- | --- |
| `@morpho-org/morpho-sdk` | minor | 1.1.0 → 1.2.0 | rollup of #601, #595, #568, #567, #569 |
| `@morpho-org/blue-sdk-viem` | patch | 4.6.4 → 4.6.5 | #573 validate permit domains |
| `@morpho-org/migration-sdk-viem` | patch | 2.3.1 → 2.3.2 | residual destination loan-token sweep + `skipRevert=true` only on morphoRepay cleanup |
| `@morpho-org/simulation-sdk` | patch | 3.4.2 → 3.4.3 | #572 case-insensitive `reallocatableVaults` match (SDK-144) |
| `@morpho-org/test` | patch | 2.7.1 → 2.7.2 | retry anvil fork startup in CI + vitest fork helper stabilization |

`updateInternalDependencies: "patch"` will additionally bump downstream consumers of these packages transitively when `pnpm changeset version` runs.

## Audit method

For every package under `packages/*`:
1. Look up the exact tag `@morpho-org/<name>-v<package.json.version>`.
2. Run `git log <tag>..origin/main -- packages/<name>/src packages/<name>/package.json`.
3. Filter out commits that don't affect published output: pure docs, CI-only changes, and the biome 2.4.14 lint chore (#583), which only added `// biome-ignore` annotations and reordered imports — no `.d.ts` or runtime impact.
4. Choose the smallest semver bump that describes what's left.

## Excluded (only chore/CI/docs since last tag)

`blue-sdk`, `blue-sdk-wagmi`, `bundler-sdk-viem`, `liquidation-sdk-viem`, `liquidity-sdk-viem`, `morpho-test`, `morpho-ts`, `simulation-sdk-wagmi`, `test-wagmi`. They may still receive transitive `patch` bumps via `updateInternalDependencies`.