### PR TITLE
chore: version packages (main)

### DIFF
--- a/.changeset/morpho-sdk-metadata-origin-prefix.md
+++ b/.changeset/morpho-sdk-metadata-origin-prefix.md
@@ -1,5 +1,0 @@
----
-"@morpho-org/morpho-sdk": patch
----
-
-`addTransactionMetadata` now strips a leading `"0x"` from `metadata.origin` before validating and appending it. Previously, passing `"0xcafe"` and `"cafe"` produced different calldata: `"0xcafe"` was rejected by the upstream `isHex` check (which receives the raw fragment) while `"cafe"` was accepted. With this change, both inputs produce the same 4-byte origin appended to `tx.data`. Length validation (max 8 hex chars) is applied to the raw fragment, so `"0xdeadbeef00"` (10 raw hex chars) is still rejected.

--- a/.changeset/test-mock-esm-only.md
+++ b/.changeset/test-mock-esm-only.md
@@ -1,7 +1,0 @@
----
-"@morpho-org/test": patch
----
-
-`mockRead` (from `@morpho-org/test/mock`) now ABI-encodes the supplied `result` **per overload** of the target function name rather than once against the ambiguous `functionName`. For ABIs where overloads share a return type the behaviour is unchanged (the same bytes are stored under every selector). For ABIs where overloads have **different** return types — e.g. `counter(uint256) returns (uint256)` and `counter(address) returns (bool)` — the encoded bytes now match each overload's declared output shape, so an `eth_call` to the bool overload no longer receives uint256-shaped bytes. If the supplied `result` does not match the return shape of **any** overload, `mockRead` now throws a clear `Error` (`"[mockRead] options.result does not match any return-type shape of overloads of <name>"`) instead of silently registering bytes that decode incorrectly.
-
-(Drive-by packaging cleanup: the previously-advertised CJS `require` condition for `./mock` is removed from `publishConfig.exports` and `mock.ts` is excluded from the CJS build. The entry was crash-on-load — `mock.ts` imports vitest, which rejects `require()` — so no working consumer is affected; only the unusable metadata is gone.)

--- a/.changeset/test-mock-subexport.md
+++ b/.changeset/test-mock-subexport.md
@@ -1,5 +1,0 @@
----
-"@morpho-org/test": minor
----
-
-Add `./mock` sub-export providing `createMockClient`, `mockRead`, and `expectReadCall` for transport-level viem mocking in unit tests. The mock installs a `vi.fn`-backed `custom()` transport on a real viem `Client`, so SDK code that uses `viem/actions` named imports (e.g. `readContract(client, …)`) resolves through it just as it would against a live RPC. `mockRead` matches every overload of a function name, so reads against contracts with overloaded `view`/`pure` methods don't silently miss.

--- a/packages/morpho-sdk/CHANGELOG.md
+++ b/packages/morpho-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @morpho-org/morpho-sdk
 
