### PR TITLE
docs(fetch): Document VaultV2 market adapter v1 liquidity support

### DIFF
--- a/packages/blue-sdk-viem/src/fetch/vault-v2/VaultV2.ts
+++ b/packages/blue-sdk-viem/src/fetch/vault-v2/VaultV2.ts
@@ -33,6 +33,46 @@ import type { DeploylessFetchParameters } from "../../types.js";
 import { fetchToken } from "../Token.js";
 import { fetchAccrualVaultV2Adapter } from "./VaultV2Adapter.js";
 
+/**
+ * Fetches VaultV2 state and liquidity-cap data.
+ *
+ * Reads token metadata, vault accounting, fee configuration, adapter addresses, the configured
+ * liquidity adapter, liquidity data, and cap allocations for supported liquidity adapters. Uses the
+ * deployless `GetVaultV2` query by default and falls back to multicall when allowed.
+ *
+ * `MorphoMarketV1Adapter` has zero support as a VaultV2 liquidity adapter. This fetcher only loads
+ * liquidity allocations for `MorphoVaultV1Adapter` and `MorphoMarketV1AdapterV2`; when a vault
+ * configures the non-V2 market adapter as `liquidityAdapter`, the returned `VaultV2` preserves the
+ * adapter address and liquidity data but leaves `liquidityAllocations` undefined. Fetch
+ * `MorphoMarketV1Adapter` through `fetchVaultV2Adapter` when it is used as a regular adapter.
+ *
+ * @param address - Address of the VaultV2 to fetch.
+ * @param client - Viem client used for deployless reads or multicalls.
+ * @param parameters.account - Optional account passed to viem calls.
+ * @param parameters.blockNumber - Optional block number for historical reads.
+ * @param parameters.blockTag - Optional block tag for historical reads.
+ * @param parameters.stateOverride - Optional viem state override.
+ * @param parameters.chainId - Optional chain id; defaults to `getChainId(client)`.
+ * @param parameters.deployless - Optional deployless read mode; defaults to `true`.
+ * @returns The hydrated `VaultV2` entity. `liquidityAllocations` is undefined when no liquidity
+ *   adapter is configured or when the configured liquidity adapter is unsupported.
+ * @throws {UnknownFactory} when the configured chain has no VaultV2 factory.
+ * @throws {UnknownOfFactory} when `address` is not a VaultV2 from the configured factory.
+ * @throws {UnsupportedVaultV2AdapterError} when a recognized liquidity adapter is configured with
+ *   unsupported liquidity data.
+ * @example
+ * ```ts
+ * import type { VaultV2 } from "@morpho-org/blue-sdk";
+ * import { fetchVaultV2 } from "@morpho-org/blue-sdk-viem";
+ * import { createPublicClient, http } from "viem";
+ * import { base } from "viem/chains";
+ *
+ * const client = createPublicClient({ chain: base, transport: http() });
+ * const vaultV2Address = "0xfDE48B9B8568189f629Bc5209bf5FA826336557a";
+ *
+ * const vault: VaultV2 = await fetchVaultV2(vaultV2Address, client);
+ * ```
+ */
 // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
 export async function fetchVaultV2(
   address: Address,
@@ -315,6 +355,45 @@ export async function fetchVaultV2(
   });
 }
 
+/**
+ * Fetches VaultV2 state with accrual data for capacity calculations.
+ *
+ * Reads all state fetched by `fetchVaultV2`, the vault asset balance, accrual state for the
+ * configured liquidity adapter and regular adapters, and force-deallocate penalties.
+ *
+ * `MorphoMarketV1Adapter` has zero support as a VaultV2 liquidity adapter. This fetcher may hydrate
+ * that adapter as an accrual adapter, but liquidity cap allocations remain undefined because
+ * `fetchVaultV2` only loads allocations for `MorphoVaultV1Adapter` and
+ * `MorphoMarketV1AdapterV2`. Calling `maxDeposit` on the returned `AccrualVaultV2` therefore throws
+ * `VaultV2Errors.UnsupportedLiquidityAdapter` for a non-V2 market adapter liquidity adapter.
+ *
+ * @param address - Address of the VaultV2 to fetch.
+ * @param client - Viem client used for deployless reads or multicalls.
+ * @param parameters.account - Optional account passed to viem calls.
+ * @param parameters.blockNumber - Optional block number for historical reads.
+ * @param parameters.blockTag - Optional block tag for historical reads.
+ * @param parameters.stateOverride - Optional viem state override.
+ * @param parameters.chainId - Optional chain id; defaults to `getChainId(client)`.
+ * @param parameters.deployless - Optional deployless read mode; defaults to `true`.
+ * @returns The hydrated `AccrualVaultV2` entity with asset balance, accrual adapters, and
+ *   force-deallocate penalties.
+ * @throws {UnknownFactory} when the configured chain has no VaultV2 factory.
+ * @throws {UnknownOfFactory} when `address` is not a VaultV2 from the configured factory.
+ * @throws {UnsupportedVaultV2AdapterError} when the vault or one of its adapters uses an
+ *   unsupported adapter class.
+ * @example
+ * ```ts
+ * import type { AccrualVaultV2 } from "@morpho-org/blue-sdk";
+ * import { fetchAccrualVaultV2 } from "@morpho-org/blue-sdk-viem";
+ * import { createPublicClient, http } from "viem";
+ * import { base } from "viem/chains";
+ *
+ * const client = createPublicClient({ chain: base, transport: http() });
+ * const vaultV2Address = "0xfDE48B9B8568189f629Bc5209bf5FA826336557a";
+ *
+ * const vault: AccrualVaultV2 = await fetchAccrualVaultV2(vaultV2Address, client);
+ * ```
+ */
 // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
 export async function fetchAccrualVaultV2(
   address: Address,


### PR DESCRIPTION
## Summary

Documents the current VaultV2 liquidity-adapter support boundary on the exported `fetchVaultV2` and `fetchAccrualVaultV2` functions.

- Notes that `MorphoMarketV1Adapter` has zero support as a VaultV2 liquidity adapter.
- Clarifies that the non-V2 market adapter remains fetchable as a regular adapter through `fetchVaultV2Adapter`.
- Describes the returned `liquidityAllocations` / `maxDeposit` behavior for that unsupported liquidity-adapter configuration.

## Linear

Links SDK-169: https://linear.app/morpho-labs/issue/SDK-169/morp2-51informational-vaultv2-fetchers-omit-morphomarketv1-liquidity

## Validation

- `pnpm exec biome check packages/blue-sdk-viem/src/fetch/vault-v2/VaultV2.ts`
- `pnpm jsdoc:coverage:check`

Full tests not run; this is JSDoc-only and does not change runtime behavior.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779098168571889)
<!-- slack-thread-ts:1779098168.571889 -->