### PR TITLE
fix: correct Blue fee accrual shares

### DIFF
--- a/.changeset/fix-blue-fee-accrual.md
+++ b/.changeset/fix-blue-fee-accrual.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk": patch
+---
+
+Fix market interest accrual fee-share minting to match Morpho Blue onchain behavior.

--- a/packages/blue-sdk/src/market/MarketUtils.ts
+++ b/packages/blue-sdk/src/market/MarketUtils.ts
@@ -88,19 +88,38 @@ export namespace MarketUtils {
   /**
    * Returns the interest accrued on both sides of the given market
    * as well as the supply shares minted to the fee recipient.
+   *
+   * Fee shares are converted from the fee amount against post-interest supply assets minus the fee amount,
+   * matching Morpho Blue's onchain accrual.
+   *
    * @param borrowRate The average borrow rate since the last market update (scaled by WAD).
-   * @param market The market state.
+   * @param market.totalSupplyAssets The market's total supplied assets before accrual.
+   * @param market.totalBorrowAssets The market's total borrowed assets before accrual.
+   * @param market.totalSupplyShares The market's total supply shares before fee shares are minted.
+   * @param market.fee The market fee percentage, scaled by WAD.
    * @param elapsed The time elapsed since the last market update (in seconds).
+   * @returns The accrued interest and the supply shares minted to the fee recipient.
+   * @example
+   * ```ts
+   * import { MarketUtils, MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const { interest, feeShares } = MarketUtils.getAccruedInterest(
+   *   5_0000000000000000n,
+   *   {
+   *     totalSupplyAssets: 1_000_000n * MathLib.WAD,
+   *     totalBorrowAssets: 800_000n * MathLib.WAD,
+   *     totalSupplyShares: 1_100_000n * MathLib.WAD,
+   *     fee: 10_0000000000000000n,
+   *   },
+   *   1n,
+   * );
+   * // { interest, feeShares } satisfies { interest: bigint; feeShares: bigint }
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getAccruedInterest(
     borrowRate: BigIntish,
-    {
-      totalSupplyAssets,
-      totalBorrowAssets,
-      totalSupplyShares,
-      fee,
-    }: {
+    market: {
       totalSupplyAssets: BigIntish;
       totalBorrowAssets: BigIntish;
       totalSupplyShares: BigIntish;
@@ -108,6 +127,9 @@ export namespace MarketUtils {
     },
     elapsed = 0n,
   ) {
+    const { totalSupplyAssets, totalBorrowAssets, totalSupplyShares, fee } =
+      market;
+
     const interest = MathLib.wMulDown(
       totalBorrowAssets,
       MathLib.wTaylorCompounded(borrowRate, elapsed),

--- a/packages/blue-sdk/src/market/MarketUtils.ts
+++ b/packages/blue-sdk/src/market/MarketUtils.ts
@@ -117,7 +117,7 @@ export namespace MarketUtils {
     const feeShares = toSupplyShares(
       feeAmount,
       {
-        totalSupplyAssets: BigInt(totalSupplyAssets) - feeAmount,
+        totalSupplyAssets: BigInt(totalSupplyAssets) + interest - feeAmount,
         totalSupplyShares,
       },
       "Down",

--- a/packages/blue-sdk/test/e2e/Market.test.ts
+++ b/packages/blue-sdk/test/e2e/Market.test.ts
@@ -334,6 +334,9 @@ describe("Market", () => {
       args: [params.id],
     });
 
+    expect(onchainTotalBorrowAssets).toBeGreaterThan(totalBorrowAssets);
+    expect(onchainTotalSupplyShares).toBeGreaterThan(totalSupplyShares);
+
     expect(market.totalSupplyAssets).toBe(onchainTotalSupplyAssets);
     expect(market.totalSupplyShares).toBe(onchainTotalSupplyShares);
     expect(market.totalBorrowAssets).toBe(onchainTotalBorrowAssets);

--- a/packages/blue-sdk/test/e2e/Market.test.ts
+++ b/packages/blue-sdk/test/e2e/Market.test.ts
@@ -253,4 +253,92 @@ describe("Market", () => {
 
     expect(receipt.status).toBe("success");
   });
+
+  test("should match onchain accrual on a fee-bearing market", async ({
+    client,
+  }) => {
+    const owner = await client.readContract({
+      abi: blueAbi,
+      address: morpho,
+      functionName: "owner",
+    });
+    const fee = parseUnits("10", 16);
+
+    await client.setBalance({ address: owner, value: parseUnits("1", 18) });
+    await client.writeContract({
+      account: owner,
+      abi: blueAbi,
+      address: morpho,
+      functionName: "setFee",
+      args: [{ ...params }, fee],
+    });
+
+    const timestamp = (await client.timestamp()) + Time.s.from.d(1n);
+
+    const [
+      totalSupplyAssets,
+      totalSupplyShares,
+      totalBorrowAssets,
+      totalBorrowShares,
+      lastUpdate,
+      marketFee,
+    ] = await client.readContract({
+      abi: blueAbi,
+      address: morpho,
+      functionName: "market",
+      args: [params.id],
+    });
+
+    expect(marketFee).toBe(fee);
+
+    const market = new Market({
+      params,
+      totalSupplyAssets,
+      totalSupplyShares,
+      totalBorrowAssets,
+      totalBorrowShares,
+      lastUpdate,
+      fee: marketFee,
+      price: await client.readContract({
+        abi: blueOracleAbi,
+        address: params.oracle,
+        functionName: "price",
+      }),
+      rateAtTarget: await client.readContract({
+        abi: adaptiveCurveIrmAbi,
+        address: params.irm,
+        functionName: "rateAtTarget",
+        args: [params.id],
+      }),
+    }).accrueInterest(timestamp);
+
+    await client.setNextBlockTimestamp({ timestamp });
+    await client.writeContract({
+      abi: blueAbi,
+      address: morpho,
+      functionName: "accrueInterest",
+      args: [{ ...params }],
+    });
+
+    const [
+      onchainTotalSupplyAssets,
+      onchainTotalSupplyShares,
+      onchainTotalBorrowAssets,
+      onchainTotalBorrowShares,
+      onchainLastUpdate,
+      onchainFee,
+    ] = await client.readContract({
+      abi: blueAbi,
+      address: morpho,
+      functionName: "market",
+      args: [params.id],
+    });
+
+    expect(market.totalSupplyAssets).toBe(onchainTotalSupplyAssets);
+    expect(market.totalSupplyShares).toBe(onchainTotalSupplyShares);
+    expect(market.totalBorrowAssets).toBe(onchainTotalBorrowAssets);
+    expect(market.totalBorrowShares).toBe(onchainTotalBorrowShares);
+    expect(market.lastUpdate).toBe(onchainLastUpdate);
+    expect(market.fee).toBe(onchainFee);
+  });
 });

--- a/packages/blue-sdk/test/unit/MarketUtils.test.ts
+++ b/packages/blue-sdk/test/unit/MarketUtils.test.ts
@@ -1,6 +1,11 @@
 import { parseUnits } from "viem";
 import { describe, expect, test } from "vitest";
-import { MarketUtils, MathLib, SECONDS_PER_YEAR } from "../../src/index.js";
+import {
+  MarketUtils,
+  MathLib,
+  SECONDS_PER_YEAR,
+  SharesMath,
+} from "../../src/index.js";
 
 const market = {
   loanToken: "0x0000000000000000000000000000000000000001",
@@ -120,5 +125,41 @@ describe("MarketUtils", () => {
     expect(
       MarketUtils.rateToApy(parseUnits("500", 16) / SECONDS_PER_YEAR),
     ).toEqual(147.41315909872503);
+  });
+
+  test("should accrue fee shares against post-interest supply assets", () => {
+    const totalSupplyAssets = 1_000_000n * MathLib.WAD;
+    const totalBorrowAssets = 800_000n * MathLib.WAD;
+    const totalSupplyShares = 1_100_000n * MathLib.WAD;
+    const fee = 10_0000000000000000n;
+    const { interest, feeShares } = MarketUtils.getAccruedInterest(
+      5_0000000000000000n,
+      {
+        totalSupplyAssets,
+        totalBorrowAssets,
+        totalSupplyShares,
+        fee,
+      },
+      1n,
+    );
+
+    const feeAmount = MathLib.wMulDown(interest, fee);
+
+    expect(feeShares).toEqual(
+      SharesMath.toShares(
+        feeAmount,
+        totalSupplyAssets + interest - feeAmount,
+        totalSupplyShares,
+        "Down",
+      ),
+    );
+    expect(feeShares).toBeLessThan(
+      SharesMath.toShares(
+        feeAmount,
+        totalSupplyAssets - feeAmount,
+        totalSupplyShares,
+        "Down",
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes Blue market interest accrual fee-share minting so the SDK matches Morpho Blue onchain behavior for fee-bearing markets.

## Root Cause

`MarketUtils.getAccruedInterest()` minted fee shares against `totalSupplyAssets - feeAmount`, but Morpho Blue first adds accrued interest to `totalSupplyAssets` and then computes fee shares against `totalSupplyAssets - feeAmount`. In SDK terms, the correct denominator is `oldTotalSupplyAssets + interest - feeAmount`.

## Changes

- Update Blue SDK market accrual to compute fee shares against post-interest supply assets.
- Add a unit regression asserting the corrected denominator and showing it mints fewer shares than the old pre-interest denominator.
- Add a fork e2e regression comparing SDK-accrued market state against onchain `accrueInterest` on a fee-bearing market.
- Add a patch changeset for `@morpho-org/blue-sdk`.

## Validation

- `pnpm vitest --project blue-sdk packages/blue-sdk/test/unit/MarketUtils.test.ts --run`
- `pnpm vitest --project blue-sdk packages/blue-sdk/test/unit/Market.test.ts packages/blue-sdk/test/unit/MarketUtils.test.ts packages/blue-sdk/test/unit/PreLiquidationPosition.test.ts packages/blue-sdk/test/unit/addresses.test.ts packages/blue-sdk/test/unit/chain.test.ts packages/blue-sdk/test/unit/Vault.test.ts --run`
- `pnpm exec biome check packages/blue-sdk/src/market/MarketUtils.ts packages/blue-sdk/test/unit/MarketUtils.test.ts packages/blue-sdk/test/e2e/Market.test.ts .changeset/fix-blue-fee-accrual.md`
- `pnpm --filter @morpho-org/blue-sdk build`

Attempted `pnpm vitest --project blue-sdk packages/blue-sdk/test/e2e/Market.test.ts --run`, but the local fork could not start because the configured RPC returned `failed to get fork block` / `no response`.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778511385266289)
<!-- slack-thread-ts:1778511385.266289 -->