### PR TITLE
docs: drop stale screening mention from evm-simulation summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For read-only integrations, `@morpho-org/morpho-ts` + `@morpho-org/blue-sdk` + `
 
 - [**`@morpho-org/blue-sdk`**](./packages/blue-sdk/): Framework-agnostic package that defines Morpho-related entity classes (such as `Market`, `Token`, `Vault`)
 
-- [**`@morpho-org/evm-simulation`**](./packages/evm-simulation/): EVM simulation engine for Morpho transactions, with Tenderly REST and `eth_simulateV1` backends, signature authorization handling, sanctions screening, and bundler retention checks
+- [**`@morpho-org/evm-simulation`**](./packages/evm-simulation/): EVM simulation engine for Morpho transactions, with Tenderly RPC and `eth_simulateV1` backends, signature authorization handling, and bundler retention checks
 
 ### Testing
 


### PR DESCRIPTION
## What

The root `README.md` entry for `@morpho-org/evm-simulation` still advertised two surfaces that no longer exist:

- **"sanctions screening"** — the `screenAddresses` function, `AddressScreeningError`, and bundled sanctioned-address list were removed in #754.
- **"Tenderly REST"** — replaced by Tenderly RPC in #756.

This aligns the one-line package summary with the package's current README and exported surface.

```diff
- ...with Tenderly REST and `eth_simulateV1` backends, signature authorization handling, sanctions screening, and bundler retention checks
+ ...with Tenderly RPC and `eth_simulateV1` backends, signature authorization handling, and bundler retention checks
```

## Other loose ends checked

- `docs/tibs/TIB-2026-05-04-*.md` still names `screenAddresses()` — left as-is; it's a dated, point-in-time *Proposed* audit and the reference was accurate when written.
- `liquidation-sdk-viem` `sanctionsList` ABI entries — unrelated pinned on-chain contract ABI, not the removed feature.
- No lingering `shareable` / `tenderlyUrl` / `TenderlyRest` references from the #756 rename.

No changeset: root-README / repo-metadata doc-only change, excluded from changeset generation per AGENTS.md §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[View Slack thread](https://morpho-labs.slack.com/archives/C0B1C0ULKMK/p1780574983460839)
<!-- slack-thread-ts:1780574983.460839 -->