### PR TITLE
feat(vaultV2): rename vault deposit parameter

### DIFF
--- a/.changeset/bright-vaults-rename.md
+++ b/.changeset/bright-vaults-rename.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": major
+---
+
+Rename VaultV1 and VaultV2 deposit parameters from `accrualVault` to `vaultData`.

--- a/packages/morpho-sdk/examples/example.ts
+++ b/packages/morpho-sdk/examples/example.ts
@@ -47,11 +47,11 @@ async function main() {
   // Example 1: Create a deposit transaction
   console.log("📥 Creating deposit transaction...");
   const depositAmount = parseUnits("1", 18); // 1 token (18 decimals)
-  const depositVaultData = await vault.getData();
+  const vaultData = await vault.getData();
   const deposit = vault.deposit({
     amount: depositAmount,
     userAddress: USER_ADDRESS,
-    vaultData: depositVaultData,
+    vaultData,
   });
   const depositTx = deposit.buildTx();
 

--- a/packages/morpho-sdk/examples/example.ts
+++ b/packages/morpho-sdk/examples/example.ts
@@ -47,11 +47,11 @@ async function main() {
   // Example 1: Create a deposit transaction
   console.log("📥 Creating deposit transaction...");
   const depositAmount = parseUnits("1", 18); // 1 token (18 decimals)
-  const accrualVault = await vault.getData();
+  const depositVaultData = await vault.getData();
   const deposit = vault.deposit({
     amount: depositAmount,
     userAddress: USER_ADDRESS,
-    accrualVault,
+    vaultData: depositVaultData,
   });
   const depositTx = deposit.buildTx();
 
@@ -101,10 +101,10 @@ async function main() {
 
   // Example 4: Get vault data
   console.log("\n📊 Fetching vault data...");
-  const vaultData = await vault.getData();
+  const fetchedVaultData = await vault.getData();
   console.log("Vault data:", {
-    address: vaultData.address,
-    asset: vaultData.asset,
+    address: fetchedVaultData.address,
+    asset: fetchedVaultData.asset,
   });
 
   console.log("\n✅ Examples completed successfully!");

--- a/packages/morpho-sdk/src/client/morphoClient.ts
+++ b/packages/morpho-sdk/src/client/morphoClient.ts
@@ -71,11 +71,11 @@ export class MorphoClient implements MorphoClientType {
    * @example
    * ```ts
    * const vault = client.vaultV1(vaultAddress, 1);
-   * const accrualVault = await vault.getData();
+   * const vaultData = await vault.getData();
    * const { buildTx } = vault.deposit({
    *   amount: 1_000_000n,
    *   userAddress: depositor,
-   *   accrualVault,
+   *   vaultData,
    * });
    * const tx = buildTx();
    * ```
@@ -93,11 +93,11 @@ export class MorphoClient implements MorphoClientType {
    * @example
    * ```ts
    * const vault = client.vaultV2(vaultAddress, 1);
-   * const accrualVault = await vault.getData();
+   * const vaultData = await vault.getData();
    * const { buildTx } = vault.deposit({
    *   amount: 1_000_000n,
    *   userAddress: depositor,
-   *   accrualVault,
+   *   vaultData,
    * });
    * const tx = buildTx();
    * ```

--- a/packages/morpho-sdk/src/client/morphoViemExtension.ts
+++ b/packages/morpho-sdk/src/client/morphoViemExtension.ts
@@ -28,11 +28,11 @@ import { MorphoClient } from "./morphoClient.js";
  * }).extend(morphoViemExtension({ supportSignature: true }));
  *
  * const vault = client.morpho.vaultV1(vaultAddress, 1);
- * const accrualVault = await vault.getData();
+ * const vaultData = await vault.getData();
  * const { buildTx } = vault.deposit({
  *   amount: 1_000_000n,
  *   userAddress: user,
- *   accrualVault,
+ *   vaultData,
  * });
  * const tx = buildTx();
  * ```

--- a/packages/morpho-sdk/src/entities/vaultV1/vaultV1.test.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1/vaultV1.test.ts
@@ -36,11 +36,11 @@ describe("MorphoVaultV1 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       const result = vault.deposit({
         amount: parseUnits("100", 6),
         userAddress: client.account.address,
-        accrualVault,
+        vaultData,
         slippageTolerance: 0n,
       });
 
@@ -63,11 +63,11 @@ describe("MorphoVaultV1 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       const result = vault.deposit({
         amount: parseUnits("100", 6),
         userAddress: client.account.address,
-        accrualVault,
+        vaultData,
         slippageTolerance: MAX_SLIPPAGE_TOLERANCE,
       });
 
@@ -90,12 +90,12 @@ describe("MorphoVaultV1 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: parseUnits("100", 6),
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
           slippageTolerance: MAX_SLIPPAGE_TOLERANCE + 1n,
         }),
       ).toThrow(ExcessiveSlippageToleranceError);
@@ -112,12 +112,12 @@ describe("MorphoVaultV1 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: parseUnits("100", 6),
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
           slippageTolerance: -1n,
         }),
       ).toThrow(NegativeSlippageToleranceError);
@@ -136,13 +136,13 @@ describe("MorphoVaultV1 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: 0n,
           nativeAmount: -1n,
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
         }),
       ).toThrow(NegativeNativeAmountError);
     });
@@ -158,13 +158,13 @@ describe("MorphoVaultV1 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: 0n,
           nativeAmount: parseUnits("1", 18),
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
         }),
       ).toThrow(NativeAmountOnNonWNativeVaultError);
     });
@@ -182,11 +182,11 @@ describe("MorphoVaultV1 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       const { getRequirements } = vault.deposit({
         amount: parseUnits("100", 6),
         userAddress: client.account.address,
-        accrualVault,
+        vaultData,
       });
 
       const requirements = await getRequirements();

--- a/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
@@ -48,7 +48,7 @@ export interface VaultV1Actions {
    * Fetches the latest vault data with accrued interest.
    *
    * @param {FetchParameters} [parameters] - Optional fetch parameters (block number, state overrides, etc.).
-   * @returns {Promise<Awaited<ReturnType<typeof fetchAccrualVault>>>} The latest accrued vault data.
+   * @returns {Promise<Awaited<ReturnType<typeof fetchAccrualVault>>>} The latest vault data.
    */
   getData: (
     parameters?: FetchParameters,
@@ -56,13 +56,13 @@ export interface VaultV1Actions {
   /**
    * Prepares a deposit into a VaultV1 (MetaMorpho) contract.
    *
-   * Uses pre-fetched accrual vault data to compute `maxSharePrice` with slippage tolerance,
+   * Uses pre-fetched vault data to compute `maxSharePrice` with slippage tolerance,
    * then returns `buildTx` and `getRequirements` for lazy evaluation.
    *
    * @param {Object} params - The deposit parameters.
    * @param {bigint} params.amount - Amount of assets to deposit.
    * @param {Address} params.userAddress - User address initiating the deposit.
-   * @param {AccrualVault} params.accrualVault - Pre-fetched vault data with asset address and share conversion.
+   * @param {AccrualVault} params.vaultData - Pre-fetched vault data with asset address and share conversion.
    * @param {bigint} [params.slippageTolerance=DEFAULT_SLIPPAGE_TOLERANCE] - Slippage tolerance (default 0.03%, max 10%).
    * @param {bigint} [params.nativeAmount] - Amount of native ETH to wrap into WETH. Vault asset must be wNative.
    * @returns {Object} Object with `buildTx` and `getRequirements`.
@@ -70,7 +70,7 @@ export interface VaultV1Actions {
   deposit: (
     params: {
       userAddress: Address;
-      accrualVault: AccrualVault;
+      vaultData: AccrualVault;
       slippageTolerance?: bigint;
     } & DepositAmountArgs,
   ) => {
@@ -162,12 +162,12 @@ export class MorphoVaultV1 implements VaultV1Actions {
   deposit({
     amount = 0n,
     userAddress,
-    accrualVault,
+    vaultData,
     slippageTolerance = DEFAULT_SLIPPAGE_TOLERANCE,
     nativeAmount,
   }: {
     userAddress: Address;
-    accrualVault: AccrualVault;
+    vaultData: AccrualVault;
     slippageTolerance?: bigint;
   } & DepositAmountArgs) {
     if (this.client.viemClient.chain?.id !== this.chainId) {
@@ -177,8 +177,8 @@ export class MorphoVaultV1 implements VaultV1Actions {
       );
     }
 
-    if (!isAddressEqual(accrualVault.address, this.vault)) {
-      throw new VaultAddressMismatchError(this.vault, accrualVault.address);
+    if (!isAddressEqual(vaultData.address, this.vault)) {
+      throw new VaultAddressMismatchError(this.vault, vaultData.address);
     }
 
     if (amount < 0n) {
@@ -205,17 +205,14 @@ export class MorphoVaultV1 implements VaultV1Actions {
     }
 
     if (nativeAmount && wNative) {
-      if (!isAddressEqual(accrualVault.asset, wNative)) {
-        throw new NativeAmountOnNonWNativeVaultError(
-          accrualVault.asset,
-          wNative,
-        );
+      if (!isAddressEqual(vaultData.asset, wNative)) {
+        throw new NativeAmountOnNonWNativeVaultError(vaultData.asset, wNative);
       }
     }
 
     const totalAssets = amount + (nativeAmount ?? 0n);
 
-    const shares = accrualVault.toShares(totalAssets);
+    const shares = vaultData.toShares(totalAssets);
     if (shares <= 0n) {
       throw new NonPositiveSharesAmountError(this.vault);
     }
@@ -232,7 +229,7 @@ export class MorphoVaultV1 implements VaultV1Actions {
     return {
       getRequirements: async (params?: { useSimplePermit?: boolean }) =>
         await getRequirements(this.client.viemClient, {
-          address: accrualVault.asset,
+          address: vaultData.asset,
           chainId: this.chainId,
           supportSignature: this.client.options.supportSignature,
           supportDeployless: this.client.options.supportDeployless,
@@ -248,7 +245,7 @@ export class MorphoVaultV1 implements VaultV1Actions {
           vault: {
             chainId: this.chainId,
             address: this.vault,
-            asset: accrualVault.asset,
+            asset: vaultData.asset,
           },
           args: {
             amount,

--- a/packages/morpho-sdk/src/entities/vaultV2/vaultV2.test.ts
+++ b/packages/morpho-sdk/src/entities/vaultV2/vaultV2.test.ts
@@ -28,11 +28,11 @@ describe("MorphoVaultV2 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       const result = vault.deposit({
         amount: parseUnits("100", 6),
         userAddress: client.account.address,
-        accrualVault,
+        vaultData,
         slippageTolerance: 0n,
       });
 
@@ -55,11 +55,11 @@ describe("MorphoVaultV2 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       const result = vault.deposit({
         amount: parseUnits("100", 6),
         userAddress: client.account.address,
-        accrualVault,
+        vaultData,
         slippageTolerance: MAX_SLIPPAGE_TOLERANCE,
       });
 
@@ -82,12 +82,12 @@ describe("MorphoVaultV2 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: parseUnits("100", 6),
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
           slippageTolerance: MAX_SLIPPAGE_TOLERANCE + 1n,
         }),
       ).toThrow(ExcessiveSlippageToleranceError);
@@ -104,12 +104,12 @@ describe("MorphoVaultV2 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: parseUnits("100", 6),
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
           slippageTolerance: -1n,
         }),
       ).toThrow(NegativeSlippageToleranceError);
@@ -125,13 +125,13 @@ describe("MorphoVaultV2 entity tests", () => {
       });
       const vault = morphoClient.vaultV2(KpkWETHVaultV2.address, mainnet.id);
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: 0n,
           nativeAmount: -1n,
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
         }),
       ).toThrow(NegativeNativeAmountError);
     });
@@ -147,13 +147,13 @@ describe("MorphoVaultV2 entity tests", () => {
         mainnet.id,
       );
 
-      const accrualVault = await vault.getData();
+      const vaultData = await vault.getData();
       expect(() =>
         vault.deposit({
           amount: 0n,
           nativeAmount: parseUnits("1", 18),
           userAddress: client.account.address,
-          accrualVault,
+          vaultData,
         }),
       ).toThrow(NativeAmountOnNonWNativeVaultError);
     });

--- a/packages/morpho-sdk/src/entities/vaultV2/vaultV2.ts
+++ b/packages/morpho-sdk/src/entities/vaultV2/vaultV2.ts
@@ -56,14 +56,14 @@ export interface VaultV2Actions {
    * Prepares a deposit transaction for the VaultV2 contract.
    *
    * This function constructs the transaction data required to deposit a specified amount of assets into the vault.
-   * Uses pre-fetched accrual vault data for accurate calculations of slippage and asset address,
+   * Uses pre-fetched vault data for accurate calculations of slippage and asset address,
    * then returns the prepared deposit transaction and a function for retrieving all required approval transactions.
    * Bundler Integration: This flow uses the bundler to atomically execute the user's asset transfer and vault deposit in a single transaction for slippage protection.
    *
    * @param {Object} params - The deposit parameters.
    * @param {bigint} [params.amount=0n] - Amount of ERC-20 assets to deposit. At least one of amount or nativeAmount must be provided.
    * @param {Address} params.userAddress - User address initiating the deposit.
-   * @param {AccrualVaultV2} params.accrualVault - Pre-fetched vault data with asset address and share conversion.
+   * @param {AccrualVaultV2} params.vaultData - Pre-fetched vault data with asset address and share conversion.
    * @param {bigint} [params.slippageTolerance=DEFAULT_SLIPPAGE_TOLERANCE] - Optional slippage tolerance value. Default is 0.03%. Slippage tolerance must be less than 10%.
    * @param {bigint} [params.nativeAmount] - Amount of native token to wrap into wNative. Vault asset must be wNative.
    * @returns {Object} The result object.
@@ -73,7 +73,7 @@ export interface VaultV2Actions {
   deposit: (
     params: {
       userAddress: Address;
-      accrualVault: AccrualVaultV2;
+      vaultData: AccrualVaultV2;
       slippageTolerance?: bigint;
     } & DepositAmountArgs,
   ) => {
@@ -194,12 +194,12 @@ export class MorphoVaultV2 implements VaultV2Actions {
   deposit({
     amount = 0n,
     userAddress,
-    accrualVault,
+    vaultData,
     slippageTolerance = DEFAULT_SLIPPAGE_TOLERANCE,
     nativeAmount,
   }: {
     userAddress: Address;
-    accrualVault: AccrualVaultV2;
+    vaultData: AccrualVaultV2;
     slippageTolerance?: bigint;
   } & DepositAmountArgs) {
     if (this.client.viemClient.chain?.id !== this.chainId) {
@@ -209,8 +209,8 @@ export class MorphoVaultV2 implements VaultV2Actions {
       );
     }
 
-    if (!isAddressEqual(accrualVault.address, this.vault)) {
-      throw new VaultAddressMismatchError(this.vault, accrualVault.address);
+    if (!isAddressEqual(vaultData.address, this.vault)) {
+      throw new VaultAddressMismatchError(this.vault, vaultData.address);
     }
 
     if (amount < 0n) {
@@ -237,17 +237,14 @@ export class MorphoVaultV2 implements VaultV2Actions {
     }
 
     if (nativeAmount && wNative) {
-      if (!isAddressEqual(accrualVault.asset, wNative)) {
-        throw new NativeAmountOnNonWNativeVaultError(
-          accrualVault.asset,
-          wNative,
-        );
+      if (!isAddressEqual(vaultData.asset, wNative)) {
+        throw new NativeAmountOnNonWNativeVaultError(vaultData.asset, wNative);
       }
     }
 
     const totalAssets = amount + (nativeAmount ?? 0n);
 
-    const shares = accrualVault.toShares(totalAssets);
+    const shares = vaultData.toShares(totalAssets);
     if (shares <= 0n) {
       throw new NonPositiveSharesAmountError(this.vault);
     }
@@ -264,7 +261,7 @@ export class MorphoVaultV2 implements VaultV2Actions {
     return {
       getRequirements: async (params?: { useSimplePermit?: boolean }) =>
         await getRequirements(this.client.viemClient, {
-          address: accrualVault.asset,
+          address: vaultData.asset,
           chainId: this.chainId,
           supportSignature: this.client.options.supportSignature,
           supportDeployless: this.client.options.supportDeployless,
@@ -280,7 +277,7 @@ export class MorphoVaultV2 implements VaultV2Actions {
           vault: {
             chainId: this.chainId,
             address: this.vault,
-            asset: accrualVault.asset,
+            asset: vaultData.asset,
           },
           args: {
             amount,

--- a/packages/morpho-sdk/test/actions/metadata.test.ts
+++ b/packages/morpho-sdk/test/actions/metadata.test.ts
@@ -34,11 +34,11 @@ describe("Metadata", () => {
           },
         });
         const vaultV2 = morpho.vaultV2(KeyrockUsdcVaultV2.address, mainnet.id);
-        const accrualVault = await vaultV2.getData();
+        const vaultData = await vaultV2.getData();
         const deposit = vaultV2.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const tx_1 = deposit.buildTx();
@@ -104,11 +104,11 @@ describe("Metadata", () => {
           },
         });
         const vaultV2 = morpho.vaultV2(KeyrockUsdcVaultV2.address, mainnet.id);
-        const accrualVault = await vaultV2.getData();
+        const vaultData = await vaultV2.getData();
         const deposit = vaultV2.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const tx = deposit.buildTx();

--- a/packages/morpho-sdk/test/actions/requirements/approval.test.ts
+++ b/packages/morpho-sdk/test/actions/requirements/approval.test.ts
@@ -29,11 +29,11 @@ describe("Approval", () => {
       },
       actionFn: async () => {
         const vault = morpho.vaultV2(Re7UsdtVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -81,11 +81,11 @@ describe("Approval", () => {
       },
       actionFn: async () => {
         const vault = morpho.vaultV2(Re7UsdtVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();

--- a/packages/morpho-sdk/test/actions/requirements/permit.test.ts
+++ b/packages/morpho-sdk/test/actions/requirements/permit.test.ts
@@ -28,11 +28,11 @@ describe("Permit", () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
 
         const vault = morpho.vaultV2(KeyrockUsdcVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
         const requirements_1 = await deposit.getRequirements({
           useSimplePermit: true,

--- a/packages/morpho-sdk/test/actions/requirements/permit2.test.ts
+++ b/packages/morpho-sdk/test/actions/requirements/permit2.test.ts
@@ -49,11 +49,11 @@ describe("Permit2", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
         const vault = morpho.vaultV2(Re7UsdtVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -137,11 +137,11 @@ describe("Permit2", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
         const vault = morpho.vaultV2(Re7UsdtVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -220,11 +220,11 @@ describe("Permit2", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
         const vault = morpho.vaultV2(KpkWETHVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -277,11 +277,11 @@ describe("Permit2", () => {
         vaults: { DaiVaultV2 },
       },
       actionFn: async () => {
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -360,11 +360,11 @@ describe("Permit2", () => {
         vaults: { KeyrockUsdcVaultV2 },
       },
       actionFn: async () => {
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements({

--- a/packages/morpho-sdk/test/actions/vaultV1/deposit.test.ts
+++ b/packages/morpho-sdk/test/actions/vaultV1/deposit.test.ts
@@ -25,11 +25,11 @@ describe("DepositVaultV1", () => {
     const morpho = new MorphoClient(client);
 
     const vault = morpho.vaultV1(SteakhouseUsdcVaultV1.address, mainnet.id);
-    const accrualVault = await vault.getData();
+    const vaultData = await vault.getData();
     const deposit = vault.deposit({
       userAddress: client.account.address,
       amount: 1000000000000000000n,
-      accrualVault,
+      vaultData,
     });
     const requirements_1 = await deposit.getRequirements();
     const tx_1 = deposit.buildTx();
@@ -50,8 +50,8 @@ describe("DepositVaultV1", () => {
     expect(deposit).toBeDefined();
     expect(requirements_1).toBeDefined();
     expect(tx_1).toStrictEqual(tx_2);
-    expect(accrualVault.asset).toStrictEqual(SteakhouseUsdcVaultV1.asset);
-    expect(accrualVault.address).toStrictEqual(SteakhouseUsdcVaultV1.address);
+    expect(vaultData.asset).toStrictEqual(SteakhouseUsdcVaultV1.asset);
+    expect(vaultData.address).toStrictEqual(SteakhouseUsdcVaultV1.address);
   });
 
   test("should deposit 1K USDC in vaultV1", async ({ client }) => {
@@ -76,11 +76,11 @@ describe("DepositVaultV1", () => {
           SteakhouseUsdcVaultV1.address,
           mainnet.id,
         );
-        const accrualVault = await vaultV1.getData();
+        const vaultData = await vaultV1.getData();
         const deposit = vaultV1.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const tx = deposit.buildTx();
@@ -144,11 +144,11 @@ describe("DepositVaultV1", () => {
           SteakhouseUSDTVaultV1.address,
           mainnet.id,
         );
-        const accrualVault = await vaultV1.getData();
+        const vaultData = await vaultV1.getData();
         const deposit = vaultV1.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const tx = deposit.buildTx();
@@ -208,11 +208,11 @@ describe("DepositVaultV1", () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
 
         const vault = morpho.vaultV1(SteakhouseUsdcVaultV1.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
         const requirements = await deposit.getRequirements({
           useSimplePermit: true,
@@ -282,11 +282,11 @@ describe("DepositVaultV1", () => {
         vaults: { SteakhouseUsdcVaultV1 },
       },
       actionFn: async () => {
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements({
@@ -380,11 +380,11 @@ describe("DepositVaultV1", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
         const vault = morpho.vaultV1(GauntletWethVaultV1.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -432,11 +432,11 @@ describe("DepositVaultV1", () => {
           mainnet.id,
         );
 
-        const accrualVault = await vaultV1.getData();
+        const vaultData = await vaultV1.getData();
         const deposit = vaultV1.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
         const requirements = await deposit.getRequirements();
         const approveTx = requirements[0];

--- a/packages/morpho-sdk/test/actions/vaultV1/redeem.test.ts
+++ b/packages/morpho-sdk/test/actions/vaultV1/redeem.test.ts
@@ -106,11 +106,11 @@ describe("Redeem VaultV1", () => {
           mainnet.id,
         );
 
-        const accrualVault = await vaultV1.getData();
+        const vaultData = await vaultV1.getData();
         const deposit = vaultV1.deposit({
           userAddress: client.account.address,
           amount: depositAmount,
-          accrualVault,
+          vaultData,
         });
         const requirements = await deposit.getRequirements();
         const approveTx = requirements[0];

--- a/packages/morpho-sdk/test/actions/vaultV2/deposit.test.ts
+++ b/packages/morpho-sdk/test/actions/vaultV2/deposit.test.ts
@@ -15,11 +15,11 @@ describe("DepositVaultV2", () => {
     const morpho = new MorphoClient(client);
 
     const vault = morpho.vaultV2(KeyrockUsdcVaultV2.address, mainnet.id);
-    const accrualVault = await vault.getData();
+    const vaultData = await vault.getData();
     const deposit = vault.deposit({
       userAddress: client.account.address,
       amount: 1000000000000000000n,
-      accrualVault,
+      vaultData,
     });
     const requirements_1 = await deposit.getRequirements();
     const data = await vault.getData();
@@ -64,11 +64,11 @@ describe("DepositVaultV2", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client);
         const vaultV2 = morpho.vaultV2(KeyrockUsdcVaultV2.address, mainnet.id);
-        const accrualVault = await vaultV2.getData();
+        const vaultData = await vaultV2.getData();
         const deposit = vaultV2.deposit({
           userAddress: client.account.address,
           amount: amount,
-          accrualVault,
+          vaultData,
         });
 
         const tx = deposit.buildTx();

--- a/packages/morpho-sdk/test/actions/wrap.test.ts
+++ b/packages/morpho-sdk/test/actions/wrap.test.ts
@@ -41,12 +41,12 @@ describe("WrapNative - VaultV1", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client);
         const vault = morpho.vaultV1(GauntletWethVaultV1.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: 0n,
           nativeAmount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -110,12 +110,12 @@ describe("WrapNative - VaultV1", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client);
         const vault = morpho.vaultV1(GauntletWethVaultV1.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount,
           nativeAmount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -170,12 +170,12 @@ describe("WrapNative - VaultV1", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
         const vault = morpho.vaultV1(GauntletWethVaultV1.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount,
           nativeAmount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -294,12 +294,12 @@ describe("WrapNative - VaultV2", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client);
         const vault = morpho.vaultV2(KpkWETHVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount: 0n,
           nativeAmount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -363,12 +363,12 @@ describe("WrapNative - VaultV2", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client);
         const vault = morpho.vaultV2(KpkWETHVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount,
           nativeAmount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();
@@ -423,12 +423,12 @@ describe("WrapNative - VaultV2", () => {
       actionFn: async () => {
         const morpho = new MorphoClient(client, { supportSignature: true });
         const vault = morpho.vaultV2(KpkWETHVaultV2.address, mainnet.id);
-        const accrualVault = await vault.getData();
+        const vaultData = await vault.getData();
         const deposit = vault.deposit({
           userAddress: client.account.address,
           amount,
           nativeAmount,
-          accrualVault,
+          vaultData,
         });
 
         const requirements = await deposit.getRequirements();


### PR DESCRIPTION
## What changed

- Renamed the Morpho SDK VaultV1 and VaultV2 deposit parameter from `accrualVault` to `vaultData`.
- Updated examples, JSDoc, and affected tests to use the new parameter name.
- Added a changeset for the public API rename.

## Why

The deposit API should expose the fetched vault payload as generic vault data and avoid surfacing `accrual` in the parameter name.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778083164292369)
<!-- slack-thread-ts:1778083164.292369 -->