### PR TITLE
ci(slack): batch repeated "commented" reviews in PR thread

### DIFF
--- a/.github/workflows/pr-slack-notify.yml
+++ b/.github/workflows/pr-slack-notify.yml
@@ -379,7 +379,7 @@ jobs:
             };
             const status = STATUS[state] || { emoji: ':eyes:', text: 'reviewed' };
 
-            async function slack(method, body) {
+            async function slackPost(method, body) {
               const res = await fetch(`https://slack.com/api/${method}`, {
                 method: 'POST',
                 headers: {
@@ -387,6 +387,16 @@ jobs:
                   'Content-Type': 'application/json',
                 },
                 body: JSON.stringify(body),
+              });
+              return res.json();
+            }
+
+            // Slack's read-style methods (conversations.history/.replies)
+            // reject POST + JSON with `invalid_arguments`; use GET + query.
+            async function slackGet(method, params) {
+              const qs = new URLSearchParams(params).toString();
+              const res = await fetch(`https://slack.com/api/${method}?${qs}`, {
+                headers: { 'Authorization': `Bearer ${token}` },
               });
               return res.json();
             }
@@ -403,10 +413,10 @@ jobs:
 
             async function postOrBatch(channel, threadTs) {
               if (state === 'commented') {
-                const replies = await slack('conversations.replies', {
+                const replies = await slackGet('conversations.replies', {
                   channel,
                   ts: threadTs,
-                  limit: 200,
+                  limit: '200',
                 });
                 if (replies.ok && Array.isArray(replies.messages)) {
                   const re = buildCommentedRegex(reviewer);
@@ -417,7 +427,7 @@ jobs:
                     const match = existing.text.match(re);
                     const nextCount = match[1] ? parseInt(match[1], 10) + 1 : 2;
                     const newText = `${status.emoji} ${reviewer} <${reviewUrl}|commented> (×${nextCount})`;
-                    const upd = await slack('chat.update', {
+                    const upd = await slackPost('chat.update', {
                       channel,
                       ts: existing.ts,
                       text: newText,
@@ -434,7 +444,7 @@ jobs:
                 }
               }
 
-              const post = await slack('chat.postMessage', {
+              const post = await slackPost('chat.postMessage', {
                 channel,
                 thread_ts: threadTs,
                 text: `${status.emoji} ${reviewer} <${reviewUrl}|${status.text}>`,

--- a/.github/workflows/pr-slack-notify.yml
+++ b/.github/workflows/pr-slack-notify.yml
@@ -5,7 +5,10 @@ name: PR Slack Notifications
 # Setup (one-time, repo settings):
 #   - secrets.SLACK_BOT_TOKEN — bot token for the Slack app posting messages.
 #     The bot must be invited to #sdks-reviews and needs scopes:
-#       chat:write, channels:history, reactions:write, im:write.
+#       chat:write, channels:history, reactions:write, im:write, im:history.
+#     (im:history is used to batch repeated "commented" reviews in the
+#      quick-win DM thread; without it that thread falls back to one reply
+#      per review.)
 #   - vars.SLACK_CHANNEL_ID — channel ID for #sdks-reviews
 #     (right-click the channel → "View channel details" → copy the ID at the bottom).
 
@@ -342,59 +345,110 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get reviewer name
+      # Posts to the PR thread (and the quick-win DM thread when present).
+      # `commented` reviews are batched in-place: instead of stacking N
+      # ":speech_balloon: <reviewer> commented" replies, we look for an
+      # existing one from the same reviewer in the thread, bump a counter,
+      # and `chat.update` it with a fresh link to the latest review.
+      # `approved` / `changes_requested` are always posted as new replies —
+      # they're signal we want to keep distinct.
+      - name: Send review update to Slack thread(s)
         if: steps.get-ts.outputs.found == 'true'
-        id: reviewer
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
-          REVIEWER_LOGIN: ${{ github.event.review.user.login }}
-        run: echo "name=$REVIEWER_LOGIN" >> $GITHUB_OUTPUT
-
-      - name: Determine review status emoji and text
-        if: steps.get-ts.outputs.found == 'true'
-        id: review-status
-        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          MAIN_CHANNEL_ID: ${{ env.SLACK_CHANNEL_ID }}
+          MAIN_THREAD_TS: ${{ steps.get-ts.outputs.thread_ts }}
+          QUICK_WIN_FOUND: ${{ steps.get-ts.outputs.quick_win_found }}
+          QUICK_WIN_CHANNEL: ${{ steps.get-ts.outputs.quick_win_channel }}
+          QUICK_WIN_TS: ${{ steps.get-ts.outputs.quick_win_ts }}
+          REVIEWER: ${{ github.event.review.user.login }}
           REVIEW_STATE: ${{ github.event.review.state }}
-        run: |
-          case "$REVIEW_STATE" in
-            "approved")
-              echo "emoji=:white_check_mark:" >> $GITHUB_OUTPUT
-              echo "text=approved" >> $GITHUB_OUTPUT
-              ;;
-            "changes_requested")
-              echo "emoji=:warning:" >> $GITHUB_OUTPUT
-              echo "text=requested changes" >> $GITHUB_OUTPUT
-              ;;
-            "commented")
-              echo "emoji=:speech_balloon:" >> $GITHUB_OUTPUT
-              echo "text=commented" >> $GITHUB_OUTPUT
-              ;;
-            *)
-              echo "emoji=:eyes:" >> $GITHUB_OUTPUT
-              echo "text=reviewed" >> $GITHUB_OUTPUT
-              ;;
-          esac
-
-      - name: Send review update to Slack thread
-        if: steps.get-ts.outputs.found == 'true'
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+          REVIEW_URL: ${{ github.event.review.html_url }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ env.SLACK_CHANNEL_ID }}
-            thread_ts: "${{ steps.get-ts.outputs.thread_ts }}"
-            text: "${{ steps.review-status.outputs.emoji }} ${{ steps.reviewer.outputs.name }} <${{ github.event.review.html_url }}|${{ steps.review-status.outputs.text }}>"
+          script: |
+            const token = process.env.SLACK_TOKEN;
+            const reviewer = process.env.REVIEWER;
+            const state = process.env.REVIEW_STATE;
+            const reviewUrl = process.env.REVIEW_URL;
 
-      - name: Send review update to quick-win DM thread
-        if: steps.get-ts.outputs.found == 'true' && steps.get-ts.outputs.quick_win_found == 'true'
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ steps.get-ts.outputs.quick_win_channel }}
-            thread_ts: "${{ steps.get-ts.outputs.quick_win_ts }}"
-            text: "${{ steps.review-status.outputs.emoji }} ${{ steps.reviewer.outputs.name }} <${{ github.event.review.html_url }}|${{ steps.review-status.outputs.text }}>"
+            const STATUS = {
+              approved: { emoji: ':white_check_mark:', text: 'approved' },
+              changes_requested: { emoji: ':warning:', text: 'requested changes' },
+              commented: { emoji: ':speech_balloon:', text: 'commented' },
+            };
+            const status = STATUS[state] || { emoji: ':eyes:', text: 'reviewed' };
+
+            async function slack(method, body) {
+              const res = await fetch(`https://slack.com/api/${method}`, {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${token}`,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(body),
+              });
+              return res.json();
+            }
+
+            const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            // Match either the first-post shape ":speech_balloon: <reviewer> <url|commented>"
+            // or the bumped shape "... <url|commented> (×N)". Anchored so an unrelated
+            // reply mentioning the reviewer can't accidentally match.
+            const buildCommentedRegex = (reviewerName) =>
+              new RegExp(
+                `^:speech_balloon: ${escapeRegex(reviewerName)} <[^|>]+\\|commented>(?: \\(×(\\d+)\\))?$`
+              );
+
+            async function postOrBatch(channel, threadTs) {
+              if (state === 'commented') {
+                const replies = await slack('conversations.replies', {
+                  channel,
+                  ts: threadTs,
+                  limit: 200,
+                });
+                if (replies.ok && Array.isArray(replies.messages)) {
+                  const re = buildCommentedRegex(reviewer);
+                  const existing = replies.messages.find(
+                    (m) => m.ts !== threadTs && typeof m.text === 'string' && re.test(m.text)
+                  );
+                  if (existing) {
+                    const match = existing.text.match(re);
+                    const nextCount = match[1] ? parseInt(match[1], 10) + 1 : 2;
+                    const newText = `${status.emoji} ${reviewer} <${reviewUrl}|commented> (×${nextCount})`;
+                    const upd = await slack('chat.update', {
+                      channel,
+                      ts: existing.ts,
+                      text: newText,
+                    });
+                    if (!upd.ok) {
+                      core.warning(`chat.update failed for ${channel}/${existing.ts}: ${upd.error}`);
+                    } else {
+                      core.info(`Batched ${reviewer}'s commented review in ${channel} (×${nextCount})`);
+                    }
+                    return;
+                  }
+                } else if (!replies.ok) {
+                  core.warning(`conversations.replies failed for ${channel}/${threadTs}: ${replies.error}`);
+                }
+              }
+
+              const post = await slack('chat.postMessage', {
+                channel,
+                thread_ts: threadTs,
+                text: `${status.emoji} ${reviewer} <${reviewUrl}|${status.text}>`,
+              });
+              if (!post.ok) {
+                core.warning(`chat.postMessage failed for ${channel}/${threadTs}: ${post.error}`);
+              }
+            }
+
+            await postOrBatch(process.env.MAIN_CHANNEL_ID, process.env.MAIN_THREAD_TS);
+
+            if (process.env.QUICK_WIN_FOUND === 'true') {
+              await postOrBatch(process.env.QUICK_WIN_CHANNEL, process.env.QUICK_WIN_TS);
+            }
 
   notify-re-review-requested:
     if: |


### PR DESCRIPTION
## Summary

The Slack bot in `pr-slack-notify.yml` posts one reply per `pull_request_review` event into the PR thread. When the same reviewer submits several `commented` reviews on the same PR, the thread fills with stacked `:speech_balloon: <reviewer> commented` replies — that's the spam.

This PR makes `commented` reviews **batch in place**:

- First `commented` from a reviewer → posts a normal reply (current shape).
- Subsequent `commented` from the same reviewer → finds the existing reply via `conversations.replies`, `chat.update`s it to `... commented (×N)` and refreshes the link to the latest review.

`approved` and `changes_requested` keep posting fresh replies — those are signal worth keeping distinct.

Same logic is applied to the quick-win DM thread.

## Implementation notes

- Replaces the two `slackapi/slack-github-action` posting steps + the bash `Determine review status emoji and text` step with one `actions/github-script` step that handles both threads.
- Uses raw `fetch` to the Slack Web API (consistent with `notify-quick-win` further down).
- Anchored regex on the existing message text so an unrelated thread reply mentioning the reviewer can't trip the match.
- DM-thread batching needs the `im:history` scope on the Slack app — added to the doc block at the top. Without it, `conversations.replies` fails gracefully (warning logged) and we fall through to a normal `chat.postMessage`, i.e. current behavior.

## Test plan

- [ ] Add `im:history` scope to the Slack app and re-install (one-time, unblocks DM-thread batching).
- [ ] Manual: open a draft PR → mark ready → leave a `Comment` review, then leave a second `Comment` review. Verify the thread shows one reply that updates to `commented (×2)` and links to the second review.
- [ ] Verify a subsequent `Approve` posts a fresh `:white_check_mark: ... approved` reply (not batched).
- [ ] Verify quick-win DM thread shows the same batching when the `quick win` label flow is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778155133612689)
<!-- slack-thread-ts:1778155133.612689 -->