### PR TITLE
chore(codeowners): require sdk-engineers review on every PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+* @morpho-org/sdk-engineers
 /.github/ @morpho-org/security
 /.changeset/config.json @morpho-org/security
 /.changeset/pre.json @morpho-org/security


### PR DESCRIPTION
## Summary
- Add catch-all `* @morpho-org/sdk-engineers` at the top of `.github/CODEOWNERS` so every PR triggers a code owner review.
- More specific rules below (e.g. `/.github/ @morpho-org/security`) still win because CODEOWNERS uses last-match semantics.

## Why
Today, PRs that touch only "logic" paths (e.g. `packages/*/src/**`) match no CODEOWNERS rule. Combined with the repo ruleset's `require_code_owner_review: true`, that requirement is vacuously satisfied — anyone with write access can approve and merge. This catch-all ensures at least one approval from `@morpho-org/sdk-engineers` on every PR.

## Caveat — needs a follow-up before this is enforced
`@morpho-org/sdk-engineers` does **not** currently have access to this repo (only `engineering`, `integration`, `platform-engineers`, `security` do). Until the team is added with at least *Read* access via Settings → Collaborators and teams, GitHub will silently ignore this line — no auto-assignment, no enforcement.

Two options to actually enable it:
1. Grant `@morpho-org/sdk-engineers` Read access to `morpho-org/sdks`.
2. Or change the catch-all to a team that already has access (e.g. `@morpho-org/engineering`).

## Test plan
- [ ] After merge + team-access fix: open a draft PR touching only `packages/*/src/**` and confirm "Reviewers" auto-assigns `@morpho-org/sdk-engineers` and "Merging is blocked" lists the code owner requirement.
- [ ] Confirm existing path-specific rules still gate `@morpho-org/security` on `.github/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778157797493129)
<!-- slack-thread-ts:1778157797.493129 -->