### PR TITLE
chore(morpho-sdk): patch republish to fix workspace:^ leak in 1.2.0

### DIFF
--- a/.changeset/morpho-sdk-1.2.1-republish.md
+++ b/.changeset/morpho-sdk-1.2.1-republish.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": patch
+---
+
+Republish to fix a broken `1.2.0` manifest. The `1.2.0` tarball on npm was published manually with `npm publish` from the pnpm workspace, which does not rewrite the `workspace:^` protocol. The published `package.json` therefore declared its internal Morpho dependencies as `workspace:^`, breaking installs for consumers that don't understand the workspace protocol (notably Yarn v1). `1.2.1` has identical source to `1.2.0` and is republished via `pnpm publish` so the workspace ranges are resolved to real semver.


### PR DESCRIPTION
## Summary

- Add a patch changeset bumping `@morpho-org/morpho-sdk` to `1.2.1`.
- No source changes — this is a republish to fix a broken `1.2.0` manifest on npm.

## Why

`1.2.0` was published manually with `npm publish` from the pnpm workspace. Because npm doesn't see pnpm's workspace structure, it didn't rewrite the `workspace:^` protocol on internal deps, and the published `package.json` shipped with:

```json
"@morpho-org/blue-sdk":         "workspace:^",
"@morpho-org/blue-sdk-viem":    "workspace:^",
"@morpho-org/bundler-sdk-viem": "workspace:^",
"@morpho-org/morpho-ts":        "workspace:^",
"@morpho-org/simulation-sdk":   "workspace:^"
```

Yarn v1 (still used by some consumers, e.g. the main app) doesn't understand the `workspace:` protocol and fails to install. Once this PR and the resulting version PR are merged, the publish workflow runs `pnpm release` (→ `pnpm publish`), which rewrites `workspace:^` to real semver ranges in the published tarball.

`1.2.0` will be deprecated on npm separately.

## Test plan

- [ ] Version PR opens automatically and bumps `morpho-sdk` to `1.2.1`.
- [ ] After merging the version PR, `1.2.1` appears on npm with semver ranges (no `workspace:` strings) — verify with `npm view @morpho-org/morpho-sdk@1.2.1 dependencies`.
- [ ] Yarn v1 consumer can `yarn add @morpho-org/morpho-sdk@1.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778163175597119)
<!-- slack-thread-ts:1778163175.597119 -->