### PR TITLE
chore(morpho-sdk): deprecate MorphoClient in favor of morphoViemExtension

### DIFF
--- a/.changeset/deprecate-morpho-client.md
+++ b/.changeset/deprecate-morpho-client.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": minor
+---
+
+Deprecate `MorphoClient` in favor of `morphoViemExtension`. Extend a viem public (or wallet) client with `morphoViemExtension(...)` and use `client.morpho.vaultV1 / vaultV2 / marketV1` instead of constructing `MorphoClient` directly. `MorphoClient` will be removed in the next major release.

--- a/packages/morpho-sdk/README.md
+++ b/packages/morpho-sdk/README.md
@@ -48,7 +48,7 @@ Every action that touches a user's tokens or positions returns two things:
 Typical requirements:
 
 - **ERC-20 approval** — the user must approve the bundler (or Morpho directly) to pull tokens. Returned as a standard `approve` transaction the consumer sends first.
-- **Permit / Permit2 signature** — off-chain approvals that go into `buildTx` as a `signature` argument, avoiding the extra approval tx. Enabled via `MorphoClient({ supportSignature: true })`.
+- **Permit / Permit2 signature** — off-chain approvals that go into `buildTx` as a `signature` argument, avoiding the extra approval tx. Enabled via `morphoViemExtension({ supportSignature: true })`.
 - **Morpho authorization** — `borrow`, `supplyCollateralBorrow`, and `repayWithdrawCollateral` require the user to authorize `GeneralAdapter1` on the Morpho contract once (`setAuthorization`). The SDK returns this as an extra transaction if it's missing.
 
 Usage pattern:
@@ -88,14 +88,15 @@ const tx = buildTx(permitSignature);
 ### VaultV2
 
 ```typescript
-import { MorphoClient } from "@morpho-org/morpho-sdk";
+import { morphoViemExtension } from "@morpho-org/morpho-sdk";
 import { createPublicClient, http } from "viem";
 import { mainnet } from "viem/chains";
 
-const viemClient = createPublicClient({ chain: mainnet, transport: http() });
-const morpho = new MorphoClient(viemClient);
+const client = createPublicClient({ chain: mainnet, transport: http() }).extend(
+  morphoViemExtension(),
+);
 
-const vault = morpho.vaultV2("0xVault...", 1);
+const vault = client.morpho.vaultV2("0xVault...", 1);
 ```
 
 #### Deposit
@@ -180,7 +181,7 @@ const tx = buildTx();
 ### VaultV1
 
 ```typescript
-const vault = morpho.vaultV1("0xVault...", 1);
+const vault = client.morpho.vaultV1("0xVault...", 1);
 ```
 
 #### Deposit
@@ -222,8 +223,8 @@ const tx = buildTx();
 Atomically migrate a full position from a VaultV1 (MetaMorpho) vault into a VaultV2 vault. The bundler redeems the V1 shares and deposits the resulting assets into V2 in a single transaction. Both vaults must share the same underlying asset.
 
 ```typescript
-const sourceVault = morpho.vaultV1("0xV1Vault...", 1);
-const targetVault = morpho.vaultV2("0xV2Vault...", 1);
+const sourceVault = client.morpho.vaultV1("0xV1Vault...", 1);
+const targetVault = client.morpho.vaultV2("0xV2Vault...", 1);
 
 const { buildTx, getRequirements } = sourceVault.migrateToV2({
   userAddress: "0xUser...",
@@ -239,7 +240,7 @@ const tx = buildTx(requirementSignature);
 ### MarketV1
 
 ```typescript
