### PR TITLE
feat(morpho-sdk): expose getRequirementsAction on public surface

### DIFF
--- a/.changeset/export-get-requirements-action.md
+++ b/.changeset/export-get-requirements-action.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": minor
+---
+
+Export `getRequirementsAction` on the public surface. The helper encodes a pre-signed permit / permit2 requirement followed by a transfer to an arbitrary `recipient`, and was previously `@internal` (reachable only via deep dist paths). Exposing it lets action builders outside this package — e.g. the Aave V3 → Vault V2 migration in `morpho-apps` — route the pulled asset to a non-default recipient such as `AaveV3CoreMigrationAdapter`, without copying the permit/permit2 encoding logic.

--- a/.changeset/export-get-requirements-action.md
+++ b/.changeset/export-get-requirements-action.md
@@ -3,3 +3,5 @@
 ---
 
 Export `getRequirementsAction` on the public surface. The helper encodes a pre-signed permit / permit2 requirement followed by a transfer to an arbitrary `recipient`, and was previously `@internal` (reachable only via deep dist paths). Exposing it lets action builders outside this package — e.g. the Aave V3 → Vault V2 migration in `morpho-apps` — route the pulled asset to a non-default recipient such as `AaveV3CoreMigrationAdapter`, without copying the permit/permit2 encoding logic.
