### PR TITLE
docs: resolve §2/§1/§10 backlink contradictions flagged on #685

### DIFF
--- a/.agents/personas/ci-release-security.md
+++ b/.agents/personas/ci-release-security.md
@@ -15,18 +15,11 @@ severity-guidance: Workflow injection → critical. Floating action tags or wide
 
 Focus: the trust boundary that ships our code. CI runs with privileged tokens; releases push artifacts under the org's identity. A bad workflow merge can leak secrets, run attacker code on a maintainer's box, or publish a poisoned package. This persona reviews diffs that touch that surface.
 
+Authoritative rules live in [`AGENTS.md` §10](../../AGENTS.md#10-review-automation--cirelease-security) (CI / release security rules) — read those first. This persona enforces them at the diff level and adds the fix-guidance Biome / GitHub Actions can't catch. When wording differs between this body and §10, §10 wins.
+
 ## Trigger
 
-Fires when `<HAS_CI_RELEASE>` is true — i.e. any changed file matches:
-
-- `.github/workflows/**`
-- `.github/actions/**` (composite or local actions)
-- `.changeset/**` (changeset entries, changesets config)
-- root `package.json` or any `packages/*/package.json` where a `scripts.*publish*` / `scripts.*release*` field is touched
-- `pnpm-lock.yaml`
-- `pnpm-workspace.yaml`
-- `.npmrc` (any level)
-- file content contains `changeset publish`, `npm publish`, `pnpm publish`, or `gh release create`
+Fires when `<HAS_CI_RELEASE>` is true. The canonical list of changed-file patterns that flip this flag lives in [`.agents/lib/pr-review-base.md`](../lib/pr-review-base.md) Step 4 — do not restate it here.
 
 ## Prompt must include
 
@@ -46,7 +39,7 @@ Fires when `<HAS_CI_RELEASE>` is true — i.e. any changed file matches:
 
 - Missing top-level `permissions:` block in a new workflow — defaults to write-all on classic-permissions repos. Require an explicit `permissions:` block (job-level if scopes differ between jobs).
 - Wide scopes where narrow ones would do: `contents: write` when only `contents: read` is needed; `id-token: write` outside of OIDC/provenance-publishing jobs; `pull-requests: write` outside of bot-comment jobs.
-- `secrets: inherit` passed to reusable workflows — flag and request explicit secret listing.
+- `secrets: inherit` passed to reusable workflows is forbidden — list secrets explicitly (per AGENTS.md §10).
 
 ### Secret exposure (HIGH)
 

--- a/.agents/personas/code-quality.md
+++ b/.agents/personas/code-quality.md
@@ -31,10 +31,10 @@ Per AGENTS.md §3 — type discipline inside the body:
 - Discriminated unions with obvious `type` tags where an options-bag was reached for.
 - `bigint` used correctly for onchain quantities and WAD-scaled rates (e.g. `92_0000000000000000n`) — not `number`.
 
-Code smells (not codified in AGENTS.md but reviewer-time conventions):
+Code smells (mostly reviewer-time conventions; the early-return / deep-nesting rule is codified in AGENTS.md §1):
 
 - Duplicated logic across functions in the diff — extract or reuse an existing helper.
-- Overly complex functions / deep nesting — prefer early returns over nested conditionals.
+- Overly complex functions / deep nesting — prefer early returns over nested conditionals (per AGENTS.md §1 "Stateless, immutable, composable": "guard clauses first, happy path last").
 - Naming that doesn't match the project's conventions (cite the rule when present in the per-package `AGENTS.md`).
 - Dead code / unreachable branches the type-checker would normally catch but didn't because of `any` or `as` upstream.
 

--- a/.agents/personas/module-api-architecture.md
+++ b/.agents/personas/module-api-architecture.md
@@ -1,7 +1,7 @@
 ---
 name: module-api-architecture
 kind: baseline
-applies: AGENTS.md §1 Architecture (layering, modularity), §3 Type discipline (at the boundary), §4 Public API & packaging
+applies: AGENTS.md §1 Architecture (layering, modularity), §2 Forbidden patterns (rule 5 — deep cross-package imports), §3 Type discipline (at the boundary), §4 Public API & packaging
 out-of-scope:
   - Lint mechanics (2-space indent, organize-imports) — see style-conventions.
   - Type-safety inside a function body — see code-quality.

--- a/.agents/personas/silent-failure-hunter.md
+++ b/.agents/personas/silent-failure-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: silent-failure-hunter
 kind: baseline
-applies: AGENTS.md §1 Architecture (testability), §2 Forbidden patterns (typed errors over `throw new Error`)
+applies: AGENTS.md §2 rule 2 — handling discipline for typed errors once they exist (code-quality owns the rule's existence; this persona owns what happens to the error after it's thrown)
 out-of-scope:
   - General type-safety inside function bodies — see code-quality.
   - Whether the typed error class exists at all (vs `throw new Error`) — see code-quality (it owns §2's typed-error rule).

--- a/.agents/personas/test-coverage.md
+++ b/.agents/personas/test-coverage.md
@@ -1,7 +1,7 @@
 ---
 name: test-coverage
 kind: baseline
-applies: AGENTS.md §5 Testing
+applies: AGENTS.md §5 Testing, §2 Forbidden patterns (rule 6 — mocked viem clients on RPC paths)
 out-of-scope:
   - Correctness of the test assertions themselves — see code-quality.
   - Missing tests for CI workflows — see ci-release-security.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Cross-layer leaks (entities encoding calldata, actions reading state, helpers de
 - Small primitives that combine. No kitchen-sink helpers; no boolean-prop explosions.
 - Prefer early returns over deep nesting — guard clauses first, happy path last.
 
-> Applied by personas: [`module-api-architecture`](./.agents/personas/module-api-architecture.md), [`web3-security`](./.agents/personas/web3-security.md) (Action-layer purity), [`silent-failure-hunter`](./.agents/personas/silent-failure-hunter.md) (testability).
+> Applied by personas: [`module-api-architecture`](./.agents/personas/module-api-architecture.md), [`web3-security`](./.agents/personas/web3-security.md) (Action-layer purity).
 
 ---
 
@@ -70,7 +70,7 @@ A scannable list of patterns reviewers reject. Most are review-only today (per t
 9. New runtime dependencies without a package-level reason and a written justification in the PR description.
 10. PRs that ship behavior-affecting package source changes without their tests, JSDoc, and semver-relevant changeset.
 
-> Applied by personas: [`code-quality`](./.agents/personas/code-quality.md) (forbidden patterns 1–4, 7–10), [`web3-security`](./.agents/personas/web3-security.md) (3 — signing in transaction builders), [`silent-failure-hunter`](./.agents/personas/silent-failure-hunter.md) (2 — typed errors).
+> Applied by personas: [`code-quality`](./.agents/personas/code-quality.md) (forbidden patterns 1–4, 7–10), [`module-api-architecture`](./.agents/personas/module-api-architecture.md) (5 — deep cross-package imports), [`test-coverage`](./.agents/personas/test-coverage.md) (6 — mocked viem clients on RPC paths), [`web3-security`](./.agents/personas/web3-security.md) (3 — signing in transaction builders), [`silent-failure-hunter`](./.agents/personas/silent-failure-hunter.md) (complement to rule 2 — handling discipline once a typed error is thrown; code-quality owns the rule's existence).
 
 ---
 
@@ -207,18 +207,18 @@ Baseline personas (always fire):
 | Persona | Anchors | Focus |
 |---|---|---|
 | [`code-quality`](./.agents/personas/code-quality.md) | §2, §3 | Type safety, code smells, naming, cross-file impact on SDK consumers, security primitives. |
-| [`module-api-architecture`](./.agents/personas/module-api-architecture.md) | §1, §3, §4 | Package boundaries, public surface, NodeNext import discipline, boundary-level type discipline. |
+| [`module-api-architecture`](./.agents/personas/module-api-architecture.md) | §1, §2 (rule 5), §3, §4 | Package boundaries, public surface, NodeNext import discipline, boundary-level type discipline. |
 | [`web3-security`](./.agents/personas/web3-security.md) | §1 (Action layer), §2, §5 (security invariants) | Contract interactions, transaction params, permit flows, race conditions. Severity defaults to critical/high. |
-| [`silent-failure-hunter`](./.agents/personas/silent-failure-hunter.md) | §1 (testability), §2 | Swallowed errors, missing error states, dead code paths. |
+| [`silent-failure-hunter`](./.agents/personas/silent-failure-hunter.md) | §2 (handling depth for rule 2 — see persona body) | Swallowed errors, missing error states, dead code paths. |
 | [`style-conventions`](./.agents/personas/style-conventions.md) | §7, §8 | Biome compliance, import discipline, changeset relevance. |
 | [`documentation`](./.agents/personas/documentation.md) | §6 | JSDoc on exports, Markdown doc accuracy, pointer integrity, AGENTS.md ↔ persona backlink consistency. |
-| [`test-coverage`](./.agents/personas/test-coverage.md) | §5 | Missing tests for new code paths and onchain interactions. |
+| [`test-coverage`](./.agents/personas/test-coverage.md) | §5, §2 (rule 6) | Missing tests for new code paths and onchain interactions. |
 
 Conditional personas (fire only when their trigger flag is true):
 
 | Persona | Trigger | Anchors |
 |---|---|---|
-| [`ci-release-security`](./.agents/personas/ci-release-security.md) | `<HAS_CI_RELEASE>` — diff touches `.github/workflows/**`, `.github/actions/**`, `.changeset/**`, any `package.json` whose `scripts.*publish*` / `scripts.*release*` field is modified, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`, or any file mentioning `npm publish` / `pnpm publish` / `changeset publish` / `gh release create` (canonical detector in [`.agents/lib/pr-review-base.md`](./.agents/lib/pr-review-base.md) Step 4) | §10 (the rules below) |
+| [`ci-release-security`](./.agents/personas/ci-release-security.md) | `<HAS_CI_RELEASE>` (computed in [`.agents/lib/pr-review-base.md`](./.agents/lib/pr-review-base.md) Step 4 — that file is the single source of truth for the changed-file patterns that flip this flag) | §10 (the rules below) |
 
 Adding a persona = drop a file under `.agents/personas/` with `applies:` frontmatter, add a row to the relevant table above, and (for a conditional persona) extend the flag detection in `.agents/lib/pr-review-base.md` Step 4.
 
@@ -229,7 +229,7 @@ These are the rules `ci-release-security` enforces. They live here as source of 
 - **Workflow injection** (CRITICAL). Never interpolate attacker-controllable GitHub context (`${{ github.event.* }}`, `${{ github.head_ref }}`, comment bodies, branch names) directly into `run:` blocks, `shell:` invocations, or third-party-action arguments. Bind to an `env:` first, then reference `$VAR` in the shell so GitHub's redaction can still apply and shell expansion can't reinterpret the value.
 - **`pull_request_target` + PR-head checkout is forbidden** unless the workflow demonstrably never runs the checked-out code (no install, no test, no script). The combination grants attacker code write-scoped repo credentials.
 - **ACL-gated comment triggers.** `issue_comment` / `pull_request_review_comment` workflows must gate on `github.event.comment.author_association` (`OWNER`, `MEMBER`, or `COLLABORATOR`) before acting on comment text.
-- **Action pinning.** Third-party `uses:` lines pin to a full commit SHA with the human-readable tag in a trailing comment: `uses: foo/bar@<40-char-sha>  # v1.2.3`. First-party `actions/*` and `github/*` may use tagged versions when Dependabot covers them via `.github/dependabot.yml`.
+- **Action pinning.** Third-party `uses:` lines pin to a full commit SHA with the human-readable tag in a trailing comment: `uses: foo/bar@<40-char-sha>  # v1.2.3`. First-party `actions/*` and `github/*` may use tagged versions when Dependabot covers them via `.github/dependabot.yml`. Newly added actions from publishers the org has not used before must surface the publisher name in the review comment so a maintainer can confirm review.
 - **`permissions:` block required** on every workflow. Default `contents: read`. Job-level scopes where they differ. `id-token: write` only on OIDC / provenance-publishing jobs. `secrets: inherit` passed to reusable workflows is forbidden — list secrets explicitly.
 - **Secret exposure.** Secrets must be `env:`-bound and referenced as `$VAR` inside scripts; never interpolated into the `run:` string directly. Secrets passed to third-party actions require those actions to be SHA-pinned.
 - **Publish-flow integrity.** `npm publish` / `pnpm publish` must use `--provenance` (or the Changesets provenance-aware path). Auth via org-scoped `NODE_AUTH_TOKEN`, never a personal access token. Tag-scope changes (e.g. `next` → `latest`) require human sign-off via `environment:` with required reviewers. Removing `--provenance` is a downgrade — flag at minimum **medium**, **high** for runtime/peer-surface packages.
@@ -238,5 +238,6 @@ These are the rules `ci-release-security` enforces. They live here as source of 
 - **Lockfile drift.** A `pnpm-lock.yaml` change without a corresponding `package.json` change is a finding unless the PR description explains why (transitive bump, security patch).
 - **Dependency hygiene.** New deps in `dependencies` or `peerDependencies` of a published package default to **high** for review. Flag unpinned semver ranges (`^`/`~`) on runtime deps, names that resemble typosquats of known packages, and deps whose registry metadata declares `postinstall` / `preinstall` / `install` scripts.
 - **`.npmrc` hardening.** `always-auth=true` or `_authToken=` committed to the repo is **critical** — credential leak. Non-`registry.npmjs.org` `registry=` or `@scope:registry=` lines require explicit human review (could redirect to a malicious registry).
+- **Workspace install behavior.** Flips of `auto-install-peers` or `strict-peer-dependencies` in `.npmrc` or `pnpm-workspace.yaml` are **medium** — surface the impact on consumer install behavior in the review comment.
 
 > Applied by persona: [`ci-release-security`](./.agents/personas/ci-release-security.md).


### PR DESCRIPTION
Follow-up to #685 (merged). [Foulques flagged four internal contradictions](https://github.com/morpho-org/sdks/pull/685#issuecomment-) that survived the audit; this PR fixes all four. Doc-only — no code paths affected.

## Summary

1. **§2 backlink no longer credits `silent-failure-hunter` for "2 — typed errors".** The persona's own body (`.agents/personas/silent-failure-hunter.md:7`) + `.agents/personas/code-quality.md:24` explicitly defer the typed-class-existence rule to `code-quality`. The §2 backlink now lists the actual owners for the two orphaned rules: `module-api-architecture` for #5 (deep cross-package imports — its body at `module-api-architecture.md:20` enforces exactly this) and `test-coverage` for #6 (mocked viem clients on RPC paths — `test-coverage.md:37`). `silent-failure-hunter` stays in the callout but reframed as the *complement* to rule 2 (handling discipline once the error is thrown) — which is what the body actually says, and what keeps the `documentation` persona's bidirectional-consistency check (`.agents/personas/documentation.md:71`) from flagging a one-way pointer.

2. **`code-quality.md`'s "Code smells" section no longer claims early returns are "not codified in AGENTS.md".** The rule is the last bullet of §1 "Stateless, immutable, composable" (`AGENTS.md:52`). Header parenthetical tightened; the bullet now cites §1 directly.

3. **CI/release dedupe (the two `<HAS_CI_RELEASE>` and `secrets: inherit` drifts).**
   - `<HAS_CI_RELEASE>` trigger path-list now lives in **exactly one place** (`.agents/lib/pr-review-base.md:85`, Step 4). The §10 inventory table cell and `ci-release-security.md`'s Trigger section are thin pointers to it.
   - Two rules that existed only in the persona body (and so couldn't be enforced as canonical) are promoted to §10: `Newly added actions from publishers the org has not used before` (appended to "Action pinning") and `Workspace install behavior` (auto-install-peers / strict-peer-dependencies flips, medium severity).
   - `secrets: inherit` wording synced — both `AGENTS.md:233` and `ci-release-security.md:42` now read `…is forbidden — list secrets explicitly`.
   - `ci-release-security.md` gains an intro line declaring §10 as source-of-truth, mirroring the pattern `code-quality.md:17` uses for §2/§3.

4. **`silent-failure-hunter.applies` no longer cites §1 (testability).** §1 "Testability" (`AGENTS.md:40-45`) is about DI / I/O at the boundary, which the persona doesn't enforce. The applies line is rewritten to describe what the persona actually does (the rule-2 complement). §1 backlink drops `silent-failure-hunter` to match.

## Files changed

| File | Why |
|---|---|
| `AGENTS.md` | §1 backlink (drop SFH); §2 backlink (drop SFH-as-enforcer, add MAA + TC + SFH-as-complement); §10 inventory rows for MAA / SFH / TC; §10 ci-release-security row collapses trigger spec to a pointer; add 2 missing rules to §10 |
| `.agents/personas/silent-failure-hunter.md` | `applies:` reframed (drop §1, narrow §2 to rule-2 complement) |
| `.agents/personas/ci-release-security.md` | Trigger section → pointer at `pr-review-base.md` Step 4; intro line referencing §10; `secrets: inherit` wording sync |
| `.agents/personas/code-quality.md` | Code-smells header parenthetical; early-returns bullet now cites §1 |
| `.agents/personas/module-api-architecture.md` | `applies:` adds §2 rule 5 |
| `.agents/personas/test-coverage.md` | `applies:` adds §2 rule 6 |

## Test plan

- [x] Bidirectional consistency walk (every `> Applied by personas:` callout in `AGENTS.md` vs every persona's `applies:` frontmatter). One pre-existing asymmetry remains at §7 ↔ ci-release-security (publish-flow); out of scope for this PR.
- [x] `<HAS_CI_RELEASE>` path-list grep — exactly one full definition in the repo (`.agents/lib/pr-review-base.md:85`), two pointers (`AGENTS.md` §10 table cell, `ci-release-security.md` Trigger section).
- [x] `secrets: inherit` grep — both occurrences match verbatim.
- [ ] `documentation` persona's bidirectional-consistency check returns clean against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779186643001879)
<!-- slack-thread-ts:1779186643.001879 -->