### PR TITLE
chore(wdk-protocol-lending-morpho-evm): bump pinned deps within current major

### DIFF
--- a/.changeset/bump-wdk-tether-deps.md
+++ b/.changeset/bump-wdk-tether-deps.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/wdk-protocol-lending-morpho-evm": patch
+---
+
+Bump pinned `@tetherto/*` runtime dependencies to the latest 1.x betas: `@tetherto/wdk-wallet` `1.0.0-beta.7` → `1.0.0-beta.8`, `@tetherto/wdk-wallet-evm` `1.0.0-beta.11` → `1.0.0-beta.12` (kept on the 1.x track; `2.0.0-rc.1` is the next major and out of scope). Also bumps the `viem` devDependency floor from `^2.49.3` to `^2.50.4` so the lockfile picks up the latest 2.x release; the `^2.0.0` peer range is unchanged. `cross-env@^7.0.3` and `jest@^29.7.0` are already at the latest release on their respective majors.

--- a/packages/wdk-protocol-lending-morpho-evm/package.json
+++ b/packages/wdk-protocol-lending-morpho-evm/package.json
@@ -60,8 +60,8 @@
     "@morpho-org/blue-sdk": "workspace:^",
     "@morpho-org/blue-sdk-viem": "workspace:^",
     "@morpho-org/morpho-sdk": "workspace:^",
-    "@tetherto/wdk-wallet": "1.0.0-beta.7",
-    "@tetherto/wdk-wallet-evm": "1.0.0-beta.11",
+    "@tetherto/wdk-wallet": "1.0.0-beta.8",
+    "@tetherto/wdk-wallet-evm": "1.0.0-beta.12",
     "@tetherto/wdk-wallet-evm-erc-4337": "1.0.0-beta.6",
     "bare-node-runtime": "1.3.1"
   },
@@ -72,7 +72,7 @@
     "cross-env": "^7.0.3",
     "jest": "^29.7.0",
     "typescript": "^6.0.3",
-    "viem": "^2.49.3"
+    "viem": "^2.50.4"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,11 +690,11 @@ importers:
         specifier: workspace:^
         version: link:../morpho-sdk
       '@tetherto/wdk-wallet':
-        specifier: 1.0.0-beta.7
-        version: 1.0.0-beta.7(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))
+        specifier: 1.0.0-beta.8
+        version: 1.0.0-beta.8(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))
       '@tetherto/wdk-wallet-evm':
-        specifier: 1.0.0-beta.11
-        version: 1.0.0-beta.11(bare-abort-controller@1.1.2)(bare-buffer@3.6.0)(bare-events@2.8.3(bare-abort-controller@1.1.2))(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))(bare-url@2.4.3)
+        specifier: 1.0.0-beta.12
+        version: 1.0.0-beta.12(bare-abort-controller@1.1.2)(bare-buffer@3.6.0)(bare-events@2.8.3(bare-abort-controller@1.1.2))(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))(bare-url@2.4.3)
       '@tetherto/wdk-wallet-evm-erc-4337':
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(bare-abort-controller@1.1.2)(bare-buffer@3.6.0)(bare-events@2.8.3(bare-abort-controller@1.1.2))(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))(bare-url@2.4.3)(typescript@6.0.3)(zod@4.4.3)
@@ -712,8 +712,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       viem:
-        specifier: ^2.49.3
-        version: 2.49.3(typescript@6.0.3)(zod@4.4.3)
+        specifier: ^2.50.4
+        version: 2.50.4(typescript@6.0.3)(zod@4.4.3)
 
 packages:
 
@@ -1903,6 +1903,9 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tetherto/wdk-failover-provider@1.0.0-beta.2':
+    resolution: {integrity: sha512-G1KNpw11Hql7Q6Xy5oqO+8P+AkJi4QBTK4JZtZvcXmx8ze+d/lzSQSufWLE/k5YAvwJ+xDx7mRzy/teG4zaiOw==}
+
   '@tetherto/wdk-safe-protocol-kit@6.1.3':
     resolution: {integrity: sha512-KazAj6y5Ywfm1SbDWdQXetHQ9Rl/8+vwWLICAl+j0Qm1QbryLBz7fbwawSt1l5wT+RYRV64HfqIetlQQaNK6YA==}
     peerDependencies:
@@ -1917,8 +1920,14 @@ packages:
   '@tetherto/wdk-wallet-evm@1.0.0-beta.11':
     resolution: {integrity: sha512-zfNOGHQdcIw+ByhnDXipEZ3/W5JRv+3kse4uS7vDvhOY+HmC4QrxrutUA0NP7/8CkgaLGR58M331DsXk9L5/Fg==}
 
