### PR TITLE
chore: version packages (main)

### DIFF
--- a/.changeset/morpho-sdk-1.2.1-republish.md
+++ b/.changeset/morpho-sdk-1.2.1-republish.md
@@ -1,5 +1,0 @@
----
-"@morpho-org/morpho-sdk": patch
----
-
-Republish to fix a broken `1.2.0` manifest. The `1.2.0` tarball on npm was published manually with `npm publish` from the pnpm workspace, which does not rewrite the `workspace:^` protocol. The published `package.json` therefore declared its internal Morpho dependencies as `workspace:^`, breaking installs for consumers that don't understand the workspace protocol (notably Yarn v1). `1.2.1` has identical source to `1.2.0` and is republished via `pnpm publish` so the workspace ranges are resolved to real semver.

--- a/.changeset/tempo-vault-v1-adapter-factory.md
+++ b/.changeset/tempo-vault-v1-adapter-factory.md
@@ -1,5 +1,0 @@
----
-"@morpho-org/blue-sdk": patch
----
-
-Add Tempo Morpho Vault V1 adapter factory address to the registry

--- a/packages/blue-sdk/package.json
+++ b/packages/blue-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@morpho-org/blue-sdk",
   "description": "Framework-agnostic package that defines Morpho-related entity classes (such as `Market`, `Token`, `Vault`).",
-  "version": "5.23.1",
+  "version": "5.23.2",
   "author": "Morpho Association <contact@morpho.org>",
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"

--- a/packages/morpho-sdk/package.json
+++ b/packages/morpho-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@morpho-org/morpho-sdk",
   "description": "Abstraction layer for Morpho's complexity.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Morpho Association <contact@morpho.org>",
   "contributors": [
     "Foulks-Plb <https://x.com/FoulkPlb>"


### PR DESCRIPTION
Replaces #642 with a signed commit (the original PR is opened by `github-actions[bot]` whose commit isn't signed and can't be merged under the branch protection that requires verified commits).

Same content as #642: applies the pending changesets for `main` so the publish workflow can publish the already-versioned packages.

- bumps `@morpho-org/blue-sdk` to `5.23.2`
- bumps `@morpho-org/morpho-sdk` to `1.2.1`
- removes the two consumed changesets

Close #642 once this lands.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778164470639089)
<!-- slack-thread-ts:1778164470.639089 -->