+## 2.1.1
+
+### Patch Changes
+
+- [#596](https://github.com/morpho-org/sdks/pull/596) [`79443e5`](https://github.com/morpho-org/sdks/commit/79443e5814e939428b7e5bbeb30729903305cf81) Thanks [@0xbulma](https://github.com/0xbulma)! - `addTransactionMetadata` now strips a leading `"0x"` from `metadata.origin` before validating and appending it. Previously, passing `"0xcafe"` and `"cafe"` produced different calldata: `"0xcafe"` was rejected by the upstream `isHex` check (which receives the raw fragment) while `"cafe"` was accepted. With this change, both inputs produce the same 4-byte origin appended to `tx.data`. Length validation (max 8 hex chars) is applied to the raw fragment, so `"0xdeadbeef00"` (10 raw hex chars) is still rejected.
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/morpho-sdk/package.json
+++ b/packages/morpho-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@morpho-org/morpho-sdk",
   "description": "Abstraction layer for Morpho's complexity.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "Morpho Association <contact@morpho.org>",
   "contributors": [
     "Foulks-Plb <https://x.com/FoulkPlb>"

--- a/packages/morpho-test/package.json
+++ b/packages/morpho-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@morpho-org/morpho-test",
   "description": "Framework-agnostic extension of `@morpho-org/blue-sdk` that exports test fixtures useful for E2E tests on forks.",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": "Morpho Association <contact@morpho.org>",
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"

--- a/packages/test-wagmi/CHANGELOG.md
+++ b/packages/test-wagmi/CHANGELOG.md
@@ -1,15 +1,8 @@
-# @morpho-org/morpho-test
-
-## 4.0.0
-
-### Patch Changes
-
-- Updated dependencies [[`79443e5`](https://github.com/morpho-org/sdks/commit/79443e5814e939428b7e5bbeb30729903305cf81), [`79443e5`](https://github.com/morpho-org/sdks/commit/79443e5814e939428b7e5bbeb30729903305cf81)]:
-  - @morpho-org/test@2.8.0
+# @morpho-org/test-wagmi
 
 ## 3.0.0
 
 ### Patch Changes
 
-- Updated dependencies [[`c9796ab`](https://github.com/morpho-org/sdks/commit/c9796ab033c7fe3ac7241542f3b1a85d17e9b987)]:
-  - @morpho-org/blue-sdk@6.0.0
+- Updated dependencies [[`79443e5`](https://github.com/morpho-org/sdks/commit/79443e5814e939428b7e5bbeb30729903305cf81), [`79443e5`](https://github.com/morpho-org/sdks/commit/79443e5814e939428b7e5bbeb30729903305cf81)]:
+  - @morpho-org/test@2.8.0

--- a/packages/test-wagmi/package.json
+++ b/packages/test-wagmi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@morpho-org/test-wagmi",
   "description": "Wagmi-based extension of `@morpho-org/test` that injects a test Wagmi config as a test fixture alongside viem's anvil client.",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "author": "Morpho Association <contact@morpho.org>",
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @morpho-org/test
 
+## 2.8.0
+
+### Minor Changes
+
+- [#596](https://github.com/morpho-org/sdks/pull/596) [`79443e5`](https://github.com/morpho-org/sdks/commit/79443e5814e939428b7e5bbeb30729903305cf81) Thanks [@0xbulma](https://github.com/0xbulma)! - Add `./mock` sub-export providing `createMockClient`, `mockRead`, and `expectReadCall` for transport-level viem mocking in unit tests. The mock installs a `vi.fn`-backed `custom()` transport on a real viem `Client`, so SDK code that uses `viem/actions` named imports (e.g. `readContract(client, …)`) resolves through it just as it would against a live RPC. `mockRead` matches every overload of a function name, so reads against contracts with overloaded `view`/`pure` methods don't silently miss.
+
+### Patch Changes
+
+- [#596](https://github.com/morpho-org/sdks/pull/596) [`79443e5`](https://github.com/morpho-org/sdks/commit/79443e5814e939428b7e5bbeb30729903305cf81) Thanks [@0xbulma](https://github.com/0xbulma)! - `mockRead` (from `@morpho-org/test/mock`) now ABI-encodes the supplied `result` **per overload** of the target function name rather than once against the ambiguous `functionName`. For ABIs where overloads share a return type the behaviour is unchanged (the same bytes are stored under every selector). For ABIs where overloads have **different** return types — e.g. `counter(uint256) returns (uint256)` and `counter(address) returns (bool)` — the encoded bytes now match each overload's declared output shape, so an `eth_call` to the bool overload no longer receives uint256-shaped bytes. If the supplied `result` does not match the return shape of **any** overload, `mockRead` now throws a clear `Error` (`"[mockRead] options.result does not match any return-type shape of overloads of <name>"`) instead of silently registering bytes that decode incorrectly.
+
+  (Drive-by packaging cleanup: the previously-advertised CJS `require` condition for `./mock` is removed from `publishConfig.exports` and `mock.ts` is excluded from the CJS build. The entry was crash-on-load — `mock.ts` imports vitest, which rejects `require()` — so no working consumer is affected; only the unusable metadata is gone.)
+
 ## 2.7.3
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@morpho-org/test",
   "description": "Viem-based package that exports utilities to build Vitest & Playwright fixtures that spawn anvil forks as child processes.",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "author": "Morpho Association <contact@morpho.org>",
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"


### PR DESCRIPTION
Forked from #689 with a signed commit so the release workflow can proceed.

This PR applies the pending changesets for main.

Merging it clears the consumed changesets and lets the publish workflow publish the already-versioned packages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779206880087359)
<!-- slack-thread-ts:1779206880.087359 -->