### PR TITLE
test(liquidity-sdk-viem): cover loader edge cases

### DIFF
--- a/packages/liquidity-sdk-viem/src/loader.test.ts
+++ b/packages/liquidity-sdk-viem/src/loader.test.ts
@@ -485,7 +485,7 @@ const setupLoaderMockClient = ({
 
 const mockApiMarkets = (
   sourceTargetWithdrawUtilization = MathLib.WAD,
-  items = [
+  items: readonly Record<string, unknown>[] = [
     {
       uniqueKey: targetMarketId,
       targetBorrowUtilization: "900000000000000000",
@@ -671,5 +671,66 @@ describe.sequential("LiquidityLoader.fetch", () => {
     ).rejects.toThrow(
       "did not return a Promise of an Array of the same length",
     );
+  });
+
+  test("rejects when the API response omits the markets list", async () => {
+    const handle = setupLoaderMockClient({ blockTimestamp: 100n });
+    nock(new URL(BLUE_API_GRAPHQL_URL).origin)
+      .post("/graphql")
+      .reply(200, { data: { markets: {} } });
+
+    await expect(
+      new LiquidityLoader(handle.client).fetch(targetMarketId),
+    ).rejects.toThrow(
+      "did not return a Promise of an Array of the same length",
+    );
+  });
+
+  test("returns an empty plan when supplying vaults are missing", async () => {
+    const handle = setupLoaderMockClient({ blockTimestamp: 100n });
+    mockApiMarkets(MathLib.WAD, [
+      {
+        uniqueKey: targetMarketId,
+        targetBorrowUtilization: "900000000000000000",
+        publicAllocatorSharedLiquidity: [],
+      },
+    ]);
+
+    await expect(
+      new LiquidityLoader(handle.client).fetch(targetMarketId),
+    ).resolves.toMatchObject({ withdrawals: [] });
+  });
+
+  test("returns an empty plan when vault allocation is missing", async () => {
+    const handle = setupLoaderMockClient({ blockTimestamp: 100n });
+    mockApiMarkets(MathLib.WAD, [
+      {
+        uniqueKey: targetMarketId,
+        targetBorrowUtilization: "900000000000000000",
+        publicAllocatorSharedLiquidity: [],
+        supplyingVaults: [{ address: vault }],
+      },
+    ]);
+
+    await expect(
+      new LiquidityLoader(handle.client).fetch(targetMarketId),
+    ).resolves.toMatchObject({ withdrawals: [] });
+  });
+
+  test("rejects with the per-market simulation error when utilization overrides throw", async () => {
+    const handle = setupLoaderMockClient({ blockTimestamp: 100n });
+    const maxWithdrawalUtilization = {} as Record<MarketId, bigint>;
+    Object.defineProperty(maxWithdrawalUtilization, sourceMarketId, {
+      get() {
+        throw new TypeError("bad utilization override");
+      },
+    });
+    mockApiMarkets();
+
+    await expect(
+      new LiquidityLoader(handle.client, {
+        maxWithdrawalUtilization,
+      }).fetch(targetMarketId),
+    ).rejects.toThrow(/^An error occurred while simulating reallocations:/);
   });
 });


### PR DESCRIPTION
## Summary

- add loader unit tests for missing GraphQL `items`, `supplyingVaults`, and vault allocation fallback paths
- add coverage for the per-market simulation error wrapping branch
- keep the new tests colocated in `packages/liquidity-sdk-viem/src/loader.test.ts` per the unit-test coverage TIB

## Impact

This brings the hand-written `liquidity-sdk-viem` loader surface to full focused unit coverage without changing runtime behavior.

## Coverage Delta

Focused run over `packages/liquidity-sdk-viem/src/**/*.{ts,tsx}`:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Lines | 97.5% | 100% | +2.5 pp |
| Branches | 60% | 100% | +40 pp |
| Functions | 100% | 100% | +0 pp |

## Validation

- `pnpm vitest run packages/liquidity-sdk-viem/src/loader.test.ts packages/liquidity-sdk-viem/src/api/index.test.ts --coverage --coverage.reporter=text --coverage.include='packages/liquidity-sdk-viem/src/**/*.{ts,tsx}' --coverage.reportOnFailure=true`
- `pnpm --filter @morpho-org/liquidity-sdk-viem exec tsc --noEmit`
- `pnpm biome check packages/liquidity-sdk-viem/src/loader.test.ts`
- `git diff --check`

Note: a full `--project liquidity-sdk-viem` run starts existing fork tests and was blocked locally by the default mainnet RPC returning Cloudflare 1015 rate limits.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779888328754559)
<!-- slack-thread-ts:1779888328.754559 -->