### PR TITLE
fix(bundler-sdk-viem): apply input-transfer rewrite when at index 0

### DIFF
--- a/.changeset/bundler-rewrite-index-zero.md
+++ b/.changeset/bundler-rewrite-index-zero.md
@@ -1,0 +1,11 @@
+---
+"@morpho-org/bundler-sdk-viem": patch
+---
+
+Fix off-by-one in `finalizeBundle`'s input-transfer rewrite optimization for
+`MetaMorpho_Withdraw` and `Blue_Repay`: the matching `Erc20_Transfer` was
+silently skipped when it happened to be the first operation in the bundle,
+because the `<= 0` guard conflated `findIndex`'s `-1` "not found" sentinel
+with a legitimate `0` index. The bundle still produced correct (just less
+optimal) calldata; this patch removes the redundant input-transfer step in
+the affected case.

--- a/packages/bundler-sdk-viem/src/operations.ts
+++ b/packages/bundler-sdk-viem/src/operations.ts
@@ -847,7 +847,7 @@ export const finalizeBundle = (
         candidate.args.to === generalAdapter1 &&
         candidate.args.amount >= shares,
     );
-    if (inputTransferIndex <= 0) return;
+    if (inputTransferIndex < 0) return;
 
     const inputTransfer = operations[
       inputTransferIndex


### PR DESCRIPTION
## Summary

`finalizeBundle`'s rewrite optimization for `MetaMorpho_Withdraw` / `Blue_Repay` was silently skipped when the matching self-`Erc20_Transfer` into `generalAdapter1` happened to be the first operation in the bundle: the `<= 0` guard conflated `findIndex`'s `-1` "not found" sentinel with a legitimate `0` index.

## Impact

Calldata correctness is unaffected — the optimization only consolidates a redundant input-transfer step when its precondition is met, so the existing path still produces a working bundle, just with one extra `Erc20_Transfer` and the corresponding gas/event overhead.

## Cause

`Array.prototype.findIndex` returns `-1` when no match is found and a non-negative integer otherwise. The early-return must reject only `-1`, not `0`.

## Why no new regression test

The current tests for this optimization (`populateBundle.test.ts`) are fork-based and exercise the index ≥ 1 path because `populateBundle` prepends `Erc20_Permit` operations before any input transfer. Hitting the index === 0 path requires either constructing a custom `SimulationState` to call `finalizeBundle` directly (heavyweight relative to a one-character fix) or rearranging the existing fixtures in a way that doesn't generalize. Happy to add one in a follow-up if reviewers prefer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->