### PR TITLE
chore(changeset): patch blue-sdk for Tempo Vault V1 adapter factory

### DIFF
--- a/.changeset/tempo-vault-v1-adapter-factory.md
+++ b/.changeset/tempo-vault-v1-adapter-factory.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk": patch
+---
+
+Add Tempo Morpho Vault V1 adapter factory address to the registry


### PR DESCRIPTION
## Motivation

PR #630 (`feat(tempo): add Vault V1 adapter factory`) merged to `main` after the last version PR (#633) without a changeset, so the Tempo Morpho Vault V1 adapter factory address added to `packages/blue-sdk/src/addresses.ts` won't ship until a changeset is recorded.

## Solution

Add a `patch` changeset for `@morpho-org/blue-sdk` so the next version PR bumps `blue-sdk` to `5.23.2` and propagates the patch to internal dependents via Changesets' `updateInternalDependencies: "patch"`.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778159165297199)
<!-- slack-thread-ts:1778159165.297199 -->