### PR TITLE
fix(token): reject unsupported EIP-5267 permit domains

### DIFF
--- a/.changeset/tame-permit-domain-extensions.md
+++ b/.changeset/tame-permit-domain-extensions.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk-viem": patch
+---
+
+Reject EIP-5267 permit domains that advertise unsupported extension fields before requesting a signature.

--- a/packages/blue-sdk-viem/src/error.ts
+++ b/packages/blue-sdk-viem/src/error.ts
@@ -27,6 +27,22 @@ export class InvalidPermitDomainVerifyingContractError extends Error {
   }
 }
 
+/** Thrown when a permit domain advertises unsupported EIP-5267 extensions. */
+export class UnsupportedPermitDomainExtensionsError extends Error {
+  public readonly extensions: readonly bigint[];
+
+  constructor(
+    public readonly token: Address,
+    extensions: readonly bigint[],
+  ) {
+    super(
+      `Unsupported EIP-5267 domain extensions for token "${token}": expected no extensions, got "${extensions.join(", ")}". Use another approval path instead of signing this permit.`,
+    );
+
+    this.extensions = [...extensions];
+  }
+}
+
 /**
  * Checks if an error is a contract revert with the "UnknownOfFactory" error name.
  * Used to propagate factory validation errors instead of falling back to multicall.

--- a/packages/blue-sdk-viem/src/signatures/permit.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit.ts
@@ -8,6 +8,7 @@ import { isAddressEqual, type TypedDataDefinition } from "viem";
 import {
   InvalidPermitDomainChainIdError,
   InvalidPermitDomainVerifyingContractError,
+  UnsupportedPermitDomainExtensionsError,
 } from "../error.js";
 
 export interface PermitArgs {
@@ -34,6 +35,27 @@ const permitTypes = {
  * Fails closed when fetched EIP-5267 metadata is not bound to the token and chain.
  * Consumers should use another approval path instead of signing an unsafe domain.
  * Docs: https://eips.ethereum.org/EIPS/eip-2612
+ * @param args The permit message fields and ERC20 token metadata.
+ * @param chainId The expected chain ID for the permit domain.
+ * @returns Typed data ready to pass to a wallet for signing.
+ * @throws InvalidPermitDomainChainIdError when fetched EIP-5267 metadata targets another chain or omits `chainId`.
+ * @throws InvalidPermitDomainVerifyingContractError when fetched EIP-5267 metadata targets another token or omits `verifyingContract`.
+ * @throws UnsupportedPermitDomainExtensionsError when fetched EIP-5267 metadata advertises extension fields unsupported by this helper.
+ * @example
+ * import { getPermitTypedData } from "@morpho-org/blue-sdk-viem";
+ *
+ * const typedData = getPermitTypedData(
+ *   {
+ *     erc20: token,
+ *     owner,
+ *     spender,
+ *     allowance: 1_000000n,
+ *     nonce,
+ *     deadline,
+ *   },
+ *   ChainId.EthMainnet,
+ * );
+ * const signature = await walletClient.signTypedData(typedData);
  */
 export const getPermitTypedData = (
   { deadline, owner, nonce, spender, erc20, allowance }: PermitArgs,
@@ -41,7 +63,16 @@ export const getPermitTypedData = (
 ): TypedDataDefinition<typeof permitTypes, "Permit"> => {
   const { usdc, eurc } = getChainAddresses(chainId);
 
-  const domain = erc20.eip5267Domain?.eip712Domain;
+  const eip5267Domain = erc20.eip5267Domain;
+
+  if (eip5267Domain?.extensions.length) {
+    throw new UnsupportedPermitDomainExtensionsError(
+      erc20.address,
+      eip5267Domain.extensions,
+    );
+  }
+
+  const domain = eip5267Domain?.eip712Domain;
 
   if (domain != null) {
     if (domain.chainId !== chainId) {

--- a/packages/blue-sdk-viem/test/Permit.test.ts
+++ b/packages/blue-sdk-viem/test/Permit.test.ts
@@ -1,10 +1,16 @@
-import { ChainId, Eip5267Domain, Token } from "@morpho-org/blue-sdk";
+import {
+  type Address,
+  ChainId,
+  Eip5267Domain,
+  Token,
+} from "@morpho-org/blue-sdk";
 import { randomAddress } from "@morpho-org/test";
 import { zeroHash } from "viem";
 import { describe, expect, test } from "vitest";
 import {
   InvalidPermitDomainChainIdError,
   InvalidPermitDomainVerifyingContractError,
+  UnsupportedPermitDomainExtensionsError,
 } from "../src/error.js";
 import { getPermitTypedData } from "../src/signatures/permit.js";
 
@@ -21,13 +27,19 @@ const permitArgs = (token: Token) => ({
   deadline: 1n,
 });
 
-// biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
-const tokenWithDomain = (
+const tokenWithDomain = ({
   address = randomAddress(),
-  fields: `0x${string}` = "0x0f",
+  fields = "0x0f",
   chainId = BigInt(ChainId.EthMainnet),
   verifyingContract = address,
-) =>
+  extensions = [],
+}: {
+  address?: Address;
+  fields?: `0x${string}`;
+  chainId?: bigint;
+  verifyingContract?: Address;
+  extensions?: readonly bigint[];
+} = {}) =>
   new Token({
     address,
     name: "Token",
@@ -38,7 +50,7 @@ const tokenWithDomain = (
       chainId,
       verifyingContract,
       salt: zeroHash,
-      extensions: [],
+      extensions,
     }),
   });
 
@@ -59,12 +71,11 @@ describe("getPermitTypedData", () => {
   test("throws when fetched EIP-5267 domain points to another token", () => {
     const token = tokenWithDomain();
     const verifyingContract = randomAddress();
-    const tokenWithForeignDomain = tokenWithDomain(
-      token.address,
-      "0x0f",
-      BigInt(ChainId.EthMainnet),
+    const tokenWithForeignDomain = tokenWithDomain({
+      address: token.address,
+      chainId: BigInt(ChainId.EthMainnet),
       verifyingContract,
-    );
+    });
 
     expect(() =>
       getPermitTypedData(
@@ -80,11 +91,10 @@ describe("getPermitTypedData", () => {
   });
 
   test("throws when fetched EIP-5267 domain points to another chain", () => {
-    const token = tokenWithDomain(
-      randomAddress(),
-      "0x0f",
-      BigInt(ChainId.PolygonMainnet),
-    );
+    const token = tokenWithDomain({
+      address: randomAddress(),
+      chainId: BigInt(ChainId.PolygonMainnet),
+    });
 
     expect(() =>
       getPermitTypedData(permitArgs(token), ChainId.EthMainnet),
@@ -98,7 +108,10 @@ describe("getPermitTypedData", () => {
   });
 
   test("throws when fetched EIP-5267 domain does not bind to a token address", () => {
-    const token = tokenWithDomain(randomAddress(), "0x07");
+    const token = tokenWithDomain({
+      address: randomAddress(),
+      fields: "0x07",
+    });
 
     expect(() =>
       getPermitTypedData(permitArgs(token), ChainId.EthMainnet),
@@ -108,7 +121,10 @@ describe("getPermitTypedData", () => {
   });
 
   test("throws when fetched EIP-5267 domain does not bind to a chain", () => {
-    const token = tokenWithDomain(randomAddress(), "0x0b");
+    const token = tokenWithDomain({
+      address: randomAddress(),
+      fields: "0x0b",
+    });
 
     expect(() =>
       getPermitTypedData(permitArgs(token), ChainId.EthMainnet),
@@ -119,5 +135,13 @@ describe("getPermitTypedData", () => {
         undefined,
       ),
     );
+  });
+
+  test("throws when fetched EIP-5267 domain advertises extensions", () => {
+    const token = tokenWithDomain({ extensions: [5267n] });
+
+    expect(() =>
+      getPermitTypedData(permitArgs(token), ChainId.EthMainnet),
+    ).toThrow(UnsupportedPermitDomainExtensionsError);
   });
 });


### PR DESCRIPTION
## Summary

- Add a typed `UnsupportedPermitDomainExtensionsError` for EIP-5267 permit domains with extension fields.
- Make `getPermitTypedData` fail closed before building typed data when fetched ERC-5267 metadata advertises unsupported extensions.
- Add regression coverage and a patch changeset for `@morpho-org/blue-sdk-viem`.

## Root Cause

`getPermitTypedData` preferred fetched ERC-5267 metadata, but `Eip5267Domain.asEip712Domain()` only serializes base EIP-712 fields. Tokens advertising extension fields could therefore be treated as signable even though the helper cannot construct the complete domain separator.

## Impact

Consumers now receive a typed error and can choose another approval path instead of prompting users to sign incomplete permit domains.

## Validation

- `pnpm test --run packages/blue-sdk-viem/test/Permit.test.ts`
- `pnpm --filter @morpho-org/blue-sdk-viem build`
- `pnpm jsdoc:coverage:check`
- `pnpm lint`

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778509866013569)
<!-- slack-thread-ts:1778509866.013569 -->