### PR TITLE
chore: add jinmel to team-members.json

### DIFF
--- a/.github/team-members.json
+++ b/.github/team-members.json
@@ -10,6 +10,7 @@
     "alexbensimon": "U08D4PDSDBQ",
     "remiroyc": "U08B2J6LCHW",
     "oumar-fall": "U02NMGCRVGA",
-    "Rubilmax": "U03L0SC1JUR"
+    "Rubilmax": "U03L0SC1JUR",
+    "jinmel": "U0B7B9A0AH4"
   }
 }


### PR DESCRIPTION
## Motivation

Add GitHub user [`jinmel`](https://github.com/jinmel) (Slack `U0B7B9A0AH4`) to the SDK contributor mapping so the PR Slack-notify workflow (`.github/workflows/pr-slack-notify.yml`) can route review/DM notifications to them.

## Solution

Append `jinmel` → `U0B7B9A0AH4` to the `members` map in `.github/team-members.json`. Routing resolves a GitHub login's Slack ID through this map (`mapping[login]`).

The `teams` map is left untouched (`{}`) — no team entry is added.

No changeset/tests: this is `.github/` repo metadata, not published package source.

Verified locally:
- Valid JSON (`jq .`)
- `jinmel` resolves to `U0B7B9A0AH4` in the non-null routing map

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1780479230328559)
<!-- slack-thread-ts:1780479230.328559 -->