### PR TITLE
refactor(morpho-sdk): pass generalAdapter1 explicitly to getRequirementsAction

### DIFF
--- a/.changeset/get-requirements-action-general-adapter-param.md
+++ b/.changeset/get-requirements-action-general-adapter-param.md
@@ -3,9 +3,9 @@
 ---
 
 Internal: `getRequirementsAction` now takes the transfer recipient as an
-explicit `generalAdapter1` parameter instead of resolving it from `chainId`.
-The function is `@internal` and not part of the public surface; all in-repo
+explicit `recipient` parameter instead of resolving it from `chainId`. The
+function is `@internal` and not part of the public surface; all in-repo
 callers (`marketV1` supply/repay paths, `vaultV1`/`vaultV2` deposit, and
-`vaultV1` migrate-to-v2) have been updated to pass `generalAdapter1`
+`vaultV1` migrate-to-v2) have been updated to pass `recipient: generalAdapter1`
 directly. No behavior change — same destination address, just no longer
 hard-coded inside the helper.

--- a/.changeset/get-requirements-action-general-adapter-param.md
+++ b/.changeset/get-requirements-action-general-adapter-param.md
@@ -1,0 +1,11 @@
+---
+"@morpho-org/morpho-sdk": patch
+---
+
+Internal: `getRequirementsAction` now takes the transfer recipient as an
+explicit `generalAdapter1` parameter instead of resolving it from `chainId`.
+The function is `@internal` and not part of the public surface; all in-repo
+callers (`marketV1` supply/repay paths, `vaultV1`/`vaultV2` deposit, and
+`vaultV1` migrate-to-v2) have been updated to pass `generalAdapter1`
+directly. No behavior change — same destination address, just no longer
+hard-coded inside the helper.

