### PR TITLE
chore: sync .claude and .codex symlinks with split pr-review commands

### DIFF
--- a/.claude/commands/pr-review-ci.md
+++ b/.claude/commands/pr-review-ci.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review-ci.md

--- a/.claude/commands/pr-review-gh.md
+++ b/.claude/commands/pr-review-gh.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review-gh.md

--- a/.claude/commands/pr-review-local.md
+++ b/.claude/commands/pr-review-local.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review-local.md

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,1 +1,0 @@
-../../.agents/commands/pr-review.md

--- a/.codex/prompts/pr-review-ci.md
+++ b/.codex/prompts/pr-review-ci.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review-ci.md

--- a/.codex/prompts/pr-review-gh.md
+++ b/.codex/prompts/pr-review-gh.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review-gh.md

--- a/.codex/prompts/pr-review-local.md
+++ b/.codex/prompts/pr-review-local.md
@@ -1,0 +1,1 @@
+../../.agents/commands/pr-review-local.md

--- a/.codex/prompts/pr-review.md
+++ b/.codex/prompts/pr-review.md
@@ -1,1 +1,0 @@
-../../.agents/commands/pr-review.md


### PR DESCRIPTION
## Motivation

#599 split `.agents/commands/pr-review.md` into `pr-review-ci.md`, `pr-review-gh.md`, and `pr-review-local.md`, but did not update the symlinks under `.claude/commands/` and `.codex/prompts/`. Both still pointed to the now-deleted `pr-review.md`, so `/pr-review-*` was unreachable from Claude Code and Codex (the symlinks resolved to nothing).

## Solution

Replace the dangling `pr-review.md` symlinks in `.claude/commands/` and `.codex/prompts/` with three fresh symlinks each — `pr-review-ci.md`, `pr-review-gh.md`, `pr-review-local.md` — pointing at the corresponding files in `.agents/commands/`. `.claude/commands/` now mirrors all 9 entries in `.agents/commands/`; `.codex/prompts/` keeps its previously curated subset (`extract-plan`, `pr-fix`) plus the three new `pr-review-*` replacements.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778144896573209)
<!-- slack-thread-ts:1778144896.573209 -->