-const market = morpho.marketV1(
+const market = client.morpho.marketV1(
   {
     loanToken: "0xLoan...",
     collateralToken: "0xCollateral...",
@@ -406,7 +407,7 @@ const { buildTx, getRequirements } = market.supplyCollateralBorrow({
 
 ```mermaid
 graph LR
-    MC[MorphoClient]
+    MC["client.morpho<br/>(morphoViemExtension)"]
 
     MC -->|.vaultV1| MV1
     MC -->|.vaultV2| MV2

--- a/packages/morpho-sdk/src/client/morphoClient.ts
+++ b/packages/morpho-sdk/src/client/morphoClient.ts
@@ -17,6 +17,42 @@ import {
  *
  * Holds no state beyond configuration: no cache, no `init()`, no warm-up. Each factory call
  * (`vaultV1`, `vaultV2`, `marketV1`) returns a fresh entity bound to this client.
+ *
+ * @deprecated Use {@link morphoViemExtension} instead. Extending your viem client keeps a single
+ *   transport / chain / account on the integrator side and exposes the same factories under
+ *   `client.morpho`, so reads and writes share one client. `MorphoClient` will be removed in the
+ *   next major release.
+ *
+ * @example
+ * ```ts
+ * // Before — wrapping a viem client in MorphoClient:
+ * import { createPublicClient, http } from "viem";
+ * import { mainnet } from "viem/chains";
+ * import { MorphoClient } from "@morpho-org/morpho-sdk";
+ *
+ * const publicClient = createPublicClient({ chain: mainnet, transport: http() });
+ * const morpho = new MorphoClient(publicClient);
+ *
+ * const vault = morpho.vaultV1(vaultAddress, 1);
+ * const vaultData = await vault.getData();
+ * ```
+ *
+ * @example
+ * ```ts
+ * // After — extend the public client directly:
+ * import { createPublicClient, http } from "viem";
+ * import { mainnet } from "viem/chains";
+ * import { morphoViemExtension } from "@morpho-org/morpho-sdk";
+ *
+ * const client = createPublicClient({ chain: mainnet, transport: http() }).extend(
+ *   morphoViemExtension(),
+ * );
+ *
+ * // Native viem reads and Morpho factories share the same client:
+ * const block = await client.getBlockNumber();
+ * const vault = client.morpho.vaultV1(vaultAddress, 1);
+ * const vaultData = await vault.getData();
+ * ```
  */
 export class MorphoClient implements MorphoClientType {
   /** SDK-wide options resolved from the constructor's `_options` argument. */
@@ -35,16 +71,19 @@ export class MorphoClient implements MorphoClientType {
    * @param _options.supportDeployless - Whether entity fetchers may use deployless multicall.
    * @param _options.metadata - Optional analytics metadata applied to every transaction this
    *   client builds.
+   * @deprecated Prefer {@link morphoViemExtension} so the SDK rides on top of a viem client the
+   *   integrator already owns (public or wallet). Will be removed in the next major release.
    * @example
    * ```ts
-   * import { createWalletClient, http } from "viem";
+   * import { createPublicClient, http } from "viem";
    * import { mainnet } from "viem/chains";
-   * import { MorphoClient } from "@morpho-org/morpho-sdk";
+   * import { morphoViemExtension } from "@morpho-org/morpho-sdk";
    *
-   * const client = new MorphoClient(
-   *   createWalletClient({ chain: mainnet, transport: http(), account: user }),
-   *   { supportSignature: true },
+   * const client = createPublicClient({ chain: mainnet, transport: http() }).extend(
+   *   morphoViemExtension({ supportSignature: true }),
    * );
+   *
+   * const vault = client.morpho.vaultV1(vaultAddress, 1);
    * ```
    */
   constructor(


### PR DESCRIPTION
## Summary

- Marks `MorphoClient` (class + constructor) as `@deprecated` and points integrators at `morphoViemExtension`, so the SDK rides on top of a viem client (public or wallet) the integrator already owns.
- Adds a before/after JSDoc example using `createPublicClient(...).extend(morphoViemExtension())` and `client.morpho.vaultV1(...)`, so a single client serves both native viem reads and Morpho factories.
- Adds a `morpho-sdk` minor changeset announcing the deprecation and the removal in the next major.

## Test plan

- [ ] CI typecheck / lint
- [ ] Confirm changeset is picked up by the release workflow

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1778592268667869)
<!-- slack-thread-ts:1778592268.667869 -->