+
+Also exports `Permit2ExpirationMissingError`, the typed error `getRequirementsAction` now throws when a `permit2` requirement signature is missing `args.expiration` (previously a generic `Error`).

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
@@ -27,10 +27,6 @@ interface GetRequirementsActionParams {
  * `amount` exactly, otherwise the function throws so the caller does not silently spend a
  * wider-than-expected approval.
  *
- * Exposed on the public surface so action builders outside this package (e.g. the Aave V3
- * → Vault V2 migration builder in `morpho-apps`) can route the pulled asset to a non-default
- * `recipient` such as the `AaveV3CoreMigrationAdapter` rather than `GeneralAdapter1`.
- *
  * @param params.asset - The ERC-20 to pull.
  * @param params.amount - The amount to pull, in the asset's smallest unit.
  * @param params.recipient - The address that receives the transfer.

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
@@ -25,8 +25,11 @@ interface GetRequirementsActionParams {
  * Permit2 path emits `approve2` + `transferFrom2`; classic permit path emits `permit` +
  * `erc20TransferFrom`. The signed `asset` and `amount` must match the pulled `asset` and
  * `amount` exactly, otherwise the function throws so the caller does not silently spend a
- * wider-than-expected approval. Internal helper — consumed only by the action builders that
- * accept a `requirementSignature`; not re-exported on the public surface.
+ * wider-than-expected approval.
+ *
+ * Exposed on the public surface so action builders outside this package (e.g. the Aave V3
+ * → Vault V2 migration builder in `morpho-apps`) can route the pulled asset to a non-default
+ * `recipient` such as the `AaveV3CoreMigrationAdapter` rather than `GeneralAdapter1`.
  *
  * @param params.asset - The ERC-20 to pull.
  * @param params.amount - The amount to pull, in the asset's smallest unit.
@@ -35,7 +38,6 @@ interface GetRequirementsActionParams {
  * @returns A pair of bundler `Action`s: a permit / approve2 followed by the transfer.
  * @throws {DepositAssetMismatchError} when the signed asset differs from `asset`.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `amount`.
- * @internal
  */
 export const getRequirementsAction = ({
   asset,

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
@@ -4,6 +4,7 @@ import {
   DepositAmountMismatchError,
   DepositAssetMismatchError,
   type Permit2Action,
+  Permit2ExpirationMissingError,
   type PermitAction,
   type PermitArgs,
 } from "../../types/index.js";
@@ -34,6 +35,7 @@ interface GetRequirementsActionParams {
  * @returns A pair of bundler `Action`s: a permit / approve2 followed by the transfer.
  * @throws {DepositAssetMismatchError} when the signed asset differs from `asset`.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `amount`.
+ * @throws {Permit2ExpirationMissingError} when `action.type === "permit2"` but `args.expiration` is missing.
  */
 export const getRequirementsAction = ({
   asset,
@@ -54,7 +56,7 @@ export const getRequirementsAction = ({
 
   if (requirementSignature.action.type === "permit2") {
     if (!("expiration" in requirementSignature.args)) {
-      throw new Error("Expiration is not defined");
+      throw new Permit2ExpirationMissingError();
     }
     return [
       {

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts
@@ -36,6 +36,31 @@ interface GetRequirementsActionParams {
  * @throws {DepositAssetMismatchError} when the signed asset differs from `asset`.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `amount`.
  * @throws {Permit2ExpirationMissingError} when `action.type === "permit2"` but `args.expiration` is missing.
+ * @example
+ * ```ts
+ * import { createWalletClient, http } from "viem";
+ * import { mainnet } from "viem/chains";
+ * import { getRequirementsAction } from "@morpho-org/morpho-sdk";
+ *
+ * const walletClient = createWalletClient({
+ *   chain: mainnet,
+ *   transport: http(),
+ *   account: borrower,
+ * });
+ *
+ * // `requirement` comes from `getRequirements*` helpers; signing produces a `RequirementSignature`.
+ * const requirementSignature = await requirement.sign(walletClient, borrower);
+ *
+ * const actions = getRequirementsAction({
+ *   asset: loanToken,
+ *   amount: 1_000_000n,
+ *   recipient: generalAdapter1,
+ *   requirementSignature,
+ * });
+ * // actions satisfies Action[]
+ * // - permit2 path: [{ type: "approve2", ... }, { type: "transferFrom2", ... }]
+ * // - classic permit path: [{ type: "permit", ... }, { type: "erc20TransferFrom", ... }]
+ * ```
  */
 export const getRequirementsAction = ({
   asset,

--- a/packages/morpho-sdk/src/actions/requirements/index.ts
+++ b/packages/morpho-sdk/src/actions/requirements/index.ts
@@ -1,6 +1,7 @@
 export * from "./encode/index.js";
 export * from "./getMorphoAuthorizationRequirement.js";
 export * from "./getRequirements.js";
+export * from "./getRequirementsAction.js";
 export * from "./getRequirementsApproval.js";
 export * from "./getRequirementsPermit.js";
 export * from "./getRequirementsPermit2.js";

--- a/packages/morpho-sdk/src/types/error.ts
+++ b/packages/morpho-sdk/src/types/error.ts
@@ -102,6 +102,15 @@ export class DepositAssetMismatchError extends Error {
   }
 }
 
+/** Thrown when a `permit2` requirement signature is missing the `expiration` field. */
+export class Permit2ExpirationMissingError extends Error {
+  constructor() {
+    super(
+      'Requirement signature with action.type === "permit2" must include args.expiration. Re-sign using the permit2 flow.',
+    );
+  }
+}
+
 /** Thrown when a vault deposit uses `nativeAmount` but the vault asset is not the chain's wNative. */
 export class NativeAmountOnNonWNativeVaultError extends Error {
   constructor(vaultAsset: Address, wNative: Address) {


### PR DESCRIPTION
## Summary

Drops the `@internal` marker on `getRequirementsAction` and re-exports it from `actions/requirements/index.ts`.

The helper encodes a pre-signed permit / permit2 followed by a transfer to an arbitrary `recipient`. Since SDK PR #654 made the recipient configurable (defaulting to `GeneralAdapter1` at every internal call site), external action builders can reuse the same encoding for migrations that target a different adapter — e.g. the Aave V3 → Vault V2 migration in `morpho-apps` PR [#2281](https://github.com/morpho-org/morpho-apps/pull/2281), which routes the aToken to `AaveV3CoreMigrationAdapter` rather than GA1.

Without this export, the consumer would either deep-import from the dist tree (unstable, blocked by `package.json#exports`) or duplicate the permit/permit2 encoding logic.

## Changes

- `packages/morpho-sdk/src/actions/requirements/index.ts` — re-export `getRequirementsAction`
- `packages/morpho-sdk/src/actions/requirements/getRequirementsAction.ts` — drop `@internal`, update JSDoc to describe the public use case
- Changeset: `minor` (new public surface)

## Test plan

- [x] `pnpm exec tsc --noEmit` in `packages/morpho-sdk`
- [x] `pnpm exec biome check src/actions/requirements/`
- [ ] CI green

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779116202869689)
<!-- slack-thread-ts:1779116202.869689 -->