### PR TITLE
fix: publish npm source metadata

### DIFF
--- a/.changeset/fix-npm-source-metadata.md
+++ b/.changeset/fix-npm-source-metadata.md
@@ -1,0 +1,20 @@
+---
+"@morpho-org/blue-sdk": patch
+"@morpho-org/blue-sdk-viem": patch
+"@morpho-org/blue-sdk-wagmi": patch
+"@morpho-org/bundler-sdk-viem": patch
+"@morpho-org/evm-simulation": patch
+"@morpho-org/liquidation-sdk-viem": patch
+"@morpho-org/liquidity-sdk-viem": patch
+"@morpho-org/migration-sdk-viem": patch
+"@morpho-org/morpho-sdk": patch
+"@morpho-org/morpho-test": patch
+"@morpho-org/morpho-ts": patch
+"@morpho-org/simulation-sdk": patch
+"@morpho-org/simulation-sdk-wagmi": patch
+"@morpho-org/test": patch
+"@morpho-org/test-wagmi": patch
+"@morpho-org/wdk-protocol-lending-morpho-evm": patch
+---
+
+Fix npm source metadata by publishing full repository URLs and monorepo package directories.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/blue-sdk-viem/package.json
+++ b/packages/blue-sdk-viem/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/blue-sdk-viem"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/blue-sdk-wagmi/package.json
+++ b/packages/blue-sdk-wagmi/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/blue-sdk-wagmi"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/blue-sdk/package.json
+++ b/packages/blue-sdk/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/blue-sdk"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/bundler-sdk-viem/package.json
+++ b/packages/bundler-sdk-viem/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/bundler-sdk-viem"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/evm-simulation/package.json
+++ b/packages/evm-simulation/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/evm-simulation"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/liquidation-sdk-viem/package.json
+++ b/packages/liquidation-sdk-viem/package.json
@@ -7,7 +7,11 @@
     "Rubilmax <rmilon@gmail.com>"
   ],
   "license": "MIT",
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/liquidation-sdk-viem"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/liquidity-sdk-viem/package.json
+++ b/packages/liquidity-sdk-viem/package.json
@@ -7,7 +7,11 @@
     "Rubilmax <rmilon@gmail.com>"
   ],
   "license": "MIT",
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/liquidity-sdk-viem"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/migration-sdk-viem/package.json
+++ b/packages/migration-sdk-viem/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "oumar-fall"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/migration-sdk-viem"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/morpho-sdk/package.json
+++ b/packages/morpho-sdk/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Foulks-Plb <https://x.com/FoulkPlb>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/morpho-sdk"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/morpho-test/package.json
+++ b/packages/morpho-test/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/morpho-test"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/morpho-ts/package.json
+++ b/packages/morpho-ts/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/morpho-ts"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/simulation-sdk-wagmi/package.json
+++ b/packages/simulation-sdk-wagmi/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/simulation-sdk-wagmi"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/simulation-sdk/package.json
+++ b/packages/simulation-sdk/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/simulation-sdk"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/test-wagmi/package.json
+++ b/packages/test-wagmi/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/test-wagmi"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -6,7 +6,11 @@
   "contributors": [
     "Rubilmax <rmilon@gmail.com>"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/test"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",

--- a/packages/wdk-protocol-lending-morpho-evm/package.json
+++ b/packages/wdk-protocol-lending-morpho-evm/package.json
@@ -17,7 +17,11 @@
   "contributors": [
     "Morpho Labs"
   ],
-  "repository": "github:morpho-org/sdks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morpho-org/sdks.git",
+    "directory": "packages/wdk-protocol-lending-morpho-evm"
+  },
   "homepage": "https://github.com/morpho-org/sdks",
   "bugs": {
     "url": "https://github.com/morpho-org/sdks/issues",


### PR DESCRIPTION
## Summary

- Replace shorthand `repository` metadata with full git repository objects.
- Add `repository.directory` for every published package in the monorepo.
- Add a patch changeset so the corrected package metadata is published to npm.

## Root cause

The npm provenance attestations point to commits in `morpho-org/sdks`, but the published package manifests used the shorthand `github:morpho-org/sdks` repository value and did not identify each package's monorepo directory. npm's package page source-link checks can fail to reconcile that metadata for published workspace packages.

## Validation

- `pnpm lint`
- `pnpm changeset status --since origin/main`
- `pnpm --dir packages/blue-sdk pack --pack-destination <tmp>` and inspected `package/package.json` from the tarball to confirm the full repository object and `packages/blue-sdk` directory are included.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1779888802173429)
<!-- slack-thread-ts:1779888802.173429 -->