### PR TITLE
test(morpho-ts): reach full coverage

### DIFF
--- a/packages/morpho-ts/src/format/format/format.ts
+++ b/packages/morpho-ts/src/format/format/format.ts
@@ -64,6 +64,7 @@ const insertString = (
 
   let filler = "";
   if (offset < 0) {
+    /* v8 ignore next -- callers only omit fillWith when offset stays non-negative. */
     if (fillWith) filler = fillWith.repeat(-offset).slice(offset);
     offset = 0;
   }
@@ -178,6 +179,7 @@ const _withUnit = (value: string, unit?: string) => {
   switch (unit) {
     case "$":
       return `$${value}`;
+    /* v8 ignore next -- empty string is handled by the falsy-unit guard above. */
     case "":
     case "%":
       return `${value}${unit}`;
@@ -385,8 +387,10 @@ export abstract class BaseFormatter {
 
         const strValue = `${whole}${newDigits.slice(0, numberExp)}.${newDigits.slice(numberExp)}`;
 
+        /* v8 ignore start -- strValue always includes the decimal separator above. */
         // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
         decimals = strValue.split(".")[1]?.length ?? 0;
+        /* v8 ignore stop */
         // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
         value = BigInt(strValue.replace(".", ""));
       } else {

--- a/packages/morpho-ts/src/format/locale.test.ts
+++ b/packages/morpho-ts/src/format/locale.test.ts
@@ -33,12 +33,12 @@ describe("getLocaleSymbols", () => {
 
   test("falls back to en-US when locale is invalid", () => {
     // The function still echoes back the input locale string but uses en-US formatter on RangeError
-    const r = getLocaleSymbols("not-a-real-locale");
+    const r = getLocaleSymbols("not-a-real-locale!");
     // The decimal/group come from the en-US fallback
     expect(r.decimalSymbol).toBe(".");
     expect(r.groupSymbol).toBe(",");
     // Locale string is echoed back as-is
-    expect(r.locale).toBe("not-a-real-locale");
+    expect(r.locale).toBe("not-a-real-locale!");
   });
 });
 

--- a/packages/morpho-ts/src/time/time.ts
+++ b/packages/morpho-ts/src/time/time.ts
@@ -57,6 +57,7 @@ Object.defineProperties(
                   unitFrom,
                   (value: bigint | number) => {
                     switch (unitFrom) {
+                      /* v8 ignore next -- unitFrom cannot be ms in this larger-unit conversion branch. */
                       case "ms":
                         return value;
                       case "s":
@@ -123,4 +124,5 @@ export namespace Time {
   export function timestamp() {
     return BigInt(Math.ceil(Date.now() / 1_000));
   }
+  /* v8 ignore next -- TypeScript emits an untestable namespace-merge fallback branch. */
 }

--- a/packages/morpho-ts/test/format.test.ts
+++ b/packages/morpho-ts/test/format.test.ts
@@ -82,6 +82,23 @@ describe("format", () => {
       expect(customOptions.default).toBe(undefined);
     });
 
+    test("should create every custom formatter type", () => {
+      const customFormat = createFormat(
+        { all: { digits: 2 } },
+        {
+          customCommas: { format: Format.commas, unit: "ETH" },
+          customHex: { format: Format.hex, prefix: true },
+          customPercent: { format: Format.percent, unit: "%" },
+          customShort: { format: Format.short, unit: "USD" },
+        },
+      );
+
+      expect(customFormat.customCommas.of(1234.5)).toEqual("1,234.50 ETH");
+      expect(customFormat.customHex.of(255)).toEqual("0xff");
+      expect(customFormat.customPercent.of(0.1234)).toEqual("12.34%");
+      expect(customFormat.customShort.of(12345)).toEqual("12.34k USD");
+    });
+
     test("shouldn't create conflicts between formatters", () => {
       const formatters = createFormat();
 
@@ -117,6 +134,10 @@ describe("format", () => {
     describe("should properly format number in hex format", () => {
       test("without option", () => {
         expect(format.hex.of(number)).toEqual((123456789).toString(16));
+      });
+
+      test("with prefix", () => {
+        expect(format.hex.prefix().of(number)).toEqual("0x75bcd15");
       });
 
       test("with a default value", () => {
@@ -219,6 +240,10 @@ describe("format", () => {
         expect(format.number.digits(2).of(number)).toEqual("12345.67");
       });
 
+      test("with readable small values", () => {
+        expect(format.number.digits(2).readable().of(0.001)).toEqual("< 0.01");
+      });
+
       test("with min", () => {
         expect(format.number.min(20000).of(number)).toEqual("< 20000.0000");
       });
@@ -291,6 +316,10 @@ describe("format", () => {
     describe("should properly format bigint in number format", () => {
       test("without option", () => {
         expect(format.number.of(bigint, decimals)).toEqual("12345.6789");
+      });
+
+      test("with non-standard negative decimals", () => {
+        expect(format.number.of(bigint, -2)).toEqual("12.3456789");
       });
 
       test("with digits", () => {
@@ -451,6 +480,14 @@ describe("format", () => {
     describe("should properly format bigint in short format", () => {
       test("with small integers", () => {
         expect(format.short.of(123n, 0)).toEqual("123");
+      });
+
+      test("with decimals but no short suffix", () => {
+        expect(format.short.of(123n, 2)).toEqual("1.23");
+      });
+
+      test("with larger suffixes", () => {
+        expect(format.short.of(1_234_567n, 0)).toEqual("1.234567M");
       });
 
       test("without option", () => {
@@ -619,6 +656,10 @@ describe("format", () => {
     describe("should properly format bigint in commas format", () => {
       test("without option", () => {
         expect(format.commas.of(bigint, decimals)).toEqual("12,345.6789");
+      });
+
+      test("without decimals", () => {
+        expect(format.commas.of(123456n, 0)).toEqual("123,456");
       });
 
       test("with digits", () => {


### PR DESCRIPTION
## Summary

- Add focused morpho-ts formatter tests for custom formatter variants, readable small values, short suffixes, zero-decimal commas, and hex prefixes.
- Exercise the locale fallback branch with a locale string that actually throws.
- Mark unreachable private/generated coverage branches with `v8 ignore` comments; no runtime behavior is changed.

## Coverage Delta

Measured with `pnpm exec vitest --project morpho-ts --coverage --coverage.reporter=text "--coverage.include=packages/morpho-ts/src/**/*.ts"`.

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Lines | 96.32% (288/299) | 100% (296/296) | +3.68 pp |
| Branches | 90.25% (176/195) | 100% (187/187) | +9.75 pp |
| Functions | 97.77% (88/90) | 100% (90/90) | +2.23 pp |

The after denominators change because unreachable private/generated branches are explicitly excluded from coverage while reachable paths are covered by tests.

## Validation

- `pnpm exec vitest --project morpho-ts --coverage --coverage.reporter=text "--coverage.include=packages/morpho-ts/src/**/*.ts"` passes with 100% statements, branches, functions, and lines.
- `pnpm --filter @morpho-org/morpho-ts build` passes.
- `pnpm lint` passes.
- `git diff --check` passes.
- `pnpm test` was run before this no-behavior revision and failed in unrelated non-morpho-ts suites: fork/API-dependent failures in `liquidation-sdk-viem`, `migration-sdk-viem`, `bundler-sdk-viem`, unrelated `morpho-sdk` spy assertions, and release-script timeouts.