### PR TITLE
fix(blue-sdk): throw UnknownMarketAllocationError on stale withdrawQueue

### DIFF
--- a/.changeset/vault-accrual-error.md
+++ b/.changeset/vault-accrual-error.md
@@ -1,5 +1,5 @@
 ---
-"@morpho-org/blue-sdk": patch
+"@morpho-org/blue-sdk": minor
 ---
 
 Throw `UnknownMarketAllocationError` when accruing interest on a vault whose withdraw queue references a market without an allocation.

--- a/.changeset/vault-accrual-error.md
+++ b/.changeset/vault-accrual-error.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk": patch
+---
+
+Throw `UnknownMarketAllocationError` when accruing interest on a vault whose withdraw queue references a market without an allocation.

--- a/packages/blue-sdk-viem/src/signatures/manager.ts
+++ b/packages/blue-sdk-viem/src/signatures/manager.ts
@@ -34,7 +34,7 @@ const authorizationTypes = {
  * const typedData = getAuthorizationTypedData(
  *   {
  *     authorizer: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
- *     authorized: "0x6566194141Ff46B819C55E7137d8329898EcD06c",
+ *     authorized: "0x6566194141fF46b819c55E7137D8329898eCd06C",
  *     isAuthorized: true,
  *     nonce: 0n,
  *     deadline: 1_900_000_000n,

--- a/packages/blue-sdk-viem/src/signatures/permit.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit.ts
@@ -149,7 +149,7 @@ const daiPermitTypes = {
  * const typedData = getDaiPermitTypedData(
  *   {
  *     owner: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
- *     spender: "0x6566194141Ff46B819C55E7137d8329898EcD06c",
+ *     spender: "0x6566194141fF46b819c55E7137D8329898eCd06C",
  *     allowance: 1_000_000_000_000_000_000n,
  *     nonce: 0n,
  *     deadline: 1_900_000_000n,

--- a/packages/blue-sdk-viem/src/signatures/permit2.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit2.ts
@@ -56,7 +56,7 @@ const permit2PermitTypes = {
  *     allowance: 1_000_000n,
  *     nonce: 0,
  *     deadline: 1_900_000_000n,
- *     spender: "0x6566194141Ff46B819C55E7137d8329898EcD06c",
+ *     spender: "0x6566194141fF46b819c55E7137D8329898eCd06C",
  *   },
  *   ChainId.EthMainnet,
  * );
@@ -120,7 +120,7 @@ const permit2TransferFromTypes = {
  *   {
  *     erc20: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  *     allowance: 1_000_000n,
- *     spender: "0x6566194141Ff46B819C55E7137d8329898EcD06c",
+ *     spender: "0x6566194141fF46b819c55E7137D8329898eCd06C",
  *     nonce: 0n,
  *     deadline: 1_900_000_000n,
  *   },

--- a/packages/blue-sdk-viem/src/utils.ts
+++ b/packages/blue-sdk-viem/src/utils.ts
@@ -77,7 +77,7 @@ export const safeParseUnits = (strValue: string, decimals = 18) => {
  * ```ts
  * import { safeGetAddress } from "@morpho-org/blue-sdk-viem";
  *
- * const address = safeGetAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+ * const address = safeGetAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
  * ```
  */
 export const safeGetAddress = (address: string) =>

--- a/packages/blue-sdk/src/errors.ts
+++ b/packages/blue-sdk/src/errors.ts
@@ -39,6 +39,13 @@ export class UnknownVaultConfigError extends UnknownDataError {
   }
 }
 
+/** Error thrown when a vault withdraw queue references a market without an allocation. */
+export class UnknownMarketAllocationError extends UnknownDataError {
+  constructor(public readonly marketId: MarketId) {
+    super(`unknown allocation for market ${marketId}`);
+  }
+}
+
 /** Error thrown when a chain id has no configured SDK registry entry. */
 export class UnsupportedChainIdError extends Error {
   constructor(public readonly chainId: number) {

--- a/packages/blue-sdk/src/vault/Vault.test.ts
+++ b/packages/blue-sdk/src/vault/Vault.test.ts
@@ -8,6 +8,7 @@ import {
   vaultInput,
   vaultMarketConfig,
 } from "../__test__/fixtures.js";
+import { UnknownMarketAllocationError } from "../errors.js";
 import { Market } from "../market/Market.js";
 import { MathLib } from "../math/MathLib.js";
 import { AccrualPosition } from "../position/Position.js";
@@ -271,5 +272,24 @@ describe("AccrualVault", () => {
 
     expect(accrued.lostAssets).toBeGreaterThanOrEqual(1n);
     expect(accrued.totalAssets).toBeGreaterThanOrEqual(accrued.lastTotalAssets);
+  });
+
+  test("accrueInterest throws UnknownMarketAllocationError when withdrawQueue references a market not in allocations", () => {
+    const vault = accrualVault();
+    const ghostMarketId = "0x1234" as MarketId;
+    // Mutate the public `withdrawQueue` after construction so it references a
+    // market that has no corresponding entry in `allocations`. Without this
+    // mutation the bug cannot be reached, because the AccrualVault constructor
+    // rebuilds `withdrawQueue` from the allocations argument.
+    vault.withdrawQueue = [...vault.withdrawQueue, ghostMarketId];
+
+    let error: unknown;
+    try {
+      vault.accrueInterest(200n);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(UnknownMarketAllocationError);
   });
 });

--- a/packages/blue-sdk/src/vault/Vault.ts
+++ b/packages/blue-sdk/src/vault/Vault.ts
@@ -429,6 +429,8 @@ export class AccrualVault extends Vault implements IAccrualVault {
   /**
    * Returns a new vault derived from this vault, whose interest has been accrued up to the given timestamp.
    * @param timestamp The timestamp at which to accrue interest. Must be greater than or equal to each of the vault's market's `lastUpdate`.
+   * @returns A new vault whose market positions and fee accounting reflect accrued interest.
+   * @throws {UnknownMarketAllocationError} when the withdraw queue references a market without an allocation.
    */
   public accrueInterest(timestamp?: BigIntish) {
     const vault = new AccrualVault(

--- a/packages/blue-sdk/src/vault/Vault.ts
+++ b/packages/blue-sdk/src/vault/Vault.ts
@@ -1,4 +1,5 @@
 import { Time } from "@morpho-org/morpho-ts";
+import { UnknownMarketAllocationError } from "../errors.js";
 import { MarketUtils } from "../market/index.js";
 import { MathLib, type RoundingDirection } from "../math/index.js";
 import { VaultToken } from "../token/index.js";
@@ -434,8 +435,16 @@ export class AccrualVault extends Vault implements IAccrualVault {
       this,
       // Keep withdraw queue order.
       this.withdrawQueue.map((marketId) => {
-        const { config, position } = this.allocations.get(marketId)!;
+        const allocation = this.allocations.get(marketId);
+        // Fail loudly rather than silently dropping the market: a stale
+        // `withdrawQueue` entry (e.g., one mutated after construction to
+        // reference a market that is no longer allocated) would otherwise
+        // crash with an opaque "Cannot destructure property 'config' of
+        // 'undefined'" via the non-null assertion below.
+        if (allocation == null)
+          throw new UnknownMarketAllocationError(marketId);
 
+        const { config, position } = allocation;
         return {
           config,
           position: position.accrueInterest(timestamp),


### PR DESCRIPTION
Cherry-picks 25ea528187ad04546f5e64e57f0afb40a1df4186 onto current main.

Supersedes #548.

Changes:
- replaces the stale withdrawQueue non-null assertion in AccrualVault.accrueInterest() with UnknownMarketAllocationError
- adds a regression test for a stale withdrawQueue allocation
- documents the exported error and includes a patch changeset for @morpho-org/blue-sdk

Validation:
- pre-commit hook passed: biome check --write --no-errors-on-unmatched && lint:address on staged TypeScript files
- attempted pnpm test -- packages/blue-sdk/src/vault/Vault.test.ts, but stopped it after repeated local RPC connection timeouts to 127.0.0.1 ephemeral ports
