### PR TITLE
docs(blue-sdk): Add blue-sdk JSDoc coverage

### DIFF
--- a/.changeset/blue-sdk-jsdoc-coverage.md
+++ b/.changeset/blue-sdk-jsdoc-coverage.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk": minor
+---
+
+Add JSDoc coverage for the exported blue-sdk surface.

--- a/packages/blue-sdk/src/__test__/fixtures.ts
+++ b/packages/blue-sdk/src/__test__/fixtures.ts
@@ -13,22 +13,33 @@ import type { IVaultMarketConfig } from "../vault/VaultMarketConfig.js";
 import type { IVaultV2 } from "../vault/v2/VaultV2.js";
 import type { IVaultV2Adapter } from "../vault/v2/VaultV2Adapter.js";
 
+/** @internal */
 export const USER = "0x0000000000000000000000000000000000000001" as Address;
+/** @internal */
 export const LOAN_TOKEN =
   "0x0000000000000000000000000000000000000002" as Address;
+/** @internal */
 export const COLLATERAL_TOKEN =
   "0x0000000000000000000000000000000000000003" as Address;
+/** @internal */
 export const ORACLE = "0x0000000000000000000000000000000000000004" as Address;
+/** @internal */
 export const IRM = "0x0000000000000000000000000000000000000005" as Address;
+/** @internal */
 export const VAULT_ADDRESS =
   "0x0000000000000000000000000000000000000006" as Address;
+/** @internal */
 export const ADAPTER = "0x0000000000000000000000000000000000000007" as Address;
+/** @internal */
 export const LIQUIDITY_ADAPTER =
   "0x0000000000000000000000000000000000000008" as Address;
+/** @internal */
 export const RECIPIENT =
   "0x0000000000000000000000000000000000000009" as Address;
+/** @internal */
 export const EMPTY_HEX = "0x" as Hex;
 
+/** @internal */
 export function marketParams(
   overrides: Partial<IMarketParams> = {},
 ): IMarketParams {
@@ -42,6 +53,7 @@ export function marketParams(
   };
 }
 