+  '@tetherto/wdk-wallet-evm@1.0.0-beta.12':
+    resolution: {integrity: sha512-y101FMTrj9Ys67d80RE9La8B2RAd2jckD5+d50c/Wa8tCNa0uUsTf7YIjVssvfmYFrXUL8uq4vMA0fcJwNFIoQ==}
+
   '@tetherto/wdk-wallet@1.0.0-beta.7':
     resolution: {integrity: sha512-QJJPhA+adCImQ/nMymmMeW4x0Ey65vEgWfoDjuXtdaD7LnFdCChFvZXcyDQUH3ghSTnve6MDutMmvfDIxhipVg==}
+
+  '@tetherto/wdk-wallet@1.0.0-beta.8':
+    resolution: {integrity: sha512-eCOpPbgRrwVuB7mJS1zGVVN47n/pvX5gLRG+WERH0NmpcIS8OHxa4DYuTJ9P1qEZYRvYl4XOSrhfizC/foonDQ==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -3980,6 +3989,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.22:
+    resolution: {integrity: sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -4576,6 +4593,14 @@ packages:
 
   viem@2.49.3:
     resolution: {integrity: sha512-FlIXd2kRygDxJtvjtPp74vjmyOKMjKlXXgTNdMxr8h3kcDrQ4bYb9q1MpSWyCVa3L2NJc9gSv+u8HcHYIZQUkw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.50.4:
+    resolution: {integrity: sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -6295,7 +6320,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.2
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -6369,6 +6394,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@tetherto/wdk-failover-provider@1.0.0-beta.2': {}
 
   '@tetherto/wdk-safe-protocol-kit@6.1.3(ethers@6.14.4)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
@@ -6446,7 +6473,37 @@ snapshots:
       - sodium-javascript
       - utf-8-validate
 
+  '@tetherto/wdk-wallet-evm@1.0.0-beta.12(bare-abort-controller@1.1.2)(bare-buffer@3.6.0)(bare-events@2.8.3(bare-abort-controller@1.1.2))(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))(bare-url@2.4.3)':
+    dependencies:
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
+      '@noble/secp256k1': 2.2.3
+      '@tetherto/wdk-failover-provider': 1.0.0-beta.2
+      '@tetherto/wdk-wallet': 1.0.0-beta.8(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))
+      bare-node-runtime: 1.3.1(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))
+      bip39: 3.1.0
+      ethers: 6.14.4
+      sodium-universal: 5.0.1(bare-abort-controller@1.1.2)(bare-buffer@3.6.0)(bare-events@2.8.3(bare-abort-controller@1.1.2))(bare-url@2.4.3)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bare-events
+      - bare-tcp
+      - bare-url
+      - bufferutil
+      - react-native-b4a
+      - sodium-javascript
+      - utf-8-validate
+
   '@tetherto/wdk-wallet@1.0.0-beta.7(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))':
+    dependencies:
+      bare-node-runtime: 1.3.1(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))
+      bip39: 3.1.0
+    transitivePeerDependencies:
+      - bare-tcp
+      - react-native-b4a
+
+  '@tetherto/wdk-wallet@1.0.0-beta.8(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))':
     dependencies:
       bare-node-runtime: 1.3.1(bare-tcp@2.2.13(bare-abort-controller@1.1.2)(bare-buffer@3.6.0))
       bip39: 3.1.0
@@ -8844,6 +8901,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.22(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -9416,6 +9488,23 @@ snapshots:
       abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
       isows: 1.0.7(ws@8.20.1)
       ox: 0.14.20(typescript@6.0.3)(zod@4.4.3)
+      ws: 8.20.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.50.4(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.22(typescript@6.0.3)(zod@4.4.3)
       ws: 8.20.1
     optionalDependencies:
       typescript: 6.0.3


### PR DESCRIPTION
## Summary

Follow-up on the dependency audit posted on #680 ([comment](https://github.com/morpho-org/sdks/pull/680#issuecomment-4496245807)). Bumps each outdated pin in `packages/wdk-protocol-lending-morpho-evm/package.json` to the latest release **within the current major** (no major upgrades, no code changes).

- `@tetherto/wdk-wallet` `1.0.0-beta.7` → `1.0.0-beta.8`
- `@tetherto/wdk-wallet-evm` `1.0.0-beta.11` → `1.0.0-beta.12` (stays on 1.x; `2.0.0-rc.1` is the next major and out of scope here)
- `viem` devDep `^2.49.3` → `^2.50.4` (lockfile now resolves 2.50.4; the `^2.0.0` peer range is unchanged)
- `cross-env@^7.0.3` and `jest@^29.7.0` are already at the latest release on their majors — no bump (bumping would be a major upgrade).

Targets the #680 branch so the migration PR lands with up-to-date pins.

## Repo rule checklist

- §2/§8 — no source-code edits; only `package.json`, `pnpm-lock.yaml`, and a changeset.
- §7 — patch changeset added at `.changeset/bump-wdk-tether-deps.md` (runtime-dep change to a published package).
- Major-version pins respected; no `2.0.0-rc.1`, no `cross-env@10`, no `jest@30`.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779266370221549)
<!-- slack-thread-ts:1779266370.221549 -->