--- a/packages/morpho-sdk/src/actions/marketV1/repay.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/repay.ts
@@ -132,7 +132,7 @@ export const marketV1Repay = ({
       ...getRequirementsAction({
         asset: marketParams.loanToken,
         amount: transferAmount,
-        generalAdapter1,
+        recipient: generalAdapter1,
         requirementSignature,
       }),
     );

--- a/packages/morpho-sdk/src/actions/marketV1/repay.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/repay.ts
@@ -130,9 +130,9 @@ export const marketV1Repay = ({
   if (requirementSignature) {
     actions.push(
       ...getRequirementsAction({
-        chainId,
         asset: marketParams.loanToken,
         amount: transferAmount,
+        generalAdapter1,
         requirementSignature,
       }),
     );

--- a/packages/morpho-sdk/src/actions/marketV1/repayWithdrawCollateral.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/repayWithdrawCollateral.ts
@@ -152,9 +152,9 @@ export const marketV1RepayWithdrawCollateral = ({
   if (requirementSignature) {
     actions.push(
       ...getRequirementsAction({
-        chainId,
         asset: marketParams.loanToken,
         amount: transferAmount,
+        generalAdapter1,
         requirementSignature,
       }),
     );

--- a/packages/morpho-sdk/src/actions/marketV1/repayWithdrawCollateral.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/repayWithdrawCollateral.ts
@@ -154,7 +154,7 @@ export const marketV1RepayWithdrawCollateral = ({
       ...getRequirementsAction({
         asset: marketParams.loanToken,
         amount: transferAmount,
-        generalAdapter1,
+        recipient: generalAdapter1,
         requirementSignature,
       }),
     );

--- a/packages/morpho-sdk/src/actions/marketV1/supplyCollateral.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/supplyCollateral.ts
@@ -120,9 +120,9 @@ export const marketV1SupplyCollateral = ({
     if (requirementSignature) {
       actions.push(
         ...getRequirementsAction({
-          chainId,
           asset: marketParams.collateralToken,
           amount,
+          generalAdapter1,
           requirementSignature,
         }),
       );

--- a/packages/morpho-sdk/src/actions/marketV1/supplyCollateral.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/supplyCollateral.ts
@@ -122,7 +122,7 @@ export const marketV1SupplyCollateral = ({
         ...getRequirementsAction({
           asset: marketParams.collateralToken,
           amount,
-          generalAdapter1,
+          recipient: generalAdapter1,
           requirementSignature,
         }),
       );

--- a/packages/morpho-sdk/src/actions/marketV1/supplyCollateralBorrow.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/supplyCollateralBorrow.ts
@@ -173,9 +173,9 @@ export const marketV1SupplyCollateralBorrow = ({
     if (requirementSignature) {
       actions.push(
         ...getRequirementsAction({
-          chainId,
           asset: marketParams.collateralToken,
           amount,
+          generalAdapter1,
           requirementSignature,
         }),
       );

--- a/packages/morpho-sdk/src/actions/marketV1/supplyCollateralBorrow.ts
+++ b/packages/morpho-sdk/src/actions/marketV1/supplyCollateralBorrow.ts
@@ -175,7 +175,7 @@ export const marketV1SupplyCollateralBorrow = ({
         ...getRequirementsAction({
           asset: marketParams.collateralToken,
           amount,
-          generalAdapter1,
+          recipient: generalAdapter1,
           requirementSignature,
         }),
       );

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
@@ -1,4 +1,3 @@
-import { getChainAddresses } from "@morpho-org/blue-sdk";
 import type { Action } from "@morpho-org/bundler-sdk-viem";
 import { type Address, isAddressEqual } from "viem";
 import {
@@ -10,9 +9,9 @@ import {
 } from "../../types/index.js";
 
 interface GetRequirementsActionParams {
-  chainId: number;
   asset: Address;
   amount: bigint;
+  generalAdapter1: Address;
   requirementSignature: {
     args: PermitArgs;
     action: PermitAction | Permit2Action;
@@ -29,9 +28,10 @@ interface GetRequirementsActionParams {
  * wider-than-expected approval. Internal helper — consumed only by the action builders that
  * accept a `requirementSignature`; not re-exported on the public surface.
  *
- * @param params.chainId - The chain the bundle targets (used to resolve `GeneralAdapter1`).
  * @param params.asset - The ERC-20 to pull into the adapter.
  * @param params.amount - The amount to pull, in the asset's smallest unit.
+ * @param params.generalAdapter1 - The bundler `GeneralAdapter1` address that receives the
+ *   transfer. Resolved by the caller from `getChainAddresses(chainId)`.
  * @param params.requirementSignature - The signed permit / permit2 to apply before the transfer.
  * @returns A pair of bundler `Action`s: a permit / approve2 followed by the transfer.
  * @throws {DepositAssetMismatchError} when the signed asset differs from `asset`.
@@ -39,9 +39,9 @@ interface GetRequirementsActionParams {
  * @internal
  */
 export const getRequirementsAction = ({
-  chainId,
   asset,
   amount,
+  generalAdapter1,
   requirementSignature,
 }: GetRequirementsActionParams): Action[] => {
   if (!isAddressEqual(requirementSignature.args.asset, asset)) {
@@ -54,10 +54,6 @@ export const getRequirementsAction = ({
       requirementSignature.args.amount,
     );
   }
-
-  const {
-    bundler3: { generalAdapter1 },
-  } = getChainAddresses(chainId);
 
   if (requirementSignature.action.type === "permit2") {
     if (!("expiration" in requirementSignature.args)) {

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
@@ -11,7 +11,7 @@ import {
 interface GetRequirementsActionParams {
   asset: Address;
   amount: bigint;
-  generalAdapter1: Address;
+  recipient: Address;
   requirementSignature: {
     args: PermitArgs;
     action: PermitAction | Permit2Action;
@@ -30,8 +30,8 @@ interface GetRequirementsActionParams {
  *
  * @param params.asset - The ERC-20 to pull into the adapter.
  * @param params.amount - The amount to pull, in the asset's smallest unit.
- * @param params.generalAdapter1 - The bundler `GeneralAdapter1` address that receives the
- *   transfer. Resolved by the caller from `getChainAddresses(chainId)`.
+ * @param params.recipient - The address that receives the transfer (the bundler
+ *   `GeneralAdapter1`, resolved by the caller from `getChainAddresses(chainId)`).
  * @param params.requirementSignature - The signed permit / permit2 to apply before the transfer.
  * @returns A pair of bundler `Action`s: a permit / approve2 followed by the transfer.
  * @throws {DepositAssetMismatchError} when the signed asset differs from `asset`.
@@ -41,7 +41,7 @@ interface GetRequirementsActionParams {
 export const getRequirementsAction = ({
   asset,
   amount,
-  generalAdapter1,
+  recipient,
   requirementSignature,
 }: GetRequirementsActionParams): Action[] => {
   if (!isAddressEqual(requirementSignature.args.asset, asset)) {
@@ -79,7 +79,7 @@ export const getRequirementsAction = ({
       },
       {
         type: "transferFrom2",
-        args: [asset, amount, generalAdapter1, false /* skipRevert */],
+        args: [asset, amount, recipient, false /* skipRevert */],
       },
     ];
   }
@@ -98,7 +98,7 @@ export const getRequirementsAction = ({
     },
     {
       type: "erc20TransferFrom",
-      args: [asset, amount, generalAdapter1, false /* skipRevert */],
+      args: [asset, amount, recipient, false /* skipRevert */],
     },
   ];
 };

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
@@ -20,7 +20,7 @@ interface GetRequirementsActionParams {
 
 /**
  * Encodes the bundler actions that consume a pre-signed permit / permit2 requirement and pull
- * the asset into `GeneralAdapter1`.
+ * the asset to `recipient`.
  *
  * Permit2 path emits `approve2` + `transferFrom2`; classic permit path emits `permit` +
  * `erc20TransferFrom`. The signed `asset` and `amount` must match the pulled `asset` and
@@ -28,10 +28,9 @@ interface GetRequirementsActionParams {
  * wider-than-expected approval. Internal helper — consumed only by the action builders that
  * accept a `requirementSignature`; not re-exported on the public surface.
  *
- * @param params.asset - The ERC-20 to pull into the adapter.
+ * @param params.asset - The ERC-20 to pull.
  * @param params.amount - The amount to pull, in the asset's smallest unit.
- * @param params.recipient - The address that receives the transfer (the bundler
- *   `GeneralAdapter1`, resolved by the caller from `getChainAddresses(chainId)`).
+ * @param params.recipient - The address that receives the transfer.
  * @param params.requirementSignature - The signed permit / permit2 to apply before the transfer.
  * @returns A pair of bundler `Action`s: a permit / approve2 followed by the transfer.
  * @throws {DepositAssetMismatchError} when the signed asset differs from `asset`.

--- a/packages/morpho-sdk/src/actions/vaultV1/deposit.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/deposit.ts
@@ -143,9 +143,9 @@ export const vaultV1Deposit = ({
     if (requirementSignature) {
       actions.push(
         ...getRequirementsAction({
-          chainId,
           asset,
           amount,
+          generalAdapter1,
           requirementSignature,
         }),
       );

--- a/packages/morpho-sdk/src/actions/vaultV1/deposit.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/deposit.ts
@@ -145,7 +145,7 @@ export const vaultV1Deposit = ({
         ...getRequirementsAction({
           asset,
           amount,
-          generalAdapter1,
+          recipient: generalAdapter1,
           requirementSignature,
         }),
       );

--- a/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.ts
@@ -144,7 +144,7 @@ export const vaultV1MigrateToV2 = ({
       ...getRequirementsAction({
         asset: sourceVault,
         amount: shares,
-        generalAdapter1,
+        recipient: generalAdapter1,
         requirementSignature,
       }),
     );

--- a/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.ts
@@ -142,9 +142,9 @@ export const vaultV1MigrateToV2 = ({
   if (requirementSignature) {
     actions.push(
       ...getRequirementsAction({
-        chainId,
         asset: sourceVault,
         amount: shares,
+        generalAdapter1,
         requirementSignature,
       }),
     );

--- a/packages/morpho-sdk/src/actions/vaultV2/deposit.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/deposit.ts
@@ -145,7 +145,7 @@ export const vaultV2Deposit = ({
         ...getRequirementsAction({
           asset,
           amount,
-          generalAdapter1,
+          recipient: generalAdapter1,
           requirementSignature,
         }),
       );

--- a/packages/morpho-sdk/src/actions/vaultV2/deposit.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/deposit.ts
@@ -143,9 +143,9 @@ export const vaultV2Deposit = ({
     if (requirementSignature) {
       actions.push(
         ...getRequirementsAction({
-          chainId,
           asset,
           amount,
+          generalAdapter1,
           requirementSignature,
         }),
       );


### PR DESCRIPTION
## Summary

`getRequirementsAction` no longer hard-codes the transfer destination via `getChainAddresses(chainId).bundler3.generalAdapter1`. It now takes an explicit `recipient: Address` parameter, and every in-repo caller passes the resolved address as `recipient: generalAdapter1`.

- `chainId` is removed from the helper's params (it was only used to resolve the destination address).
- Updated callers: `marketV1` (`supplyCollateral`, `supplyCollateralBorrow`, `repay`, `repayWithdrawCollateral`), `vaultV1` (`deposit`, `migrateToV2`), `vaultV2` (`deposit`).
- JSDoc rewritten to describe `recipient` generically — no more `GeneralAdapter1` lock-in in the helper's contract.
- The helper is `@internal`, so this is **not** a public-API break. Behaviour is unchanged: the same address still receives the transferred asset.

### Naming note

The SDK TS layer (`bundler-sdk-viem`) already uses `recipient` for both the `transferFrom2` and `erc20TransferFrom` action tuples, so `recipient` is consistent with the SDK's vocabulary. On-chain ABIs are split (`transferFrom2` → `recipient`, `erc20TransferFrom` → `receiver`) — out of scope for this PR.

Replaces #646 (resigned commits).

## Test plan

- [x] `pnpm exec tsc --noEmit` in `packages/morpho-sdk` (clean locally)
- [ ] CI: fork-based integration tests on each updated builder
- [ ] Verify snapshot transactions on the affected paths are unchanged (no calldata change expected)

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778484584979589)
<!-- slack-thread-ts:1778484584.979589 -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->