### PR TITLE
fix(changeset): filename convention

### DIFF
--- a/.agents/commands/release.md
+++ b/.agents/commands/release.md
@@ -81,7 +81,7 @@ Ask the user to confirm or adjust bumps and wording.
 
 Use `pnpm changeset` (interactive) when the user prefers the prompt, or write the file directly when running non-interactively.
 
-**Direct file form** (write to `.changeset/<short-kebab-name>.md`):
+**Direct file form** (write to `.changeset/<package-short-name>-<new-version>.md`):
 
 ```markdown
 ---
@@ -104,7 +104,7 @@ For docs/chore-only PRs, write an empty changeset:
 
 (Equivalent to `pnpm changeset --empty`.)
 
-The filename should be a short kebab-case slug derived from the change (e.g. `fix-permit-domain-validation.md`). Avoid auto-generated random names — they make `git log` harder to read.
+**Filename convention.** Name the file `<package-short-name>-<new-version>.md`: package short name first, then the version the bump will produce. Read the current `version` from the package's `package.json`, apply the chosen bump, and use the result. Example: a `minor` bump on `@morpho-org/morpho-sdk` currently at `1.2.0` → `.changeset/morpho-sdk-1.3.0.md`. When a single changeset bumps several packages, name it after the primary (most impacted) package and its new version. For empty changesets, use a short kebab-case description (e.g. `docs-readmes-license.md`). Never keep the auto-generated random slugs from `pnpm changeset` — they make `git log` and `.changeset/` unreadable.
 
 ### Step 5: Commit With the Source Change
 

--- a/.changeset/docs-changeset-filename-convention.md
+++ b/.changeset/docs-changeset-filename-convention.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document the changeset filename convention for package-first versioned names.

--- a/.changeset/docs-changeset-filename-convention.md
+++ b/.changeset/docs-changeset-filename-convention.md
@@ -1,4 +1,0 @@
----
----
-
-Document the changeset filename convention for package-first versioned names.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ A scannable list of patterns reviewers reject. Most are review-only today (per t
 ## 7. Releases & versioning
 
 - **SemVer, strict.** Patch: bug fixes, internal changes, doc-only. Minor: additive surface, deprecations. Major: removed/renamed/retyped public symbols.
-- **CHANGELOG via Changesets** — every user-visible change ships with a changeset (review-only today).
+- **CHANGELOG via Changesets** — every user-visible change ships with a changeset (review-only today). Name non-empty changeset files `<package-short-name>-<new-version>.md`, with the package name first and the version the bump will produce second.
 - **`main` is always releasable.** Fork suite green per chain matrix.
 - **Pin ABIs and addresses in-package.** No runtime ABI fetch; no address drift between releases.
 - **4-step deprecation flow:** introduce successor → deprecate with `@deprecated` JSDoc → maintain both for one minor → remove in the next major. No silent removals.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,12 @@ pnpm changeset --empty
 
 Commit the generated `.changeset/*.md` file with the source change. Do not update package versions manually.
 
+### Changeset filename convention
+
+Rename the changeset file to `<package-short-name>-<new-version>.md`: put the package short name first, then the version the bump will produce. Example: a `minor` bump on `@morpho-org/morpho-sdk` from `1.2.0` becomes `.changeset/morpho-sdk-1.3.0.md`. This makes `git log` and `.changeset/` browsable at a glance and avoids the random slugs `pnpm changeset` generates.
+
+When a single changeset bumps several packages, name the file after the primary (most impacted) package and its new version, and list every package in the frontmatter as usual.
+
 This repository does not keep package `CHANGELOG.md` files in source. Changesets are configured with `"changelog": false`, so contributors should not add or edit changelog files as part of normal package changes.
 
 After changes land on `main` or `next`, CI runs `pnpm run version` (the repository script for `changeset version`) and commits generated version updates directly to that branch. The next CI run publishes only package versions that have not already been published. Releases from `main` use the `latest` npm tag; releases from `next` use Changesets prerelease mode and publish with the `next` npm tag.


### PR DESCRIPTION
## What changed

- Documented the changeset filename convention in the root agent rules and contributor guide.
- Updated `/release` instructions so generated changesets use `<package-short-name>-<new-version>.md` for non-empty bumps.
- Added an empty changeset for this repo-meta documentation change.

## Why

Changeset filenames should be readable and deterministic, with the affected package first and the resulting version second, instead of keeping random generated slugs.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778082418620949)
<!-- slack-thread-ts:1778082418.620949 -->