### PR TITLE
docs(agents): default to omitting Low-severity findings in PR review

### DIFF
--- a/.agents/lib/pr-review-base.md
+++ b/.agents/lib/pr-review-base.md
@@ -120,6 +120,7 @@ Shared per-agent contract (applied uniformly to every launched persona):
 - Agents must analyze the **full diff**, not just the latest commit.
 - Each agent **must return** a JSON array `[{severity: "critical"|"high"|"medium"|"low", file: "path", line: number, description: "what is wrong + how to fix"}]` OR an explicit error sentinel `{"agent_error": "<reason>"}` if it could not complete (the aggregator in Step 6 distinguishes "no findings" from "agent failed").
 - **Stay in scope (avoid scope creep).** Focus on the diff: flag issues introduced by these changes, and issues in adjacent code only when the diff makes that adjacent code materially worse (e.g. a renamed function whose remaining callers now misbehave, a new code path that exposes an existing bug). Do NOT flag pre-existing issues in unchanged lines of changed files, propose unrelated refactors, suggest new features or abstractions, or recommend cleanups outside the PR's intent. When in doubt, omit — the reviewer is reviewing *this change*, not the file's history.
+- **Default to omitting Low-severity findings.** Only include a Low finding when it would mislead a future reader or compound with another finding on the same code. Polish, wording, and stylistic preferences are not findings.
 - Only **actionable** findings — no praise, no summaries.
 
 ### Current persona inventory


### PR DESCRIPTION
## Summary

Adds a structural nitpick guard to the shared per-agent contract in `.agents/lib/pr-review-base.md` (Step 5):

> **Default to omitting Low-severity findings.** Only include a Low finding when it would mislead a future reader or compound with another finding on the same code. Polish, wording, and stylistic preferences are not findings.

## Why

Audit of the existing review tooling found a gap. Scope-creep is well-handled (explicit "Stay in scope" clause + per-persona `out-of-scope:` frontmatter + aggregator path filter). But the nitpick guard is essentially absent:

- The base says *"Only actionable findings"* and never defines "actionable".
- The Step 6 aggregator path-filters out-of-scope findings but has no severity floor — Lows pass through untouched.
- Personas enumerate what *makes* a Low finding (e.g. `style-conventions` lists "JSDoc-only diff without a patch changeset") but never tell agents to *withhold* Lows by default.

Concretely, this surfaced after a docs-only PR review where the only thing keeping the output clean was passing `make sure to not scope creep or nitpick` as a manual directive. That should be the default, not user-supplied.

## How

One bullet, one file. Broadcasts to every launched persona (baseline + conditional) via the existing per-agent contract — no per-persona edits required. The clause allows compounding Lows on the same code path when they would mislead a future reader together, so legitimately-related low-severity signal still gets through.

## Test Plan

- [x] `git diff --check`
- [ ] Sanity-run `/pr-review-local` (or `/pr-review-gh`) on a recent PR after this lands and confirm Low-severity polish suggestions are now omitted by default.

## Changeset

Not needed — agent/review documentation only; no published package source changed.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779272376842079)
<!-- slack-thread-ts:1779272376.842079 -->