+/** @internal */
 export function marketInput(overrides: Partial<IMarket> = {}): IMarket {
   return {
     params: marketParams(),
@@ -57,10 +69,12 @@ export function marketInput(overrides: Partial<IMarket> = {}): IMarket {
   };
 }
 
+/** @internal */
 export function market(overrides: Partial<IMarket> = {}) {
   return new Market(marketInput(overrides));
 }
 
+/** @internal */
 export function positionInput(overrides: Partial<IPosition> = {}): IPosition {
   const m = market();
   return {
@@ -73,6 +87,7 @@ export function positionInput(overrides: Partial<IPosition> = {}): IPosition {
   };
 }
 
+/** @internal */
 export function accrualPosition(
   positionOverrides: Partial<IAccrualPosition> = {},
   marketOverrides: Partial<IMarket> = {},
@@ -89,6 +104,7 @@ export function accrualPosition(
   );
 }
 
+/** @internal */
 export function vaultConfig(
   overrides: Partial<IVaultConfig> = {},
 ): IVaultConfig {
@@ -102,6 +118,7 @@ export function vaultConfig(
   };
 }
 
+/** @internal */
 export function vaultInput(overrides: Partial<IVault> = {}): IVault {
   return {
     ...vaultConfig(),
@@ -124,6 +141,7 @@ export function vaultInput(overrides: Partial<IVault> = {}): IVault {
   };
 }
 
+/** @internal */
 export function vaultMarketConfig(
   marketId: MarketId,
   overrides: Partial<IVaultMarketConfig> = {},
@@ -139,6 +157,7 @@ export function vaultMarketConfig(
   };
 }
 
+/** @internal */
 export function vaultV2Input(overrides: Partial<IVaultV2> = {}): IVaultV2 {
   return {
     address: VAULT_ADDRESS,
@@ -170,6 +189,7 @@ export function vaultV2Input(overrides: Partial<IVaultV2> = {}): IVaultV2 {
   };
 }
 
+/** @internal */
 export function vaultV2AdapterInput(
   overrides: Partial<IVaultV2Adapter> = {},
 ): IVaultV2Adapter {

--- a/packages/blue-sdk/src/addresses.ts
+++ b/packages/blue-sdk/src/addresses.ts
@@ -16,6 +16,7 @@ import type { Address } from "./types.js";
  */
 export const NATIVE_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 
+/** Registry entry for protocol, adapter, factory, and token addresses on one chain. */
 export interface ChainAddresses {
   morpho: Address;
   permit2?: Address;
@@ -830,6 +831,7 @@ const _addressesRegistry = {
   },
 } as const;
 
+/** Deployment block registry with the same shape as `ChainAddresses`. */
 export type ChainDeployments<Addresses = ChainAddresses> = {
   [key in keyof Addresses]: Address extends Addresses[key]
     ? bigint
@@ -1447,8 +1449,23 @@ const _deployments = {
   },
 } as const satisfies Record<ChainId, ChainDeployments>;
 
+/** Dot-separated label for an address entry in the chain registry. */
 export type AddressLabel = DottedKeys<(typeof _addressesRegistry)[ChainId]>;
 
+/**
+ * Returns the protocol address registry for a chain.
+ *
+ * @param chainId - The EIP-155 chain id.
+ * @returns The configured protocol, adapter, factory, and token addresses for `chainId`.
+ * @throws {UnsupportedChainIdError} when no address registry exists for `chainId`.
+ * @example
+ * ```ts
+ * import { ChainId, getChainAddresses } from "@morpho-org/blue-sdk";
+ *
+ * const chainAddresses = getChainAddresses(ChainId.EthMainnet);
+ * // chainAddresses satisfies ChainAddresses
+ * ```
+ */
 export const getChainAddresses = (chainId: number): ChainAddresses => {
   const chainAddresses = addresses[chainId];
   if (chainAddresses == null) throw new UnsupportedChainIdError(chainId);
@@ -1592,6 +1609,20 @@ const _unwrappedTokensMapping: Record<number, Record<Address, Address>> = {
   },
 };
 
+/**
+ * Returns the unwrapped token mapped to a wrapped token on a chain.
+ *
+ * @param wrappedToken - The wrapped token address to resolve.
+ * @param chainId - The EIP-155 chain id.
+ * @returns The unwrapped token address, or `undefined` when no mapping is registered.
+ * @example
+ * ```ts
+ * import { ChainId, getUnwrappedToken, NATIVE_ADDRESS, addresses } from "@morpho-org/blue-sdk";
+ *
+ * const unwrapped = getUnwrappedToken(addresses[ChainId.EthMainnet].wNative!, ChainId.EthMainnet);
+ * // unwrapped === NATIVE_ADDRESS
+ * ```
+ */
 export function getUnwrappedToken(wrappedToken: Address, chainId: number) {
   return unwrappedTokensMapping[chainId]?.[wrappedToken];
 }
@@ -1632,6 +1663,19 @@ export const permissionedCoinbaseTokens: Record<number, Set<Address>> = {
   ]),
 };
 
+/**
+ * Returns the known Coinbase-attested wrapped tokens for a chain.
+ *
+ * @param chainId - The EIP-155 chain id.
+ * @returns A set of permissioned wrapped token addresses, or an empty set when none are registered.
+ * @example
+ * ```ts
+ * import { ChainId, getPermissionedCoinbaseTokens } from "@morpho-org/blue-sdk";
+ *
+ * const tokens = getPermissionedCoinbaseTokens(ChainId.BaseMainnet);
+ * // tokens satisfies Set<Address>
+ * ```
+ */
 export const getPermissionedCoinbaseTokens = (chainId: number) =>
   permissionedCoinbaseTokens[chainId] ?? new Set();
 
@@ -1667,9 +1711,13 @@ export const convexWrapperTokens: Record<number, Set<Address>> = {
   ]),
 };
 
+/** Deep-frozen registry of known chain addresses, keyed by chain id. */
 export let addressesRegistry = deepFreeze(_addressesRegistry);
+/** Address registry keyed by numeric chain id. */
 export let addresses = addressesRegistry as Record<number, ChainAddresses>;
+/** Deep-frozen registry of deployment blocks, keyed by chain id. */
 export let deployments = deepFreeze(_deployments);
+/** Deep-frozen registry of wrapped token to unwrapped token mappings. */
 export let unwrappedTokensMapping = deepFreeze(_unwrappedTokensMapping);
 
 /**
@@ -1687,6 +1735,7 @@ export let unwrappedTokensMapping = deepFreeze(_unwrappedTokensMapping);
  *                              Must provide all required deployments if chain is unknown.
  *
  * @throws {Error} If attempting to override an existing address.
+ * @returns Nothing.
  *
  * @example
  * ```ts

--- a/packages/blue-sdk/src/chain.ts
+++ b/packages/blue-sdk/src/chain.ts
@@ -1,3 +1,4 @@
+/** Supported EIP-155 chain ids with Morpho Blue deployments or registry metadata. */
 export enum ChainId {
   EthMainnet = 1,
   BaseMainnet = 8453,
@@ -41,6 +42,7 @@ export enum ChainId {
   ArcMainnet = 5042,
 }
 
+/** Explorer, native currency, and identifier metadata for a supported chain. */
 export interface ChainMetadata {
   readonly name: string;
   readonly id: ChainId;
@@ -55,7 +57,21 @@ export interface ChainMetadata {
   readonly hasReliableNativeBalance?: boolean;
 }
 
+/** Chain metadata helpers and registries. */
 export namespace ChainUtils {
+  /**
+   * Returns whether native token balances are reliable on a chain.
+   *
+   * @param chainId - The EIP-155 chain id to inspect.
+   * @returns `false` only for chains whose metadata marks native balances as unreliable.
+   * @example
+   * ```ts
+   * import { ChainId, ChainUtils } from "@morpho-org/blue-sdk";
+   *
+   * const reliable = ChainUtils.hasReliableNativeBalance(ChainId.EthMainnet);
+   * // reliable === true
+   * ```
+   */
   export const hasReliableNativeBalance = (chainId: number): boolean => {
     return (
       (CHAIN_METADATA as Record<number, ChainMetadata | undefined>)[chainId]
@@ -63,22 +79,77 @@ export namespace ChainUtils {
     );
   };
 
+  /**
+   * Converts a supported chain id to its hexadecimal JSON-RPC form.
+   *
+   * @param chainId - The supported chain id.
+   * @returns The chain id as a `0x`-prefixed hexadecimal string.
+   * @example
+   * ```ts
+   * import { ChainId, ChainUtils } from "@morpho-org/blue-sdk";
+   *
+   * const hexChainId = ChainUtils.toHexChainId(ChainId.EthMainnet);
+   * // hexChainId === "0x1"
+   * ```
+   */
   export const toHexChainId = (chainId: ChainId) => {
     return `0x${chainId.toString(16)}`;
   };
 
+  /**
+   * Returns the block explorer base URL for a supported chain.
+   *
+   * @param chainId - The supported chain id.
+   * @returns The chain's configured block explorer base URL.
+   * @example
+   * ```ts
+   * import { ChainId, ChainUtils } from "@morpho-org/blue-sdk";
+   *
+   * const explorerUrl = ChainUtils.getExplorerUrl(ChainId.EthMainnet);
+   * // explorerUrl === "https://etherscan.io"
+   * ```
+   */
   export const getExplorerUrl = (chainId: ChainId) => {
     return ChainUtils.CHAIN_METADATA[chainId].explorerUrl;
   };
 
+  /**
+   * Returns a block explorer address URL for a supported chain.
+   *
+   * @param chainId - The supported chain id.
+   * @param address - The address to link to.
+   * @returns The block explorer URL for `address`.
+   * @example
+   * ```ts
+   * import { ChainId, ChainUtils, NATIVE_ADDRESS } from "@morpho-org/blue-sdk";
+   *
+   * const url = ChainUtils.getExplorerAddressUrl(ChainId.EthMainnet, NATIVE_ADDRESS);
+   * // url satisfies string
+   * ```
+   */
   export const getExplorerAddressUrl = (chainId: ChainId, address: string) => {
     return `${getExplorerUrl(chainId)}/address/${address}`;
   };
 
+  /**
+   * Returns a block explorer transaction URL for a supported chain.
+   *
+   * @param chainId - The supported chain id.
+   * @param tx - The transaction hash to link to.
+   * @returns The block explorer URL for `tx`.
+   * @example
+   * ```ts
+   * import { ChainId, ChainUtils } from "@morpho-org/blue-sdk";
+   *
+   * const url = ChainUtils.getExplorerTransactionUrl(ChainId.EthMainnet, "0xabc");
+   * // url satisfies string
+   * ```
+   */
   export const getExplorerTransactionUrl = (chainId: ChainId, tx: string) => {
     return `${getExplorerUrl(chainId)}/tx/${tx}`;
   };
 
+  /** Metadata for each supported chain, keyed by `ChainId`. */
   export const CHAIN_METADATA = {
     [ChainId.EthMainnet]: {
       name: "Ethereum",

--- a/packages/blue-sdk/src/errors.ts
+++ b/packages/blue-sdk/src/errors.ts
@@ -1,44 +1,52 @@
 import { formatUnits, type Hex } from "viem";
 import type { Address, MarketId } from "./types.js";
 
+/** Error thrown when bytes cannot be decoded into valid Morpho Blue market params. */
 export class InvalidMarketParamsError extends Error {
   constructor(public readonly data: Hex) {
     super(`cannot decode valid MarketParams from "${data}"`);
   }
 }
 
+/** Base error for optional data lookups that were not available. */
 export class UnknownDataError extends Error {}
 
+/** Error thrown when token metadata is unavailable for an address. */
 export class UnknownTokenError extends UnknownDataError {
   constructor(public readonly address: Address) {
     super(`unknown token ${address}`);
   }
 }
 
+/** Error thrown when a token price is unavailable for an address. */
 export class UnknownTokenPriceError extends UnknownDataError {
   constructor(public readonly address: Address) {
     super(`unknown price of token ${address}`);
   }
 }
 
+/** Error thrown when market params are unavailable for a market id. */
 export class UnknownMarketParamsError extends UnknownDataError {
   constructor(public readonly marketId: MarketId) {
     super(`unknown config for market ${marketId}`);
   }
 }
 
+/** Error thrown when vault config is unavailable for a vault address. */
 export class UnknownVaultConfigError extends UnknownDataError {
   constructor(public readonly vault: Address) {
     super(`unknown config for vault ${vault}`);
   }
 }
 
+/** Error thrown when a chain id has no configured SDK registry entry. */
 export class UnsupportedChainIdError extends Error {
   constructor(public readonly chainId: number) {
     super(`unsupported chain ${chainId}`);
   }
 }
 
+/** Error thrown when no default pre-liquidation params exist for an LLTV. */
 export class UnsupportedPreLiquidationParamsError extends Error {
   constructor(public readonly lltv: bigint) {
     super(
@@ -47,13 +55,16 @@ export class UnsupportedPreLiquidationParamsError extends Error {
   }
 }
 
+/** Error thrown when a Vault V2 adapter address is not supported by the SDK. */
 export class UnsupportedVaultV2AdapterError extends Error {
   constructor(public readonly address: Address) {
     super(`vault v2 adapter "${address}" is not supported`);
   }
 }
 
+/** Morpho Blue protocol simulation errors. */
 export namespace BlueErrors {
+  /** Error thrown when a value that must be set once is already set. */
   export class AlreadySet extends Error {
     constructor(
       public readonly name: string,
@@ -63,6 +74,7 @@ export namespace BlueErrors {
     }
   }
 
+  /** Error thrown when market interest accrual is requested before `lastUpdate`. */
   export class InvalidInterestAccrual extends Error {
     // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
     constructor(
@@ -76,6 +88,7 @@ export namespace BlueErrors {
     }
   }
 
+  /** Error thrown when asset and share inputs describe inconsistent values. */
   export class InconsistentInput extends Error {
     constructor(
       public readonly assets: bigint,
@@ -85,18 +98,21 @@ export namespace BlueErrors {
     }
   }
 
+  /** Error thrown when a market has insufficient liquidity for an operation. */
   export class InsufficientLiquidity extends Error {
     constructor(public readonly marketId: MarketId) {
       super(`insufficient liquidity on market ${marketId}`);
     }
   }
 
+  /** Error thrown when a market oracle price is unavailable. */
   export class UnknownOraclePrice extends Error {
     constructor(public readonly marketId: MarketId) {
       super(`unknown oracle price of market "${marketId}"`);
     }
   }
 
+  /** Error thrown when a user position is too small for an operation. */
   export class InsufficientPosition extends Error {
     constructor(
       public readonly user: Address,
@@ -106,6 +122,7 @@ export namespace BlueErrors {
     }
   }
 
+  /** Error thrown when a user position lacks required collateral. */
   export class InsufficientCollateral extends Error {
     constructor(
       public readonly user: Address,
@@ -115,6 +132,7 @@ export namespace BlueErrors {
     }
   }
 
+  /** Error thrown when a signature deadline has expired. */
   export class ExpiredSignature extends Error {
     constructor(public readonly deadline: bigint) {
       super(`expired signature deadline "${deadline}"`);
@@ -122,7 +140,9 @@ export namespace BlueErrors {
   }
 }
 
+/** Morpho Vault V2 simulation errors. */
 export namespace VaultV2Errors {
+  /** Error thrown when vault interest accrual is requested before `lastUpdate`. */
   export class InvalidInterestAccrual extends Error {
     // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
     constructor(
@@ -136,6 +156,7 @@ export namespace VaultV2Errors {
     }
   }
 
+  /** Error thrown when a Vault V2 liquidity adapter is not supported by the SDK. */
   export class UnsupportedLiquidityAdapter extends Error {
     constructor(public readonly address: Address) {
       super(`unsupported liquidity adapter "${address}"`);
@@ -143,12 +164,14 @@ export namespace VaultV2Errors {
   }
 }
 
+/** Error thrown when a factory address is unavailable. */
 export class UnknownFactory extends Error {
   constructor() {
     super(`unknown factory`);
   }
 }
 
+/** Error thrown when an address is not deployed by the expected factory. */
 export class UnknownOfFactory extends Error {
   constructor(
     public readonly factory: Address,
@@ -158,19 +181,35 @@ export class UnknownOfFactory extends Error {
   }
 }
 
+/** Constructor type for errors accepted by `_try`. */
 export interface ErrorClass<E extends Error = Error> {
   // biome-ignore lint/suspicious/noExplicitAny: match any type of arg
   new (...args: any[]): E;
 }
 
+/**
+ * Runs an async accessor and returns `undefined` for expected lookup errors.
+ *
+ * @internal
+ */
 export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
   accessor: () => Promise<T>,
   ...errorClasses: ErrorClasses
 ): Promise<T | undefined>;
+/**
+ * Runs a sync accessor and returns `undefined` for expected lookup errors.
+ *
+ * @internal
+ */
 export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
   accessor: () => T,
   ...errorClasses: ErrorClasses
 ): T | undefined;
+/**
+ * Runs an accessor and returns `undefined` for expected lookup errors.
+ *
+ * @internal
+ */
 export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
   accessor: () => T | Promise<T>,
   ...errorClasses: ErrorClasses

--- a/packages/blue-sdk/src/holding/AssetBalances.ts
+++ b/packages/blue-sdk/src/holding/AssetBalances.ts
@@ -1,5 +1,6 @@
 import type { Token } from "../token/Token.js";
 
+/** Balance conversion category for a requested token and related peripheral tokens. */
 export type PeripheralBalanceType =
   | "base" // The balance of the requested token (ETH for ETH, wstETH for wstETH).
   | "wrapped" // The balance of the unwrapped token (none for DAI, wstETH for wstETH).
@@ -36,8 +37,10 @@ export interface PeripheralBalance {
   dstAmount: bigint;
 }
 
+/** Constructor input for `AssetBalances`. */
 export interface IAssetBalances extends Omit<PeripheralBalance, "type"> {}
 
+/** Aggregates balances across a requested token and related peripheral tokens. */
 export class AssetBalances {
   /**
    * The total balance of all types of related tokens.

--- a/packages/blue-sdk/src/holding/Holding.ts
+++ b/packages/blue-sdk/src/holding/Holding.ts
@@ -3,27 +3,32 @@ import { entries, fromEntries } from "@morpho-org/morpho-ts";
 import type { AddressLabel } from "../addresses.js";
 import type { Address, BigIntish } from "../types.js";
 
+/** Address registry labels that may receive ERC-20 allowances from a user. */
 export const ERC20_ALLOWANCE_RECIPIENTS = [
   "morpho",
   "permit2",
   "bundler3.generalAdapter1",
 ] as const satisfies readonly AddressLabel[];
 
+/** Address registry label that may receive an ERC-20 allowance from a user. */
 export type Erc20AllowanceRecipient =
   (typeof ERC20_ALLOWANCE_RECIPIENTS)[number];
 
+/** Normalized Permit2 allowance values. */
 export interface Permit2Allowance {
   amount: bigint;
   expiration: bigint;
   nonce: bigint;
 }
 
+/** Input shape for Permit2 allowance values before bigint normalization. */
 export interface IPermit2Allowance {
   amount: BigIntish;
   expiration: BigIntish;
   nonce: BigIntish;
 }
 
+/** Input shape for a user's token holding and allowance state. */
 export interface IHolding {
   user: Address;
   token: Address;
@@ -36,6 +41,7 @@ export interface IHolding {
   balance: bigint;
 }
 
+/** Represents a user's balance and allowance state for one token. */
 export class Holding implements IHolding {
   /**
    * The user of this holding.

--- a/packages/blue-sdk/src/market/Market.ts
+++ b/packages/blue-sdk/src/market/Market.ts
@@ -10,13 +10,16 @@ import { type CapacityLimit, CapacityLimitReason } from "../utils.js";
 import { type IMarketParams, MarketParams } from "./MarketParams.js";
 import { MarketUtils } from "./MarketUtils.js";
 
+/** Options for max borrow capacity calculations. */
 export interface MaxBorrowOptions {
   maxLtv?: bigint;
 }
+/** Options for max withdraw collateral capacity calculations. */
 export interface MaxWithdrawCollateralOptions {
   maxLtv?: bigint;
 }
 
+/** Capacity limits for each market operation available to a position. */
 export interface MaxPositionCapacities {
   supply: CapacityLimit;
   withdraw: CapacityLimit;
@@ -26,6 +29,7 @@ export interface MaxPositionCapacities {
   withdrawCollateral: CapacityLimit | undefined;
 }
 
+/** Plain input shape for a Morpho Blue market. */
 export interface IMarket {
   params: IMarketParams;
   totalSupplyAssets: bigint;

--- a/packages/blue-sdk/src/market/MarketParams.ts
+++ b/packages/blue-sdk/src/market/MarketParams.ts
@@ -7,6 +7,7 @@ import {
 import type { Address, BigIntish, MarketId } from "../types.js";
 import { MarketUtils } from "./MarketUtils.js";
 
+/** Plain input shape for Morpho Blue market params. */
 export interface IMarketParams {
   loanToken: Address;
   collateralToken: Address;
@@ -15,11 +16,13 @@ export interface IMarketParams {
   lltv: BigIntish;
 }
 
+/** Minimal market params shape accepted by SDK constructors and helpers. */
 export type InputMarketParams = Pick<
   MarketParams,
   "loanToken" | "collateralToken" | "oracle" | "irm" | "lltv"
 >;
 
+/** ABI tuple definition for Morpho Blue market params. */
 export const marketParamsAbi = {
   type: "tuple",
   components: [

--- a/packages/blue-sdk/src/market/MarketUtils.ts
+++ b/packages/blue-sdk/src/market/MarketUtils.ts
@@ -18,6 +18,22 @@ export namespace MarketUtils {
   /**
    * Returns the id of a market based on its params.
    * @param market The market params.
+   * @returns The deterministic Morpho Blue market id.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const marketParams = {
+   *   loanToken: "0x0000000000000000000000000000000000000001",
+   *   collateralToken: "0x0000000000000000000000000000000000000002",
+   *   oracle: "0x0000000000000000000000000000000000000003",
+   *   irm: "0x0000000000000000000000000000000000000004",
+   *   lltv: 860_000_000_000_000_000n,
+   * } as const;
+   *
+   * const id = MarketUtils.getMarketId(marketParams);
+   * // id satisfies MarketId
+   * ```
    */
   export function getMarketId(market: IMarketParams) {
     return `0x${bytesToHex(
@@ -41,6 +57,14 @@ export namespace MarketUtils {
   /**
    * Returns the liquidation incentive factor for a given market params.
    * @param config The market params.
+   * @returns The liquidation incentive factor, scaled by WAD.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const lif = MarketUtils.getLiquidationIncentiveFactor({ lltv: 86_0000000000000000n });
+   * // lif satisfies bigint
+   * ```
    */
   export function getLiquidationIncentiveFactor({ lltv }: { lltv: BigIntish }) {
     return MathLib.min(
@@ -56,6 +80,17 @@ export namespace MarketUtils {
   /**
    * Returns the market's utilization rate (scaled by WAD).
    * @param market The market state.
+   * @returns The market utilization rate, scaled by WAD.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const utilization = MarketUtils.getUtilization({
+   *   totalSupplyAssets: 100n,
+   *   totalBorrowAssets: 50n,
+   * });
+   * // utilization === 500000000000000000n
+   * ```
    */
   export function getUtilization({
     totalSupplyAssets,
@@ -80,6 +115,14 @@ export namespace MarketUtils {
    * Returns the per-second rate continuously compounded over a year,
    * as calculated in Morpho Blue assuming the market is frequently accrued onchain.
    * @param rate The per-second rate to compound annually.
+   * @returns The annual percentage yield as a JavaScript number.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const apy = MarketUtils.rateToApy(1n);
+   * // apy satisfies number
+   * ```
    */
   export function rateToApy(rate: BigIntish) {
     return Math.expm1(+formatEther(BigInt(rate) * SECONDS_PER_YEAR));
@@ -152,6 +195,17 @@ export namespace MarketUtils {
    * Returns the smallest volume to supply until the market gets the closest to the given utilization rate.
    * @param market The market state.
    * @param utilization The target utilization rate (scaled by WAD).
+   * @returns The amount to supply to approach the target utilization.
+   * @example
+   * ```ts
+   * import { MarketUtils, MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const assets = MarketUtils.getSupplyToUtilization(
+   *   { totalSupplyAssets: 100n, totalBorrowAssets: 80n },
+   *   MathLib.WAD / 2n,
+   * );
+   * // assets satisfies bigint
+   * ```
    */
   export function getSupplyToUtilization(
     market: {
@@ -178,6 +232,17 @@ export namespace MarketUtils {
    * Returns the liquidity available to withdraw until the market gets the closest to the given utilization rate.
    * @param market The market state.
    * @param utilization The target utilization rate (scaled by WAD).
+   * @returns The amount withdrawable before reaching the target utilization.
+   * @example
+   * ```ts
+   * import { MarketUtils, MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const assets = MarketUtils.getWithdrawToUtilization(
+   *   { totalSupplyAssets: 100n, totalBorrowAssets: 50n },
+   *   MathLib.WAD,
+   * );
+   * // assets satisfies bigint
+   * ```
    */
   export function getWithdrawToUtilization(
     {
@@ -209,6 +274,17 @@ export namespace MarketUtils {
    * Returns the liquidity available to borrow until the market gets the closest to the given utilization rate.
    * @param market The market state.
    * @param utilization The target utilization rate (scaled by WAD).
+   * @returns The amount borrowable before reaching the target utilization.
+   * @example
+   * ```ts
+   * import { MarketUtils, MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const assets = MarketUtils.getBorrowToUtilization(
+   *   { totalSupplyAssets: 100n, totalBorrowAssets: 50n },
+   *   MathLib.WAD,
+   * );
+   * // assets satisfies bigint
+   * ```
    */
   export function getBorrowToUtilization(
     {
@@ -230,6 +306,17 @@ export namespace MarketUtils {
    * Returns the smallest volume to repay until the market gets the closest to the given utilization rate.
    * @param market The market state.
    * @param utilization The target utilization rate (scaled by WAD).
+   * @returns The amount to repay before reaching the target utilization.
+   * @example
+   * ```ts
+   * import { MarketUtils, MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const assets = MarketUtils.getRepayToUtilization(
+   *   { totalSupplyAssets: 100n, totalBorrowAssets: 80n },
+   *   MathLib.WAD / 2n,
+   * );
+   * // assets satisfies bigint
+   * ```
    */
   export function getRepayToUtilization(
     {
@@ -247,6 +334,20 @@ export namespace MarketUtils {
     );
   }
 
+  /**
+   * Returns the borrow power of a collateral amount before oracle pricing.
+   *
+   * @param collateral - The collateral amount.
+   * @param marketParams.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The collateral amount multiplied by LLTV.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const power = MarketUtils.getCollateralPower(100n, { lltv: 50_0000000000000000n });
+   * // power === 50n
+   * ```
+   */
   export function getCollateralPower(
     collateral: BigIntish,
     { lltv }: { lltv: BigIntish },
@@ -257,6 +358,17 @@ export namespace MarketUtils {
   /**
    * Returns the value of a given amount of collateral quoted in loan assets.
    * Return `undefined` iff the market's price is undefined.
+   *
+   * @param collateral - The collateral amount.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @returns The collateral value in loan assets, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const value = MarketUtils.getCollateralValue(2n, { price: ORACLE_PRICE_SCALE });
+   * // value === 2n
+   * ```
    */
   export function getCollateralValue(
     collateral: BigIntish,
@@ -271,6 +383,22 @@ export namespace MarketUtils {
    * Returns the maximum debt allowed given a certain amount of collateral.
    * Return `undefined` iff the market's price is undefined.
    * To calculate the amount of loan assets that can be borrowed, use `getMaxBorrowableAssets`.
+   *
+   * @param collateral - The collateral amount.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @param marketParams.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The maximum borrow assets allowed, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const maxBorrow = MarketUtils.getMaxBorrowAssets(
+   *   2n,
+   *   { price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // maxBorrow === 1n
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getMaxBorrowAssets(
@@ -287,6 +415,25 @@ export namespace MarketUtils {
   /**
    * Returns the maximum amount of loan assets that can be borrowed given a certain borrow position.
    * Return `undefined` iff the market's price is undefined.
+   *
+   * @param position.collateral - The collateral amount in the position.
+   * @param position.borrowShares - The borrow shares in the position.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @param marketParams.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The additional borrowable loan assets, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const borrowable = MarketUtils.getMaxBorrowableAssets(
+   *   { collateral: 2n, borrowShares: 0n },
+   *   { totalBorrowAssets: 0n, totalBorrowShares: 0n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // borrowable satisfies bigint | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getMaxBorrowableAssets(
@@ -317,6 +464,24 @@ export namespace MarketUtils {
   /**
    * Returns the amount of collateral that would be seized in a liquidation given a certain amount of repaid shares.
    * Return `undefined` iff the market's price is undefined.
+   *
+   * @param repaidShares - The borrow shares repaid by the liquidation.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @param config.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The seized collateral amount, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const seized = MarketUtils.getLiquidationSeizedAssets(
+   *   1n,
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 86_0000000000000000n },
+   * );
+   * // seized satisfies bigint | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getLiquidationSeizedAssets(
@@ -346,6 +511,24 @@ export namespace MarketUtils {
   /**
    * Returns the amount of borrow shares that would be repaid in a liquidation given a certain amount of seized collateral.
    * Return `undefined` iff the market's price is undefined.
+   *
+   * @param seizedAssets - The collateral amount seized by the liquidation.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @param config.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The borrow shares repaid, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const shares = MarketUtils.getLiquidationRepaidShares(
+   *   1n,
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 86_0000000000000000n },
+   * );
+   * // shares satisfies bigint | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getLiquidationRepaidShares(
@@ -372,6 +555,25 @@ export namespace MarketUtils {
   /**
    * Returns the maximum amount of collateral that is worth being seized in a liquidation given a certain borrow position.
    * Return `undefined` iff the market's price is undefined.
+   *
+   * @param position.collateral - The collateral amount in the position.
+   * @param position.borrowShares - The borrow shares in the position.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @param config.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The maximum seizable collateral, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const collateral = MarketUtils.getSeizableCollateral(
+   *   { collateral: 1n, borrowShares: 1n },
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // collateral satisfies bigint | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getSeizableCollateral(
@@ -397,6 +599,25 @@ export namespace MarketUtils {
   /**
    * Returns the amount of collateral that can be withdrawn given a certain borrow position.
    * Return `undefined` iff the market's price is undefined.
+   *
+   * @param position.collateral - The collateral amount in the position.
+   * @param position.borrowShares - The borrow shares in the position.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @param marketParams.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The withdrawable collateral amount, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const collateral = MarketUtils.getWithdrawableCollateral(
+   *   { collateral: 2n, borrowShares: 0n },
+   *   { totalBorrowAssets: 0n, totalBorrowShares: 0n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // collateral satisfies bigint | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getWithdrawableCollateral(
@@ -433,6 +654,20 @@ export namespace MarketUtils {
    * Returns whether a given borrow position is healthy.
    * Return `undefined` iff the market's price is undefined.
    * @param position The borrow position to check.
+   * @param market The market state used to value the position.
+   * @param marketParams The market params containing LLTV.
+   * @returns Whether the position is healthy, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const healthy = MarketUtils.isHealthy(
+   *   { collateral: 2n, borrowShares: 0n },
+   *   { totalBorrowAssets: 0n, totalBorrowShares: 0n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // healthy satisfies boolean | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function isHealthy(
@@ -461,6 +696,24 @@ export namespace MarketUtils {
    * Returns the price of the collateral quoted in the loan token (e.g. ETH/DAI)
    * that set the user's position to be liquidatable.
    * Returns null if the position is not a borrow.
+   *
+   * @param position.collateral - The collateral amount in the position.
+   * @param position.borrowShares - The borrow shares in the position.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param marketParams.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The liquidation price, or `null` when the position has no borrow.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const price = MarketUtils.getLiquidationPrice(
+   *   { collateral: 2n, borrowShares: 1n },
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // price satisfies bigint | null
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getLiquidationPrice(
@@ -491,6 +744,22 @@ export namespace MarketUtils {
    * Negative when healthy (the price needs to drop x%), positive when unhealthy (the price needs to soar x%).
    * Returns `undefined` iff the market's price is undefined.
    * Returns null if the position is not a borrow.
+   *
+   * @param position - The borrow position to evaluate.
+   * @param market - The market state used to value the position.
+   * @param marketParams - The market params containing LLTV.
+   * @returns The WAD-scaled price variation, `undefined`, or `null` when the position has no borrow.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const variation = MarketUtils.getPriceVariationToLiquidationPrice(
+   *   { collateral: 2n, borrowShares: 1n },
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // variation satisfies bigint | null | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getPriceVariationToLiquidationPrice(
@@ -521,6 +790,25 @@ export namespace MarketUtils {
    * Returns the health factor of a given borrow position (scaled by WAD).
    * If the debt is 0, health factor is `MaxUint256`.
    * Returns `undefined` iff the market's price is undefined.
+   *
+   * @param position.collateral - The collateral amount in the position.
+   * @param position.borrowShares - The borrow shares in the position.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @param marketParams.lltv - The market liquidation loan-to-value, scaled by WAD.
+   * @returns The WAD-scaled health factor, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const healthFactor = MarketUtils.getHealthFactor(
+   *   { collateral: 2n, borrowShares: 1n },
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // healthFactor satisfies bigint | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getHealthFactor(
@@ -552,6 +840,23 @@ export namespace MarketUtils {
    * Returns the loan-to-value ratio of a given borrow position (scaled by WAD).
    * Returns `undefined` iff the market's price is undefined.
    * Returns null if the position is not a borrow.
+   *
+   * @param position.collateral - The collateral amount in the position.
+   * @param position.borrowShares - The borrow shares in the position.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param market.price - The oracle price, scaled by `ORACLE_PRICE_SCALE`.
+   * @returns The WAD-scaled loan-to-value ratio, `undefined`, or `null` when the position has no borrow.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const ltv = MarketUtils.getLtv(
+   *   { collateral: 2n, borrowShares: 1n },
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n, price: ORACLE_PRICE_SCALE },
+   * );
+   * // ltv satisfies bigint | null | undefined
+   * ```
    */
   export function getLtv(
     {
@@ -581,6 +886,22 @@ export namespace MarketUtils {
   /**
    * Returns the usage ratio of the maximum borrow capacity given a certain borrow position (scaled by WAD).
    * Returns `undefined` iff the market's price is undefined.
+   *
+   * @param position - The borrow position to evaluate.
+   * @param market - The market state used to value the position.
+   * @param marketParams - The market params containing LLTV.
+   * @returns The WAD-scaled borrow capacity usage, or `undefined` when price is unavailable.
+   * @example
+   * ```ts
+   * import { MarketUtils, ORACLE_PRICE_SCALE } from "@morpho-org/blue-sdk";
+   *
+   * const usage = MarketUtils.getBorrowCapacityUsage(
+   *   { collateral: 2n, borrowShares: 1n },
+   *   { totalBorrowAssets: 1n, totalBorrowShares: 1n, price: ORACLE_PRICE_SCALE },
+   *   { lltv: 50_0000000000000000n },
+   * );
+   * // usage satisfies bigint | undefined
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getBorrowCapacityUsage(
@@ -599,6 +920,25 @@ export namespace MarketUtils {
     return MathLib.wDivUp(MathLib.WAD, hf);
   }
 
+  /**
+   * Converts market supply shares to loan assets.
+   *
+   * @param shares - The supply shares to convert.
+   * @param market.totalSupplyAssets - The market's total supplied assets.
+   * @param market.totalSupplyShares - The market's total supply shares.
+   * @param rounding - Optional rounding direction. Defaults to `"Down"`.
+   * @returns The equivalent amount of supplied loan assets.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const assets = MarketUtils.toSupplyAssets(100n, {
+   *   totalSupplyAssets: 1_000n,
+   *   totalSupplyShares: 100n,
+   * });
+   * // assets satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toSupplyAssets(
     shares: BigIntish,
@@ -616,6 +956,25 @@ export namespace MarketUtils {
     );
   }
 
+  /**
+   * Converts market supply assets to supply shares.
+   *
+   * @param assets - The supplied loan assets to convert.
+   * @param market.totalSupplyAssets - The market's total supplied assets.
+   * @param market.totalSupplyShares - The market's total supply shares.
+   * @param rounding - Optional rounding direction. Defaults to `"Up"`.
+   * @returns The equivalent amount of supply shares.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const shares = MarketUtils.toSupplyShares(100n, {
+   *   totalSupplyAssets: 1_000n,
+   *   totalSupplyShares: 100n,
+   * });
+   * // shares satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toSupplyShares(
     assets: BigIntish,
@@ -633,6 +992,25 @@ export namespace MarketUtils {
     );
   }
 
+  /**
+   * Converts market borrow shares to loan assets.
+   *
+   * @param shares - The borrow shares to convert.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param rounding - Optional rounding direction. Defaults to `"Up"`.
+   * @returns The equivalent amount of borrowed loan assets.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const assets = MarketUtils.toBorrowAssets(100n, {
+   *   totalBorrowAssets: 1_000n,
+   *   totalBorrowShares: 100n,
+   * });
+   * // assets satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toBorrowAssets(
     shares: BigIntish,
@@ -650,6 +1028,25 @@ export namespace MarketUtils {
     );
   }
 
+  /**
+   * Converts market borrow assets to borrow shares.
+   *
+   * @param assets - The borrowed loan assets to convert.
+   * @param market.totalBorrowAssets - The market's total borrowed assets.
+   * @param market.totalBorrowShares - The market's total borrow shares.
+   * @param rounding - Optional rounding direction. Defaults to `"Down"`.
+   * @returns The equivalent amount of borrow shares.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/blue-sdk";
+   *
+   * const shares = MarketUtils.toBorrowShares(100n, {
+   *   totalBorrowAssets: 1_000n,
+   *   totalBorrowShares: 100n,
+   * });
+   * // shares satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toBorrowShares(
     assets: BigIntish,

--- a/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.ts
+++ b/packages/blue-sdk/src/math/AdaptiveCurveIrmLib.ts
@@ -7,11 +7,17 @@ import { MathLib } from "./MathLib.js";
  * JS implementation of {@link https://github.com/morpho-org/morpho-blue-irm/blob/main/src/libraries/adaptive-curve/ExpLib.sol ExpLib} used by the Adaptive Curve IRM.
  */
 export namespace AdaptiveCurveIrmLib {
+  /** Curve steepness constant, scaled by WAD. */
   export const CURVE_STEEPNESS = 4_000000000000000000n;
+  /** Target utilization for the Adaptive Curve IRM, scaled by WAD. */
   export const TARGET_UTILIZATION = 90_0000000000000000n;
+  /** Initial per-second rate at target utilization, scaled by WAD. */
   export const INITIAL_RATE_AT_TARGET = 4_0000000000000000n / SECONDS_PER_YEAR;
+  /** Per-second speed used to adjust the rate at target utilization. */
   export const ADJUSTMENT_SPEED = 50_000000000000000000n / SECONDS_PER_YEAR;
+  /** Minimum per-second rate at target utilization, scaled by WAD. */
   export const MIN_RATE_AT_TARGET = 10_00000000000000n / SECONDS_PER_YEAR;
+  /** Maximum per-second rate at target utilization, scaled by WAD. */
   export const MAX_RATE_AT_TARGET = 2_000000000000000000n / SECONDS_PER_YEAR;
 
   /**
@@ -38,7 +44,15 @@ export namespace AdaptiveCurveIrmLib {
 
   /**
    * Returns an approximation of exp(x) used by the Adaptive Curve IRM.
-   * @param x
+   * @param x - The WAD-scaled exponent.
+   * @returns The WAD-scaled exponential approximation.
+   * @example
+   * ```ts
+   * import { AdaptiveCurveIrmLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = AdaptiveCurveIrmLib.wExp(0n);
+   * // value === 1000000000000000000n
+   * ```
    */
   export function wExp(x: BigIntish) {
     // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
@@ -63,6 +77,25 @@ export namespace AdaptiveCurveIrmLib {
     return expR >> -q;
   }
 
+  /**
+   * Computes Adaptive Curve IRM borrow rates from utilization and elapsed time.
+   *
+   * @param startUtilization - The market utilization at the start of the period, scaled by WAD.
+   * @param startRateAtTarget - The rate at target utilization at the start of the period, scaled by WAD.
+   * @param elapsed - The elapsed time in seconds.
+   * @returns The average borrow rate, end borrow rate, and end rate at target, all scaled by WAD.
+   * @example
+   * ```ts
+   * import { AdaptiveCurveIrmLib } from "@morpho-org/blue-sdk";
+   *
+   * const rates = AdaptiveCurveIrmLib.getBorrowRate(
+   *   AdaptiveCurveIrmLib.TARGET_UTILIZATION,
+   *   AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET,
+   *   12n,
+   * );
+   * // rates satisfies { avgBorrowRate: bigint; endBorrowRate: bigint; endRateAtTarget: bigint }
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function getBorrowRate(
     startUtilization: BigIntish,
@@ -156,6 +189,23 @@ export namespace AdaptiveCurveIrmLib {
     };
   }
 
+  /**
+   * Finds the utilization corresponding to a borrow rate and rate at target.
+   *
+   * @param borrowRate - The borrow rate to invert, scaled by WAD.
+   * @param rateAtTarget - The rate at target utilization, scaled by WAD.
+   * @returns The utilization corresponding to `borrowRate`, scaled by WAD.
+   * @example
+   * ```ts
+   * import { AdaptiveCurveIrmLib } from "@morpho-org/blue-sdk";
+   *
+   * const utilization = AdaptiveCurveIrmLib.getUtilizationAtBorrowRate(
+   *   AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET,
+   *   AdaptiveCurveIrmLib.INITIAL_RATE_AT_TARGET,
+   * );
+   * // utilization === AdaptiveCurveIrmLib.TARGET_UTILIZATION
+   * ```
+   */
   export function getUtilizationAtBorrowRate(
     borrowRate: BigIntish,
     rateAtTarget: BigIntish,

--- a/packages/blue-sdk/src/math/MathLib.ts
+++ b/packages/blue-sdk/src/math/MathLib.ts
@@ -1,5 +1,6 @@
 import type { BigIntish } from "../types.js";
 
+/** Rounding direction used by fixed-point math helpers. */
 export type RoundingDirection = "Up" | "Down";
 
 /**
@@ -7,14 +8,33 @@ export type RoundingDirection = "Up" | "Down";
  * https://github.com/morpho-org/morpho-blue/blob/main/src/libraries/MathLib.sol
  */
 export namespace MathLib {
+  /** WAD scale used for 18-decimal fixed-point values. */
   export const WAD = 1_000000000000000000n;
+  /** RAY scale used for 27-decimal fixed-point values. */
   export const RAY = 1_000000000000000000000000000n;
 
+  /** Maximum unsigned integer representable with 256 bits. */
   export const MAX_UINT_256 = maxUint(256);
+  /** Maximum unsigned integer representable with 160 bits. */
   export const MAX_UINT_160 = maxUint(160);
+  /** Maximum unsigned integer representable with 128 bits. */
   export const MAX_UINT_128 = maxUint(128);
+  /** Maximum unsigned integer representable with 48 bits. */
   export const MAX_UINT_48 = maxUint(48);
 
+  /**
+   * Returns the maximum unsigned integer representable with a bit width.
+   *
+   * @param nBits - The bit width, which must be divisible by 4.
+   * @returns The maximum unsigned integer representable by `nBits`.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const max = MathLib.maxUint(8);
+   * // max === 255n
+   * ```
+   */
   export function maxUint(nBits: number) {
     if (nBits % 4 !== 0) throw new Error(`Invalid number of bits: ${nBits}`);
 
@@ -24,6 +44,14 @@ export namespace MathLib {
   /**
    * Returns the absolute value of a number
    * @param a The number
+   * @returns The absolute value as a bigint.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.abs(-2n);
+   * // value === 2n
+   * ```
    */
   export function abs(a: BigIntish) {
     // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
@@ -34,8 +62,15 @@ export namespace MathLib {
 
   /**
    * Returns the smallest number given as param
-   * @param x The first number
-   * @param y The second number
+   * @param xs The numbers to compare.
+   * @returns The smallest value as a bigint.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.min(2n, 1n, 3n);
+   * // value === 1n
+   * ```
    */
   export function min(...xs: BigIntish[]) {
     return xs.map(BigInt).reduce((x, y) => (x <= y ? x : y));
@@ -43,8 +78,15 @@ export namespace MathLib {
 
   /**
    * Returns the greatest number given as param
-   * @param x The first number
-   * @param y The second number
+   * @param xs The numbers to compare.
+   * @returns The greatest value as a bigint.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.max(2n, 1n, 3n);
+   * // value === 3n
+   * ```
    */
   export function max(...xs: BigIntish[]) {
     return xs.map(BigInt).reduce((x, y) => (x <= y ? y : x));
@@ -54,6 +96,14 @@ export namespace MathLib {
    * Returns the subtraction of b from a, floored to zero if negative
    * @param x The first number
    * @param y The second number
+   * @returns `x - y`, floored to `0n`.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.zeroFloorSub(1n, 2n);
+   * // value === 0n
+   * ```
    */
   export function zeroFloorSub(x: BigIntish, y: BigIntish) {
     // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
@@ -68,6 +118,14 @@ export namespace MathLib {
    * Perform the WAD-based multiplication of 2 numbers, rounded down
    * @param x The first number
    * @param y The second number
+   * @returns The WAD-scaled product rounded down.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.wMulDown(MathLib.WAD, 2n * MathLib.WAD);
+   * // value === 2n * MathLib.WAD
+   * ```
    */
   export function wMulDown(x: BigIntish, y: BigIntish) {
     return MathLib.wMul(x, y, "Down");
@@ -77,6 +135,14 @@ export namespace MathLib {
    * Perform the WAD-based multiplication of 2 numbers, rounded up
    * @param x The first number
    * @param y The second number
+   * @returns The WAD-scaled product rounded up.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.wMulUp(1n, MathLib.WAD);
+   * // value === 1n
+   * ```
    */
   export function wMulUp(x: BigIntish, y: BigIntish) {
     return MathLib.wMul(x, y, "Up");
@@ -86,6 +152,15 @@ export namespace MathLib {
    * Perform the WAD-based multiplication of 2 numbers with a provided rounding direction
    * @param x The first number
    * @param y The second number
+   * @param rounding The rounding direction.
+   * @returns The WAD-scaled product rounded as requested.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.wMul(MathLib.WAD, MathLib.WAD, "Down");
+   * // value === MathLib.WAD
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function wMul(
@@ -100,6 +175,14 @@ export namespace MathLib {
    * Perform the WAD-based division of 2 numbers, rounded down
    * @param x The first number
    * @param y The second number
+   * @returns The WAD-scaled quotient rounded down.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.wDivDown(MathLib.WAD, 2n * MathLib.WAD);
+   * // value === 500000000000000000n
+   * ```
    */
   export function wDivDown(x: BigIntish, y: BigIntish) {
     return MathLib.wDiv(x, y, "Down");
@@ -109,6 +192,14 @@ export namespace MathLib {
    * Perform the WAD-based multiplication of 2 numbers, rounded up
    * @param x The first number
    * @param y The second number
+   * @returns The WAD-scaled quotient rounded up.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.wDivUp(MathLib.WAD, 2n * MathLib.WAD);
+   * // value === 500000000000000000n
+   * ```
    */
   export function wDivUp(x: BigIntish, y: BigIntish) {
     return MathLib.wDiv(x, y, "Up");
@@ -118,6 +209,15 @@ export namespace MathLib {
    * Perform the WAD-based multiplication of 2 numbers with a provided rounding direction
    * @param x The first number
    * @param y The second number
+   * @param rounding The rounding direction.
+   * @returns The WAD-scaled quotient rounded as requested.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.wDiv(MathLib.WAD, MathLib.WAD, "Down");
+   * // value === MathLib.WAD
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function wDiv(
@@ -133,6 +233,14 @@ export namespace MathLib {
    * @param x The first number
    * @param y The second number
    * @param denominator The denominator
+   * @returns `x * y / denominator`, rounded down.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.mulDivDown(5n, 2n, 3n);
+   * // value === 3n
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function mulDivDown(
@@ -156,6 +264,14 @@ export namespace MathLib {
    * @param x The first number
    * @param y The second number
    * @param denominator The denominator
+   * @returns `x * y / denominator`, rounded up.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.mulDivUp(5n, 2n, 3n);
+   * // value === 4n
+   * ```
    */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function mulDivUp(x: BigIntish, y: BigIntish, denominator: BigIntish) {
@@ -172,6 +288,22 @@ export namespace MathLib {
     return (x * y) / denominator + roundup;
   }
 
+  /**
+   * Multiplies two numbers and divides by a denominator.
+   *
+   * @param x - The first number.
+   * @param y - The second number.
+   * @param denominator - The denominator.
+   * @param rounding - The rounding direction.
+   * @returns `x * y / denominator`, rounded as requested.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const value = MathLib.mulDiv(5n, 2n, 3n, "Down");
+   * // value === 3n
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function mulDiv(
     x: BigIntish,
@@ -188,6 +320,14 @@ export namespace MathLib {
    *
    * @param x The base of the exponent
    * @param n The exponent
+   * @returns The WAD-scaled compounded rate approximation.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const compounded = MathLib.wTaylorCompounded(1n, 1n);
+   * // compounded satisfies bigint
+   * ```
    */
   export function wTaylorCompounded(x: BigIntish, n: BigIntish) {
     const firstTerm = BigInt(x) * BigInt(n);
@@ -208,6 +348,14 @@ export namespace MathLib {
   /**
    * Converts a WAD-based quantity to a RAY-based quantity.
    * @param x The WAD-based quantity.
+   * @returns The same quantity scaled to RAY precision.
+   * @example
+   * ```ts
+   * import { MathLib } from "@morpho-org/blue-sdk";
+   *
+   * const ray = MathLib.wToRay(MathLib.WAD);
+   * // ray === MathLib.RAY
+   * ```
    */
   export function wToRay(x: BigIntish) {
     return BigInt(x) * 1_000000000n;

--- a/packages/blue-sdk/src/math/SharesMath.ts
+++ b/packages/blue-sdk/src/math/SharesMath.ts
@@ -7,9 +7,27 @@ import { MathLib, type RoundingDirection } from "./MathLib.js";
  * & MetaMorpho (via {@link https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC4626.sol ERC4626}).
  */
 export namespace SharesMath {
+  /** Virtual shares added to Morpho Blue and ERC-4626 share conversions. */
   export const VIRTUAL_SHARES = 1000000n;
+  /** Virtual assets added to Morpho Blue and ERC-4626 asset conversions. */
   export const VIRTUAL_ASSETS = 1n;
 
+  /**
+   * Converts shares to assets using Morpho virtual shares and assets.
+   *
+   * @param shares - The amount of shares.
+   * @param totalAssets - The total assets before conversion.
+   * @param totalShares - The total shares before conversion.
+   * @param rounding - The rounding direction.
+   * @returns The equivalent amount of assets.
+   * @example
+   * ```ts
+   * import { SharesMath } from "@morpho-org/blue-sdk";
+   *
+   * const assets = SharesMath.toAssets(100n, 1_000n, 100n, "Down");
+   * // assets satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toAssets(
     shares: BigIntish,
@@ -25,6 +43,22 @@ export namespace SharesMath {
     );
   }
 
+  /**
+   * Converts assets to shares using Morpho virtual shares and assets.
+   *
+   * @param assets - The amount of assets.
+   * @param totalAssets - The total assets before conversion.
+   * @param totalShares - The total shares before conversion.
+   * @param rounding - The rounding direction.
+   * @returns The equivalent amount of shares.
+   * @example
+   * ```ts
+   * import { SharesMath } from "@morpho-org/blue-sdk";
+   *
+   * const shares = SharesMath.toShares(100n, 1_000n, 100n, "Up");
+   * // shares satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toShares(
     assets: BigIntish,

--- a/packages/blue-sdk/src/position/Position.ts
+++ b/packages/blue-sdk/src/position/Position.ts
@@ -10,6 +10,7 @@ import { MathLib } from "../math/MathLib.js";
 import type { Address, BigIntish, MarketId } from "../types.js";
 import { CapacityLimitReason } from "../utils.js";
 
+/** Plain input shape for a user's Morpho Blue market position. */
 export interface IPosition {
   user: Address;
   marketId: MarketId;
@@ -18,6 +19,7 @@ export interface IPosition {
   collateral: bigint;
 }
 
+/** Represents a user's supply, borrow, and collateral balances on one market. */
 export class Position implements IPosition {
   /**
    * The user holding this position.
@@ -57,8 +59,10 @@ export class Position implements IPosition {
   }
 }
 
+/** Plain input shape for a position paired with market state for accrual math. */
 export interface IAccrualPosition extends Omit<IPosition, "marketId"> {}
 
+/** Represents a position paired with market state for derived and accrued values. */
 export class AccrualPosition extends Position implements IAccrualPosition {
   protected readonly _market: Market;
 

--- a/packages/blue-sdk/src/position/PreLiquidationPosition.ts
+++ b/packages/blue-sdk/src/position/PreLiquidationPosition.ts
@@ -5,6 +5,7 @@ import { MathLib, SharesMath } from "../math/index.js";
 import type { BigIntish } from "../types.js";
 import { AccrualPosition, type IAccrualPosition } from "./Position.js";
 
+/** Plain input shape for PreLiquidation contract parameters. */
 export interface IPreLiquidationParams {
   preLltv: BigIntish;
   preLCF1: BigIntish;
@@ -14,6 +15,7 @@ export interface IPreLiquidationParams {
   preLiquidationOracle: Address;
 }
 
+/** Represents PreLiquidation contract parameters and factor interpolation helpers. */
 export class PreLiquidationParams implements IPreLiquidationParams {
   public readonly preLltv: bigint;
   public readonly preLCF1: bigint;
@@ -51,6 +53,7 @@ export class PreLiquidationParams implements IPreLiquidationParams {
   }
 }
 
+/** Plain input shape for a position associated with a PreLiquidation contract. */
 export interface IPreLiquidationPosition extends IAccrualPosition {
   /**
    * The pre-liquidation parameters of the associated PreLiquidation contract.
@@ -67,6 +70,7 @@ export interface IPreLiquidationPosition extends IAccrualPosition {
   preLiquidationOraclePrice?: BigIntish;
 }
 
+/** Represents a position evaluated under PreLiquidation-specific risk parameters. */
 export class PreLiquidationPosition
   extends AccrualPosition
   implements IPreLiquidationPosition

--- a/packages/blue-sdk/src/preLiquidation.ts
+++ b/packages/blue-sdk/src/preLiquidation.ts
@@ -2,6 +2,7 @@ import { parseEther } from "viem";
 import { UnsupportedPreLiquidationParamsError } from "./errors.js";
 import type { BigIntish } from "./types.js";
 
+/** Default PreLiquidation parameter registry keyed by Morpho Blue LLTV. */
 export const defaultPreLiquidationParamsRegistry = new Map([
   [
     parseEther("0.385"),
@@ -85,6 +86,21 @@ export const defaultPreLiquidationParamsRegistry = new Map([
   ],
 ]);
 
+/**
+ * Returns default PreLiquidation params for a supported Morpho Blue LLTV.
+ *
+ * @param lltv - The Morpho Blue liquidation loan-to-value, scaled by WAD.
+ * @returns The default PreLiquidation parameter set for `lltv`.
+ * @throws {UnsupportedPreLiquidationParamsError} when no default parameters exist for `lltv`.
+ * @example
+ * ```ts
+ * import { getDefaultPreLiquidationParams } from "@morpho-org/blue-sdk";
+ * import { parseEther } from "viem";
+ *
+ * const params = getDefaultPreLiquidationParams(parseEther("0.86"));
+ * // params satisfies { preLltv: bigint; preLCF1: bigint; preLCF2: bigint; preLIF1: bigint; preLIF2: bigint }
+ * ```
+ */
 export const getDefaultPreLiquidationParams = (lltv: BigIntish) => {
   // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
   lltv = BigInt(lltv);

--- a/packages/blue-sdk/src/token/ConstantWrappedToken.ts
+++ b/packages/blue-sdk/src/token/ConstantWrappedToken.ts
@@ -4,6 +4,7 @@ import type { Address, BigIntish } from "../types.js";
 import type { IToken } from "./Token.js";
 import { WrappedToken } from "./WrappedToken.js";
 
+/** Represents a wrapped token with a constant decimals-based conversion rate. */
 export class ConstantWrappedToken extends WrappedToken {
   public readonly underlyingDecimals;
 

--- a/packages/blue-sdk/src/token/Eip5267Domain.ts
+++ b/packages/blue-sdk/src/token/Eip5267Domain.ts
@@ -1,5 +1,6 @@
 import type { Address } from "../types.js";
 
+/** Ordered EIP-712 domain fields exposed by EIP-5267. */
 export const EIP_712_FIELDS = [
   "name",
   "version",
@@ -8,8 +9,10 @@ export const EIP_712_FIELDS = [
   "salt",
 ] as const;
 
+/** EIP-712 domain field name exposed by EIP-5267. */
 export type Eip712Field = (typeof EIP_712_FIELDS)[number];
 
+/** Plain input shape for an EIP-5267 signing domain. */
 export interface IEip5267Domain {
   fields: `0x${string}`;
   name: string;
@@ -20,6 +23,7 @@ export interface IEip5267Domain {
   extensions: readonly bigint[];
 }
 
+/** Represents an EIP-5267 signing domain and derived EIP-712 domain object. */
 export class Eip5267Domain implements IEip5267Domain {
   /**
    * A bit map where bit i is set to 1 if and only if domain field i is present (0 ≤ i ≤ 4).

--- a/packages/blue-sdk/src/token/ExchangeRateWrappedToken.ts
+++ b/packages/blue-sdk/src/token/ExchangeRateWrappedToken.ts
@@ -4,6 +4,7 @@ import type { Address } from "../types.js";
 import type { IToken } from "./Token.js";
 import { WrappedToken } from "./WrappedToken.js";
 
+/** Represents a wrapped token whose conversion uses a WAD-scaled exchange rate. */
 export class ExchangeRateWrappedToken extends WrappedToken {
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   constructor(

--- a/packages/blue-sdk/src/token/Token.ts
+++ b/packages/blue-sdk/src/token/Token.ts
@@ -4,6 +4,7 @@ import { MathLib, type RoundingDirection } from "../math/index.js";
 import type { Address, BigIntish } from "../types.js";
 import type { Eip5267Domain } from "./Eip5267Domain.js";
 
+/** Plain input shape for an ERC-20-like token. */
 export interface IToken {
   address: Address;
   name?: string;
@@ -13,6 +14,7 @@ export interface IToken {
   eip5267Domain?: Eip5267Domain;
 }
 
+/** Represents an ERC-20-like token and optional price/signing metadata. */
 export class Token implements IToken {
   static native(chainId: ChainId) {
     const currency = ChainUtils.CHAIN_METADATA[chainId].nativeCurrency;

--- a/packages/blue-sdk/src/token/VaultToken.ts
+++ b/packages/blue-sdk/src/token/VaultToken.ts
@@ -4,11 +4,13 @@ import type { IVaultConfig } from "../vault/VaultConfig.js";
 import { VaultUtils } from "../vault/VaultUtils.js";
 import { WrappedToken } from "./WrappedToken.js";
 
+/** Plain input shape for ERC-4626-like vault token totals. */
 export interface IVaultToken {
   totalAssets: bigint;
   totalSupply: bigint;
 }
 
+/** Represents an ERC-4626-like vault token with share and asset conversion math. */
 export class VaultToken extends WrappedToken implements IVaultToken {
   public readonly asset: Address;
   public readonly decimalsOffset: bigint;

--- a/packages/blue-sdk/src/token/WrappedToken.ts
+++ b/packages/blue-sdk/src/token/WrappedToken.ts
@@ -3,6 +3,7 @@ import type { Address } from "../types.js";
 
 import { type IToken, Token } from "./Token.js";
 
+/** Base class for tokens that wrap and unwrap another token. */
 export abstract class WrappedToken extends Token {
   constructor(
     token: IToken,

--- a/packages/blue-sdk/src/types.ts
+++ b/packages/blue-sdk/src/types.ts
@@ -8,6 +8,7 @@ export type Address = `0x${string}`;
  */
 export type MarketId = `0x${string}` & { __TYPE__: "marketId" };
 
+/** Primitive values accepted at SDK boundaries and normalized to `bigint`. */
 export type BigIntish = bigint | string | number | boolean;
 
 /**
@@ -22,9 +23,25 @@ export enum TransactionType {
   Repay = "Repay",
 }
 
+/** Value that may not have been loaded yet. */
 export type Loadable<T> = T | undefined;
+/** Value that may fail to resolve. */
 export type Failable<T> = T | null;
+/** Value that may be unloaded or fail to resolve. */
 export type Fetchable<T> = Failable<Loadable<T>>;
 
+/**
+ * Checks whether a value is a 32-byte Morpho Blue market id.
+ *
+ * @param value - The unknown value to inspect.
+ * @returns `true` when `value` is a `0x`-prefixed 32-byte hex string.
+ * @example
+ * ```ts
+ * import { isMarketId } from "@morpho-org/blue-sdk";
+ *
+ * const valid = isMarketId("0x0000000000000000000000000000000000000000000000000000000000000000");
+ * // valid satisfies boolean
+ * ```
+ */
 export const isMarketId = (value: unknown): value is MarketId =>
   typeof value === "string" && /^0x[0-9A-Fa-f]{64}$/.test(value);

--- a/packages/blue-sdk/src/user/User.ts
+++ b/packages/blue-sdk/src/user/User.ts
@@ -1,5 +1,6 @@
 import type { Address } from "../types.js";
 
+/** Represents a Morpho Blue user authorization and nonce state. */
 export class User {
   /**
    * The user's address.

--- a/packages/blue-sdk/src/utils.ts
+++ b/packages/blue-sdk/src/utils.ts
@@ -1,3 +1,4 @@
+/** Reason why a capacity calculation is capped. */
 export enum CapacityLimitReason {
   liquidity = "Liquidity",
   balance = "Balance",
@@ -8,6 +9,7 @@ export enum CapacityLimitReason {
   vaultV2_relativeCap = "VaultV2_RelativeCap",
 }
 
+/** Bounded capacity value and the reason for the bound. */
 export interface CapacityLimit {
   value: bigint;
   limiter: CapacityLimitReason;

--- a/packages/blue-sdk/src/vault/Vault.ts
+++ b/packages/blue-sdk/src/vault/Vault.ts
@@ -10,11 +10,13 @@ import {
   VaultMarketAllocation,
 } from "./VaultMarketAllocation.js";
 
+/** Pending governance value and the timestamp at which it becomes valid. */
 export interface Pending<T> {
   value: T;
   validAt: bigint;
 }
 
+/** PublicAllocator configuration attached to a MetaMorpho vault. */
 export interface VaultPublicAllocatorConfig {
   /**
    * The PublicAllocator's admin address.
@@ -30,6 +32,7 @@ export interface VaultPublicAllocatorConfig {
   accruedFee: bigint;
 }
 
+/** Plain input shape for a MetaMorpho vault. */
 export interface IVault extends IVaultConfig {
   curator: Address;
   owner: Address;
@@ -50,6 +53,7 @@ export interface IVault extends IVaultConfig {
   publicAllocatorConfig?: VaultPublicAllocatorConfig;
 }
 
+/** Represents a MetaMorpho vault and its governance, queue, and accounting state. */
 export class Vault extends VaultToken implements IVault {
   /**
    * The vault's share token's name.
@@ -187,6 +191,7 @@ export class Vault extends VaultToken implements IVault {
   }
 }
 
+/** Aggregated vault allocation exposure for one collateral asset. */
 export interface CollateralAllocation {
   address: Address;
   lltvs: Set<bigint>;
@@ -195,9 +200,11 @@ export interface CollateralAllocation {
   proportion: bigint;
 }
 
+/** Plain input shape for a MetaMorpho vault paired with accrued market allocations. */
 export interface IAccrualVault
   extends Omit<IVault, "withdrawQueue" | "totalAssets"> {}
 
+/** Represents a MetaMorpho vault with accrued market allocation state. */
 export class AccrualVault extends Vault implements IAccrualVault {
   /**
    * @inheritdoc

--- a/packages/blue-sdk/src/vault/VaultConfig.ts
+++ b/packages/blue-sdk/src/vault/VaultConfig.ts
@@ -1,11 +1,13 @@
 import { type IToken, Token } from "../token/Token.js";
 import type { Address, BigIntish } from "../types.js";
 
+/** Plain input shape for immutable MetaMorpho vault token configuration. */
 export interface IVaultConfig extends Omit<IToken, "decimals"> {
   decimalsOffset: BigIntish;
   asset: Address;
 }
 
+/** Represents immutable MetaMorpho vault token configuration. */
 export class VaultConfig extends Token implements IVaultConfig {
   public readonly decimalsOffset;
   public readonly asset;

--- a/packages/blue-sdk/src/vault/VaultMarketAllocation.ts
+++ b/packages/blue-sdk/src/vault/VaultMarketAllocation.ts
@@ -6,11 +6,13 @@ import {
   VaultMarketConfig,
 } from "./VaultMarketConfig.js";
 
+/** Plain input shape for a vault allocation on one Morpho Blue market. */
 export interface IVaultMarketAllocation {
   config: IVaultMarketConfig;
   position: AccrualPosition;
 }
 
+/** Represents a vault allocation on one Morpho Blue market. */
 export class VaultMarketAllocation implements IVaultMarketAllocation {
   /**
    * The vault's configuration on the corresponding market.

--- a/packages/blue-sdk/src/vault/VaultMarketConfig.ts
+++ b/packages/blue-sdk/src/vault/VaultMarketConfig.ts
@@ -3,6 +3,7 @@ import type { Address, MarketId } from "../types.js";
 import type { Pending } from "./Vault.js";
 import type { VaultMarketPublicAllocatorConfig } from "./VaultMarketPublicAllocatorConfig.js";
 
+/** Plain input shape for a vault's configuration on one Morpho Blue market. */
 export interface IVaultMarketConfig {
   vault: Address;
   marketId: MarketId;
@@ -13,6 +14,7 @@ export interface IVaultMarketConfig {
   publicAllocatorConfig?: VaultMarketPublicAllocatorConfig;
 }
 
+/** Represents a vault's configuration on one Morpho Blue market. */
 export class VaultMarketConfig implements IVaultMarketConfig {
   /**
    * The vault's address.

--- a/packages/blue-sdk/src/vault/VaultMarketPublicAllocatorConfig.ts
+++ b/packages/blue-sdk/src/vault/VaultMarketPublicAllocatorConfig.ts
@@ -10,6 +10,7 @@ export interface IVaultMarketPublicAllocatorConfig {
   maxOut: bigint;
 }
 
+/** Represents a vault market's PublicAllocator limits. */
 export class VaultMarketPublicAllocatorConfig
   implements IVaultMarketPublicAllocatorConfig
 {

--- a/packages/blue-sdk/src/vault/VaultUser.ts
+++ b/packages/blue-sdk/src/vault/VaultUser.ts
@@ -1,5 +1,6 @@
 import type { Address } from "../types.js";
 
+/** Plain input shape for a user's MetaMorpho vault state. */
 export interface IVaultUser {
   vault: Address;
   user: Address;
@@ -7,6 +8,7 @@ export interface IVaultUser {
   allowance: bigint;
 }
 
+/** Represents a user's MetaMorpho vault allocator and allowance state. */
 export class VaultUser implements IVaultUser {
   /**
    * The vault's address.

--- a/packages/blue-sdk/src/vault/VaultUtils.ts
+++ b/packages/blue-sdk/src/vault/VaultUtils.ts
@@ -1,13 +1,45 @@
 import { MathLib, type RoundingDirection } from "../math/index.js";
 import type { BigIntish } from "../types.js";
 
+/** ERC-4626 virtual share and asset conversion helpers for MetaMorpho vaults. */
 export namespace VaultUtils {
+  /** Virtual assets added to ERC-4626 total assets in conversion formulas. */
   export const VIRTUAL_ASSETS = 1n;
 
+  /**
+   * Returns the decimals offset between 18-decimal vault shares and an asset.
+   *
+   * @param decimals - The asset decimals.
+   * @returns The non-negative decimals offset.
+   * @example
+   * ```ts
+   * import { VaultUtils } from "@morpho-org/blue-sdk";
+   *
+   * const offset = VaultUtils.decimalsOffset(6n);
+   * // offset === 12n
+   * ```
+   */
   export function decimalsOffset(decimals: BigIntish) {
     return MathLib.zeroFloorSub(18n, decimals);
   }
 
+  /**
+   * Converts vault shares to underlying assets.
+   *
+   * @param shares - The amount of vault shares.
+   * @param vault.totalAssets - The vault's total assets.
+   * @param vault.totalSupply - The vault's total share supply.
+   * @param vault.decimalsOffset - The vault's decimals offset.
+   * @param rounding - Optional rounding direction. Defaults to `"Down"`.
+   * @returns The equivalent amount of underlying assets.
+   * @example
+   * ```ts
+   * import { VaultUtils } from "@morpho-org/blue-sdk";
+   *
+   * const assets = VaultUtils.toAssets(100n, { totalAssets: 1_000n, totalSupply: 100n, decimalsOffset: 0n });
+   * // assets satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toAssets(
     shares: BigIntish,
@@ -31,6 +63,23 @@ export namespace VaultUtils {
     );
   }
 
+  /**
+   * Converts underlying assets to vault shares.
+   *
+   * @param assets - The amount of underlying assets.
+   * @param vault.totalAssets - The vault's total assets.
+   * @param vault.totalSupply - The vault's total share supply.
+   * @param vault.decimalsOffset - The vault's decimals offset.
+   * @param rounding - Optional rounding direction. Defaults to `"Up"`.
+   * @returns The equivalent amount of vault shares.
+   * @example
+   * ```ts
+   * import { VaultUtils } from "@morpho-org/blue-sdk";
+   *
+   * const shares = VaultUtils.toShares(100n, { totalAssets: 1_000n, totalSupply: 100n, decimalsOffset: 0n });
+   * // shares satisfies bigint
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   export function toShares(
     assets: BigIntish,

--- a/packages/blue-sdk/src/vault/v2/VaultV2.ts
+++ b/packages/blue-sdk/src/vault/v2/VaultV2.ts
@@ -6,6 +6,7 @@ import type { BigIntish } from "../../types.js";
 import { type CapacityLimit, CapacityLimitReason } from "../../utils.js";
 import type { IAccrualVaultV2Adapter } from "./VaultV2Adapter.js";
 
+/** Plain input shape for one Vault V2 liquidity allocation. */
 export interface IVaultV2Allocation {
   id: Hash;
   absoluteCap: bigint;
@@ -13,6 +14,7 @@ export interface IVaultV2Allocation {
   allocation: bigint;
 }
 
+/** Plain input shape for a Morpho Vault V2. */
 export interface IVaultV2 extends IToken {
   asset: Address;
   /**
@@ -36,6 +38,7 @@ export interface IVaultV2 extends IToken {
   managementFeeRecipient: Address;
 }
 
+/** Represents a Morpho Vault V2 and its fee, adapter, and accounting state. */
 export class VaultV2 extends WrappedToken implements IVaultV2 {
   public readonly asset: Address;
 
@@ -119,8 +122,10 @@ export class VaultV2 extends WrappedToken implements IVaultV2 {
   }
 }
 
+/** Plain input shape for a Morpho Vault V2 paired with accrued adapter state. */
 export interface IAccrualVaultV2 extends Omit<IVaultV2, "adapters"> {}
 
+/** Represents a Morpho Vault V2 with accrued adapter and liquidity state. */
 export class AccrualVaultV2 extends VaultV2 implements IAccrualVaultV2 {
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   constructor(

--- a/packages/blue-sdk/src/vault/v2/VaultV2Adapter.ts
+++ b/packages/blue-sdk/src/vault/v2/VaultV2Adapter.ts
@@ -2,6 +2,7 @@ import type { Address, Hash, Hex } from "viem";
 import type { BigIntish } from "../../types.js";
 import type { CapacityLimit } from "../../utils.js";
 
+/** Plain input shape for a Morpho Vault V2 adapter. */
 export interface IVaultV2Adapter {
   type: string;
   address: Address;
@@ -10,6 +11,7 @@ export interface IVaultV2Adapter {
   skimRecipient: Address;
 }
 
+/** Base class for Morpho Vault V2 adapters. */
 export abstract class VaultV2Adapter implements IVaultV2Adapter {
   public readonly type: string;
   public readonly address: Address;
@@ -32,6 +34,7 @@ export abstract class VaultV2Adapter implements IVaultV2Adapter {
   }
 }
 
+/** Adapter interface with accrued asset and capacity methods. */
 export interface IAccrualVaultV2Adapter extends IVaultV2Adapter {
   realAssets(timestamp: BigIntish): bigint;
 

--- a/packages/blue-sdk/src/vault/v2/VaultV2MorphoMarketV1Adapter.ts
+++ b/packages/blue-sdk/src/vault/v2/VaultV2MorphoMarketV1Adapter.ts
@@ -13,12 +13,14 @@ import type {
 } from "./VaultV2Adapter.js";
 import { VaultV2Adapter } from "./VaultV2Adapter.js";
 
+/** Plain input shape for a Vault V2 adapter investing in Morpho Blue markets. */
 export interface IVaultV2MorphoMarketV1Adapter
   extends Omit<IVaultV2Adapter, "adapterId" | "type"> {
   type?: "VaultV2MorphoMarketV1Adapter";
   marketParamsList: IMarketParams[];
 }
 
+/** Represents a Vault V2 adapter investing in Morpho Blue markets. */
 export class VaultV2MorphoMarketV1Adapter
   extends VaultV2Adapter
   implements IVaultV2MorphoMarketV1Adapter
@@ -78,9 +80,11 @@ export class VaultV2MorphoMarketV1Adapter
   }
 }
 
+/** Plain input shape for an accrued Morpho Blue market Vault V2 adapter. */
 export interface IAccrualVaultV2MorphoMarketV1Adapter
   extends IVaultV2MorphoMarketV1Adapter {}
 
+/** Represents an accrued Morpho Blue market Vault V2 adapter. */
 export class AccrualVaultV2MorphoMarketV1Adapter
   extends VaultV2MorphoMarketV1Adapter
   implements IAccrualVaultV2MorphoMarketV1Adapter, IAccrualVaultV2Adapter

--- a/packages/blue-sdk/src/vault/v2/VaultV2MorphoMarketV1AdapterV2.ts
+++ b/packages/blue-sdk/src/vault/v2/VaultV2MorphoMarketV1AdapterV2.ts
@@ -12,6 +12,7 @@ import type {
 } from "./VaultV2Adapter.js";
 import { VaultV2Adapter } from "./VaultV2Adapter.js";
 
+/** Plain input shape for a Vault V2 Morpho Blue market adapter using market ids. */
 export interface IVaultV2MorphoMarketV1AdapterV2
   extends Omit<IVaultV2Adapter, "adapterId" | "type"> {
   type?: "VaultV2MorphoMarketV1AdapterV2";
@@ -20,6 +21,7 @@ export interface IVaultV2MorphoMarketV1AdapterV2
   supplyShares: Record<MarketId, bigint>;
 }
 
+/** Represents a Vault V2 Morpho Blue market adapter using market ids. */
 export class VaultV2MorphoMarketV1AdapterV2
   extends VaultV2Adapter
   implements IVaultV2MorphoMarketV1AdapterV2
@@ -85,9 +87,11 @@ export class VaultV2MorphoMarketV1AdapterV2
   }
 }
 
+/** Plain input shape for an accrued Vault V2 Morpho Blue market-id adapter. */
 export interface IAccrualVaultV2MorphoMarketV1AdapterV2
   extends IVaultV2MorphoMarketV1AdapterV2 {}
 
+/** Represents an accrued Vault V2 Morpho Blue market-id adapter. */
 export class AccrualVaultV2MorphoMarketV1AdapterV2
   extends VaultV2MorphoMarketV1AdapterV2
   implements IAccrualVaultV2MorphoMarketV1AdapterV2, IAccrualVaultV2Adapter

--- a/packages/blue-sdk/src/vault/v2/VaultV2MorphoVaultV1Adapter.ts
+++ b/packages/blue-sdk/src/vault/v2/VaultV2MorphoVaultV1Adapter.ts
@@ -2,6 +2,7 @@ import { type Address, encodeAbiParameters, type Hex, keccak256 } from "viem";
 
 import { VaultV2Adapter } from "./VaultV2Adapter.js";
 
+/** Plain input shape for a Vault V2 adapter investing in a MetaMorpho V1 vault. */
 export interface IVaultV2MorphoVaultV1Adapter
   extends Omit<IVaultV2Adapter, "adapterId" | "type"> {
   type?: "VaultV2MorphoVaultV1Adapter";
@@ -15,6 +16,7 @@ import type {
   IVaultV2Adapter,
 } from "./VaultV2Adapter.js";
 
+/** Represents a Vault V2 adapter investing in a MetaMorpho V1 vault. */
 export class VaultV2MorphoVaultV1Adapter
   extends VaultV2Adapter
   implements IVaultV2MorphoVaultV1Adapter
@@ -50,9 +52,11 @@ export class VaultV2MorphoVaultV1Adapter
   }
 }
 
+/** Plain input shape for an accrued Vault V2 MetaMorpho V1 adapter. */
 export interface IAccrualVaultV2MorphoVaultV1Adapter
   extends IVaultV2MorphoVaultV1Adapter {}
 
+/** Represents an accrued Vault V2 MetaMorpho V1 adapter. */
 export class AccrualVaultV2MorphoVaultV1Adapter
   extends VaultV2MorphoVaultV1Adapter
   implements IAccrualVaultV2MorphoVaultV1Adapter, IAccrualVaultV2Adapter


### PR DESCRIPTION
## Summary

- Add JSDoc coverage across the exported `@morpho-org/blue-sdk` surface.
- Document helper namespaces, protocol model classes, address/chain utilities, math helpers, token models, vault models, and test fixtures marked internal.
- Add a changeset for the package release notes.

## Impact

This improves generated API documentation and AI-readable examples for blue-sdk consumers without changing runtime behavior.

## Validation

- `pnpm lint`
- `pnpm jsdoc:coverage`
- `git diff --check HEAD`

Note: `pnpm docs:build` still fails on existing cross-package TypeScript errors outside this diff.

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1780328677843269)
<!-- slack-thread-ts:1780328677.843269 -->