### PR TITLE
feat(midnight-sdk): ratify Ecrecover trees with client signing

### DIFF
--- a/.changeset/add-midnight-sdk.md
+++ b/.changeset/add-midnight-sdk.md
@@ -12,9 +12,9 @@ Payload collateral validation mirrors `Midnight.touchMarket` by rejecting zero c
 
 Offer creation and payload validation require `expiry` to be strictly greater than `start`, so SDK-built offers cannot later fail payload encoding on a zero-duration time range.
 
-Ecrecover ratification rejects trees whose offers span multiple makers, so one maker signature cannot produce payload items for another maker's leaves.
+Ecrecover ratification supports direct maker signatures and delegated signer signatures, including mixed-maker trees when the same signer is authorized by every maker onchain.
 
-Ecrecover ratification accepts a wallet client directly for maker-side signing and derives the EIP-712 domain chain id from that wallet while validating the wallet account and returned signature before producing payload items.
+Ecrecover ratification accepts a viem client plus explicit signer account, derives the EIP-712 domain chain id from that client, and validates the returned signature before producing payload items.
 
 Offer creation only accepts protocol-reachable tick spacings and offer groups require a shared cap mode and value, matching Midnight's tick accessibility and group consumption accounting.
 

--- a/.changeset/add-midnight-sdk.md
+++ b/.changeset/add-midnight-sdk.md
@@ -14,6 +14,8 @@ Offer creation and payload validation require `expiry` to be strictly greater th
 
 Ecrecover ratification rejects trees whose offers span multiple makers, so one maker signature cannot produce payload items for another maker's leaves.
 
+Ecrecover ratification accepts a wallet client directly for maker-side signing and derives the EIP-712 domain chain id from that wallet while validating the wallet account and returned signature before producing payload items.
+
 Offer creation only accepts protocol-reachable tick spacings and offer groups require a shared cap mode and value, matching Midnight's tick accessibility and group consumption accounting.
 
 Tick math constants mirror the current Midnight protocol range and price quantum.

--- a/docs/tibs/TIB-2026-05-20-midnight-sdk-utilities.md
+++ b/docs/tibs/TIB-2026-05-20-midnight-sdk-utilities.md
@@ -530,7 +530,8 @@ if (!validation.valid) {
 // EcrecoverRatifierUtils derives the verifier from offer.ratifier and rejects mixed-ratifier trees.
 const items = await EcrecoverRatifierUtils.ratify({
   tree,
-  walletClient,
+  client: walletClient,
+  account: signer,
 });
 
 const payload = await Payload.encode(items);
@@ -549,7 +550,7 @@ Pure utility namespaces stay available for object-first integrations:
 - `TreeUtils.buildRoot`
 - `TreeUtils.buildProof`
 - `TreeUtils.verifyProof`
-- `EcrecoverRatifierUtils.typedData`, `EcrecoverRatifierUtils.digest`, or `EcrecoverRatifierUtils.sign` with a wallet client;
+- `EcrecoverRatifierUtils.typedData`, `EcrecoverRatifierUtils.digest`, or `EcrecoverRatifierUtils.sign` with a viem client and explicit signer account;
 - `EcrecoverRatifierUtils.encodeRatifierData`
 - `EcrecoverRatifierUtils.decodeRatifierData`
 - `SetterRatifierUtils.encodeRatifierData`

--- a/docs/tibs/TIB-2026-05-20-midnight-sdk-utilities.md
+++ b/docs/tibs/TIB-2026-05-20-midnight-sdk-utilities.md
@@ -530,8 +530,7 @@ if (!validation.valid) {
 // EcrecoverRatifierUtils derives the verifier from offer.ratifier and rejects mixed-ratifier trees.
 const items = await EcrecoverRatifierUtils.ratify({
   tree,
-  chainId,
-  signTypedData,
+  walletClient,
 });
 
 const payload = await Payload.encode(items);
@@ -550,7 +549,7 @@ Pure utility namespaces stay available for object-first integrations:
 - `TreeUtils.buildRoot`
 - `TreeUtils.buildProof`
 - `TreeUtils.verifyProof`
-- `EcrecoverRatifierUtils.typedData`, `EcrecoverRatifierUtils.digest`, or `EcrecoverRatifierUtils.sign` with an injected `signTypedData` callback;
+- `EcrecoverRatifierUtils.typedData`, `EcrecoverRatifierUtils.digest`, or `EcrecoverRatifierUtils.sign` with a wallet client;
 - `EcrecoverRatifierUtils.encodeRatifierData`
 - `EcrecoverRatifierUtils.decodeRatifierData`
 - `SetterRatifierUtils.encodeRatifierData`
@@ -659,7 +658,7 @@ Expose app-style labels, call requests, signature requests, and success callback
 - Authorization is explicit. SDK helpers must not silently grant authorization; any wallet flow that needs `setIsAuthorized` must expose that call deliberately.
 - Future permit helpers must distinguish no permit, ERC-2612, and Permit2 modes. Encoded
   `TokenPermit` shape tests are deferred until those helpers land.
-- Signature helpers must never own wallet state. They accept injected signing callbacks or return typed data descriptors.
+- Signature helpers must never own wallet state. They accept caller-owned wallet clients for signing or return typed data descriptors.
 - Validation helpers must surface typed errors. No SDK source should throw plain `Error`.
 - Tick/price and units/assets helpers must be byte-for-byte compatible with the deployed Solidity math where they claim parity.
 

--- a/packages/midnight-sdk/README.md
+++ b/packages/midnight-sdk/README.md
@@ -19,9 +19,9 @@ Midnight HTTP API helpers are exported from `@morpho-org/midnight-sdk/api`. This
 ## Making offers
 
 The make-side starts with local offer construction, groups offers that should share consumption, and
-commits grouped and standalone offers into one tree. Validate the tree before asking the maker to
-sign or approve the root, then encode the ratified items into a mempool payload and submit the raw
-payload bytes onchain.
+commits grouped and standalone offers into one tree. Validate the tree before asking the maker or an
+authorized signer to sign, or before asking the maker contract to approve the root. Then encode the
+ratified items into a mempool payload and submit the raw payload bytes onchain.
 
 ```ts
 import { addresses } from "@morpho-org/morpho-ts";
@@ -35,7 +35,6 @@ import {
 import {
   parseUnits,
   zeroAddress,
-  type Account,
   type Address,
   type Chain,
   type Transport,
@@ -49,7 +48,7 @@ const ecrecoverRatifier = addresses[chainId].ecrecoverRatifier!;
 const midnightMempool = addresses[chainId].midnightMempool!;
 
 export async function makeBaseUsdcWethOffers(params: {
-  readonly walletClient: WalletClient<Transport, Chain, Account>;
+  readonly walletClient: WalletClient<Transport, Chain>;
   readonly maker: Address;
   readonly wethUsdcOracle: Address;
 }) {
@@ -107,9 +106,11 @@ export async function makeBaseUsdcWethOffers(params: {
   }
 
   // EcrecoverRatifierUtils derives the verifier from offer.ratifier and rejects mixed-ratifier trees.
+  // The account may be the maker or an authorized signer for every maker in the tree.
   const items = await EcrecoverRatifierUtils.ratify({
     tree,
-    walletClient: params.walletClient,
+    client: params.walletClient,
+    account: params.maker,
   });
   const payload = await Payload.encode(items);
 

--- a/packages/midnight-sdk/README.md
+++ b/packages/midnight-sdk/README.md
@@ -32,7 +32,15 @@ import {
   Payload,
   Tree,
 } from "@morpho-org/midnight-sdk";
-import { parseUnits, zeroAddress, type Address, type WalletClient } from "viem";
+import {
+  parseUnits,
+  zeroAddress,
+  type Account,
+  type Address,
+  type Chain,
+  type Transport,
+  type WalletClient,
+} from "viem";
 
 const chainId = 8453;
 const usdc = addresses[chainId].usdc!;
@@ -41,7 +49,7 @@ const ecrecoverRatifier = addresses[chainId].ecrecoverRatifier!;
 const midnightMempool = addresses[chainId].midnightMempool!;
 
 export async function makeBaseUsdcWethOffers(params: {
-  readonly walletClient: WalletClient;
+  readonly walletClient: WalletClient<Transport, Chain, Account>;
   readonly maker: Address;
   readonly wethUsdcOracle: Address;
 }) {
@@ -101,12 +109,7 @@ export async function makeBaseUsdcWethOffers(params: {
   // EcrecoverRatifierUtils derives the verifier from offer.ratifier and rejects mixed-ratifier trees.
   const items = await EcrecoverRatifierUtils.ratify({
     tree,
-    chainId,
-    signTypedData: (typedData) =>
-      params.walletClient.signTypedData({
-        account: params.maker,
-        ...typedData,
-      }),
+    walletClient: params.walletClient,
   });
   const payload = await Payload.encode(items);
 

--- a/packages/midnight-sdk/src/errors.ts
+++ b/packages/midnight-sdk/src/errors.ts
@@ -1,3 +1,5 @@
+import type { Address } from "viem";
+
 /**
  * Thrown when a Midnight offer group violates protocol-level group mechanics.
  *
@@ -215,6 +217,65 @@ export class InvalidTreeError extends Error {
   public constructor(message: string) {
     super(message);
     this.name = "InvalidTreeError";
+  }
+}
+
+/**
+ * Thrown when an Ecrecover signing wallet client is not bound to the tree maker.
+ *
+ * @example
+ * ```ts
+ * import { EcrecoverRatifierAccountMismatchError } from "@morpho-org/midnight-sdk";
+ *
+ * throw new EcrecoverRatifierAccountMismatchError(
+ *   "0x0000000000000000000000000000000000000001",
+ *   "0x0000000000000000000000000000000000000002",
+ * );
+ * ```
+ */
+export class EcrecoverRatifierAccountMismatchError extends Error {
+  /** Account address reported by the wallet client. */
+  public readonly clientAccount: Address;
+
+  /** Maker address expected by the tree. */
+  public readonly expectedMaker: Address;
+
+  public constructor(clientAccount: Address, expectedMaker: Address) {
+    super(
+      `Ecrecover wallet client account mismatch: expected maker "${expectedMaker}", got "${clientAccount}". Connect the maker account before signing.`,
+    );
+    this.name = "EcrecoverRatifierAccountMismatchError";
+    this.clientAccount = clientAccount;
+    this.expectedMaker = expectedMaker;
+  }
+}
+
+/**
+ * Thrown when an Ecrecover wallet returns a signature that fails verification.
+ *
+ * @example
+ * ```ts
+ * import { InvalidEcrecoverRatifierSignatureError } from "@morpho-org/midnight-sdk";
+ *
+ * throw new InvalidEcrecoverRatifierSignatureError({
+ *   maker: "0x0000000000000000000000000000000000000001",
+ * });
+ * ```
+ */
+export class InvalidEcrecoverRatifierSignatureError extends Error {
+  /** Maker address the signature was expected to recover. */
+  public readonly maker: Address;
+
+  public constructor(params: {
+    readonly maker: Address;
+    readonly cause?: unknown;
+  }) {
+    super(
+      `Ecrecover signature verification failed for maker "${params.maker}". The wallet signed different typed data or returned a malformed signature.`,
+      params.cause === undefined ? undefined : { cause: params.cause },
+    );
+    this.name = "InvalidEcrecoverRatifierSignatureError";
+    this.maker = params.maker;
   }
 }
 

--- a/packages/midnight-sdk/src/errors.ts
+++ b/packages/midnight-sdk/src/errors.ts
@@ -1,5 +1,3 @@
-import type { Address } from "viem";
-
 /**
  * Thrown when a Midnight offer group violates protocol-level group mechanics.
  *
@@ -217,35 +215,6 @@ export class InvalidTreeError extends Error {
   public constructor(message: string) {
     super(message);
     this.name = "InvalidTreeError";
-  }
-}
-
-/**
- * Thrown when an Ecrecover signing client returns a signature that fails verification.
- *
- * @example
- * ```ts
- * import { InvalidEcrecoverRatifierSignatureError } from "@morpho-org/midnight-sdk";
- *
- * throw new InvalidEcrecoverRatifierSignatureError({
- *   signer: "0x0000000000000000000000000000000000000001",
- * });
- * ```
- */
-export class InvalidEcrecoverRatifierSignatureError extends Error {
-  /** Signer address the signature was expected to recover. */
-  public readonly signer: Address;
-
-  public constructor(params: {
-    readonly signer: Address;
-    readonly cause?: unknown;
-  }) {
-    super(
-      `Ecrecover signature verification failed for signer "${params.signer}". The client signed different typed data or returned a malformed signature.`,
-      params.cause === undefined ? undefined : { cause: params.cause },
-    );
-    this.name = "InvalidEcrecoverRatifierSignatureError";
-    this.signer = params.signer;
   }
 }
 

--- a/packages/midnight-sdk/src/errors.ts
+++ b/packages/midnight-sdk/src/errors.ts
@@ -221,61 +221,31 @@ export class InvalidTreeError extends Error {
 }
 
 /**
- * Thrown when an Ecrecover signing wallet client is not bound to the tree maker.
- *
- * @example
- * ```ts
- * import { EcrecoverRatifierAccountMismatchError } from "@morpho-org/midnight-sdk";
- *
- * throw new EcrecoverRatifierAccountMismatchError(
- *   "0x0000000000000000000000000000000000000001",
- *   "0x0000000000000000000000000000000000000002",
- * );
- * ```
- */
-export class EcrecoverRatifierAccountMismatchError extends Error {
-  /** Account address reported by the wallet client. */
-  public readonly clientAccount: Address;
-
-  /** Maker address expected by the tree. */
-  public readonly expectedMaker: Address;
-
-  public constructor(clientAccount: Address, expectedMaker: Address) {
-    super(
-      `Ecrecover wallet client account mismatch: expected maker "${expectedMaker}", got "${clientAccount}". Connect the maker account before signing.`,
-    );
-    this.name = "EcrecoverRatifierAccountMismatchError";
-    this.clientAccount = clientAccount;
-    this.expectedMaker = expectedMaker;
-  }
-}
-
-/**
- * Thrown when an Ecrecover wallet returns a signature that fails verification.
+ * Thrown when an Ecrecover signing client returns a signature that fails verification.
  *
  * @example
  * ```ts
  * import { InvalidEcrecoverRatifierSignatureError } from "@morpho-org/midnight-sdk";
  *
  * throw new InvalidEcrecoverRatifierSignatureError({
- *   maker: "0x0000000000000000000000000000000000000001",
+ *   signer: "0x0000000000000000000000000000000000000001",
  * });
  * ```
  */
 export class InvalidEcrecoverRatifierSignatureError extends Error {
-  /** Maker address the signature was expected to recover. */
-  public readonly maker: Address;
+  /** Signer address the signature was expected to recover. */
+  public readonly signer: Address;
 
   public constructor(params: {
-    readonly maker: Address;
+    readonly signer: Address;
     readonly cause?: unknown;
   }) {
     super(
-      `Ecrecover signature verification failed for maker "${params.maker}". The wallet signed different typed data or returned a malformed signature.`,
+      `Ecrecover signature verification failed for signer "${params.signer}". The client signed different typed data or returned a malformed signature.`,
       params.cause === undefined ? undefined : { cause: params.cause },
     );
     this.name = "InvalidEcrecoverRatifierSignatureError";
-    this.maker = params.maker;
+    this.signer = params.signer;
   }
 }
 

--- a/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.test.ts
+++ b/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.test.ts
@@ -1,19 +1,9 @@
-import {
-  type Account,
-  type Chain,
-  createWalletClient,
-  custom,
-  type Hex,
-  type Signature,
-  type Transport,
-  type WalletClient,
-} from "viem";
+import { createWalletClient, custom, type Hex, type Signature } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { base } from "viem/chains";
 import { describe, expect, test } from "vitest";
-import { addresses, baseOffer, chainId } from "../__test__/fixtures.js";
+import { addresses, baseOffer } from "../__test__/fixtures.js";
 import {
-  EcrecoverRatifierAccountMismatchError,
   InvalidEcrecoverRatifierSignatureError,
   InvalidTreeError,
   InvalidTreeHeightError,
@@ -58,20 +48,20 @@ describe("EcrecoverRatifierUtils.ratify", () => {
     ).toBe(true);
   });
 
-  test("behavior: signs with wallet client", async () => {
+  test("behavior: signs with client and account", async () => {
     const account = privateKeyToAccount(privateKey);
     const tree = Tree.create([
       baseOffer({ maker: account.address, maxAssets: 0n }),
     ]);
-    const walletClient = createWalletClient({
-      account,
+    const client = createWalletClient({
       chain: base,
       transport: custom({ request: async () => null }),
     });
 
     const items = await EcrecoverRatifierUtils.ratify({
       tree,
-      walletClient,
+      client,
+      account,
     });
     const decoded = EcrecoverRatifierUtils.decodeRatifierData(
       items[0]!.ratifierData,
@@ -88,6 +78,28 @@ describe("EcrecoverRatifierUtils.ratify", () => {
         proof: decoded.proof,
       }),
     ).toBe(true);
+  });
+
+  test("behavior: signs mixed-maker tree with delegate account", async () => {
+    const account = privateKeyToAccount(privateKey);
+    const tree = Tree.create([
+      baseOffer({ maxAssets: 0n, maker: addresses.maker }),
+      baseOffer({ maxAssets: 0n, maker: addresses.taker }),
+    ]);
+    const client = createWalletClient({
+      chain: base,
+      transport: custom({ request: async () => null }),
+    });
+
+    const items = await EcrecoverRatifierUtils.ratify({
+      tree,
+      client,
+      account,
+    });
+
+    expect(items).toHaveLength(2);
+    expect(items[0]!.offer.maker).toBe(addresses.maker);
+    expect(items[1]!.offer.maker).toBe(addresses.taker);
   });
 
   test("error: InvalidTreeError mixed ratifiers", async () => {
@@ -114,82 +126,21 @@ describe("EcrecoverRatifierUtils.ratify", () => {
     ).rejects.toThrow(InvalidTreeError);
   });
 
-  test("error: InvalidTreeError mixed makers", async () => {
-    const tree = Tree.create([
-      baseOffer({ maxAssets: 0n, maker: addresses.maker }),
-      baseOffer({ maxAssets: 0n, maker: addresses.taker }),
-    ]);
-
-    await expect(
-      EcrecoverRatifierUtils.ratify({
-        tree,
-        signature: {
-          v: 27,
-          r: "0x0000000000000000000000000000000000000000000000000000000000000000",
-          s: "0x0000000000000000000000000000000000000000000000000000000000000000",
-        },
-      }),
-    ).rejects.toThrow(InvalidTreeError);
-  });
-
-  test("error: InvalidTreeError mixed makers before signing", async () => {
-    const tree = Tree.create([
-      baseOffer({ maxAssets: 0n, maker: addresses.maker }),
-      baseOffer({ maxAssets: 0n, maker: addresses.taker }),
-    ]);
-    let signed = false;
-
-    await expect(
-      EcrecoverRatifierUtils.ratify({
-        tree,
-        walletClient: {
-          account: addresses.maker,
-          chain: { id: chainId },
-          signTypedData: () => {
-            signed = true;
-            return invalidSignature;
-          },
-        } as unknown as WalletClient<Transport, Chain, Account>,
-      }),
-    ).rejects.toThrow(InvalidTreeError);
-    expect(signed).toBe(false);
-  });
-
-  test("error: EcrecoverRatifierAccountMismatchError before signing", async () => {
-    const account = privateKeyToAccount(privateKey);
-    const tree = Tree.create([baseOffer({ maxAssets: 0n })]);
-    let signed = false;
-
-    await expect(
-      EcrecoverRatifierUtils.ratify({
-        tree,
-        walletClient: {
-          account,
-          chain: { id: chainId },
-          signTypedData: () => {
-            signed = true;
-            return invalidSignature;
-          },
-        } as unknown as WalletClient<Transport, Chain, Account>,
-      }),
-    ).rejects.toThrow(EcrecoverRatifierAccountMismatchError);
-    expect(signed).toBe(false);
-  });
-
   test("error: InvalidEcrecoverRatifierSignatureError", async () => {
     const account = privateKeyToAccount(privateKey);
     const tree = Tree.create([
       baseOffer({ maker: account.address, maxAssets: 0n }),
     ]);
+    const client = createWalletClient({
+      chain: base,
+      transport: custom({ request: async () => invalidSignature }),
+    });
 
     await expect(
       EcrecoverRatifierUtils.ratify({
         tree,
-        walletClient: {
-          account,
-          chain: { id: chainId },
-          signTypedData: () => invalidSignature,
-        } as unknown as WalletClient<Transport, Chain, Account>,
+        client,
+        account: account.address,
       }),
     ).rejects.toThrow(InvalidEcrecoverRatifierSignatureError);
   });
@@ -229,15 +180,15 @@ describe("EcrecoverRatifierUtils.typedData", () => {
     ).toThrow(InvalidTreeError);
   });
 
-  test("error: InvalidTreeError mixed makers", () => {
+  test("behavior: accepts mixed makers", () => {
     const tree = Tree.create([
       baseOffer({ maxAssets: 0n, maker: addresses.maker }),
       baseOffer({ maxAssets: 0n, maker: addresses.taker }),
     ]);
 
-    expect(() =>
-      EcrecoverRatifierUtils.typedData({ tree, chainId: 8453n }),
-    ).toThrow(InvalidTreeError);
+    expect(
+      EcrecoverRatifierUtils.typedData({ tree, chainId: 8453n }).primaryType,
+    ).toBe("OfferTree");
   });
 });
 
@@ -258,15 +209,15 @@ describe("EcrecoverRatifierUtils.sign", () => {
     const tree = Tree.create([
       baseOffer({ maker: account.address, maxAssets: 0n }),
     ]);
-    const walletClient = createWalletClient({
-      account,
+    const client = createWalletClient({
       chain: base,
       transport: custom({ request: async () => null }),
     });
 
     const signature = await EcrecoverRatifierUtils.sign({
       tree,
-      walletClient,
+      client,
+      account,
     });
 
     expect(signature).toMatch(/^0x[0-9a-f]{130}$/);
@@ -298,13 +249,13 @@ describe("EcrecoverRatifierUtils.toSignature", () => {
 });
 
 describe("EcrecoverRatifierUtils.ratifierData", () => {
-  test("error: InvalidTreeError mixed makers", () => {
+  test("behavior: accepts mixed makers", () => {
     const tree = Tree.create([
       baseOffer({ maxAssets: 0n, maker: addresses.maker }),
       baseOffer({ maxAssets: 0n, maker: addresses.taker }),
     ]);
 
-    expect(() =>
+    expect(
       EcrecoverRatifierUtils.ratifierData({
         tree,
         leafIndex: 0n,
@@ -313,8 +264,8 @@ describe("EcrecoverRatifierUtils.ratifierData", () => {
           r: "0x0000000000000000000000000000000000000000000000000000000000000000",
           s: "0x0000000000000000000000000000000000000000000000000000000000000000",
         },
-      }),
-    ).toThrow(InvalidTreeError);
+      }).startsWith("0x"),
+    ).toBe(true);
   });
 });
 

--- a/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.test.ts
+++ b/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.test.ts
@@ -1,7 +1,23 @@
-import type { Signature } from "viem";
+import {
+  type Account,
+  type Chain,
+  createWalletClient,
+  custom,
+  type Hex,
+  type Signature,
+  type Transport,
+  type WalletClient,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
 import { describe, expect, test } from "vitest";
-import { addresses, baseOffer } from "../__test__/fixtures.js";
-import { InvalidTreeError, InvalidTreeHeightError } from "../errors.js";
+import { addresses, baseOffer, chainId } from "../__test__/fixtures.js";
+import {
+  EcrecoverRatifierAccountMismatchError,
+  InvalidEcrecoverRatifierSignatureError,
+  InvalidTreeError,
+  InvalidTreeHeightError,
+} from "../errors.js";
 import { EcrecoverRatifierUtils } from "./EcrecoverRatifierUtils.js";
 import { Tree } from "./Tree.js";
 import { TreeUtils } from "./TreeUtils.js";
@@ -10,6 +26,9 @@ const root =
   "0x3333333333333333333333333333333333333333333333333333333333333333" as const;
 const proofNode =
   "0x4444444444444444444444444444444444444444444444444444444444444444" as const;
+const privateKey =
+  "0x0000000000000000000000000000000000000000000000000000000000000001" as const;
+const invalidSignature = `0x${"00".repeat(65)}` as Hex;
 
 describe("EcrecoverRatifierUtils.ratify", () => {
   test("default", async () => {
@@ -29,6 +48,38 @@ describe("EcrecoverRatifierUtils.ratify", () => {
     expect(items).toHaveLength(1);
     expect(items[0]!.offer).toBe(tree.offers[0]);
     expect(decoded.signature).toEqual(signature);
+    expect(
+      TreeUtils.verifyProof({
+        offer: items[0]!.offer,
+        root: decoded.root,
+        leafIndex: decoded.leafIndex,
+        proof: decoded.proof,
+      }),
+    ).toBe(true);
+  });
+
+  test("behavior: signs with wallet client", async () => {
+    const account = privateKeyToAccount(privateKey);
+    const tree = Tree.create([
+      baseOffer({ maker: account.address, maxAssets: 0n }),
+    ]);
+    const walletClient = createWalletClient({
+      account,
+      chain: base,
+      transport: custom({ request: async () => null }),
+    });
+
+    const items = await EcrecoverRatifierUtils.ratify({
+      tree,
+      walletClient,
+    });
+    const decoded = EcrecoverRatifierUtils.decodeRatifierData(
+      items[0]!.ratifierData,
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]!.offer).toBe(tree.offers[0]);
+    expect([27, 28]).toContain(decoded.signature.v);
     expect(
       TreeUtils.verifyProof({
         offer: items[0]!.offer,
@@ -91,14 +142,56 @@ describe("EcrecoverRatifierUtils.ratify", () => {
     await expect(
       EcrecoverRatifierUtils.ratify({
         tree,
-        chainId: 8453n,
-        signTypedData: () => {
-          signed = true;
-          return "0x";
-        },
+        walletClient: {
+          account: addresses.maker,
+          chain: { id: chainId },
+          signTypedData: () => {
+            signed = true;
+            return invalidSignature;
+          },
+        } as unknown as WalletClient<Transport, Chain, Account>,
       }),
     ).rejects.toThrow(InvalidTreeError);
     expect(signed).toBe(false);
+  });
+
+  test("error: EcrecoverRatifierAccountMismatchError before signing", async () => {
+    const account = privateKeyToAccount(privateKey);
+    const tree = Tree.create([baseOffer({ maxAssets: 0n })]);
+    let signed = false;
+
+    await expect(
+      EcrecoverRatifierUtils.ratify({
+        tree,
+        walletClient: {
+          account,
+          chain: { id: chainId },
+          signTypedData: () => {
+            signed = true;
+            return invalidSignature;
+          },
+        } as unknown as WalletClient<Transport, Chain, Account>,
+      }),
+    ).rejects.toThrow(EcrecoverRatifierAccountMismatchError);
+    expect(signed).toBe(false);
+  });
+
+  test("error: InvalidEcrecoverRatifierSignatureError", async () => {
+    const account = privateKeyToAccount(privateKey);
+    const tree = Tree.create([
+      baseOffer({ maker: account.address, maxAssets: 0n }),
+    ]);
+
+    await expect(
+      EcrecoverRatifierUtils.ratify({
+        tree,
+        walletClient: {
+          account,
+          chain: { id: chainId },
+          signTypedData: () => invalidSignature,
+        } as unknown as WalletClient<Transport, Chain, Account>,
+      }),
+    ).rejects.toThrow(InvalidEcrecoverRatifierSignatureError);
   });
 });
 
@@ -156,6 +249,27 @@ describe("EcrecoverRatifierUtils.digest", () => {
     });
 
     expect(digest).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+});
+
+describe("EcrecoverRatifierUtils.sign", () => {
+  test("default", async () => {
+    const account = privateKeyToAccount(privateKey);
+    const tree = Tree.create([
+      baseOffer({ maker: account.address, maxAssets: 0n }),
+    ]);
+    const walletClient = createWalletClient({
+      account,
+      chain: base,
+      transport: custom({ request: async () => null }),
+    });
+
+    const signature = await EcrecoverRatifierUtils.sign({
+      tree,
+      walletClient,
+    });
+
+    expect(signature).toMatch(/^0x[0-9a-f]{130}$/);
   });
 });
 

--- a/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.test.ts
+++ b/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.test.ts
@@ -3,11 +3,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import { base } from "viem/chains";
 import { describe, expect, test } from "vitest";
 import { addresses, baseOffer } from "../__test__/fixtures.js";
-import {
-  InvalidEcrecoverRatifierSignatureError,
-  InvalidTreeError,
-  InvalidTreeHeightError,
-} from "../errors.js";
+import { InvalidTreeError, InvalidTreeHeightError } from "../errors.js";
 import { EcrecoverRatifierUtils } from "./EcrecoverRatifierUtils.js";
 import { Tree } from "./Tree.js";
 import { TreeUtils } from "./TreeUtils.js";
@@ -126,7 +122,7 @@ describe("EcrecoverRatifierUtils.ratify", () => {
     ).rejects.toThrow(InvalidTreeError);
   });
 
-  test("error: InvalidEcrecoverRatifierSignatureError", async () => {
+  test("error: propagates viem signature verification errors", async () => {
     const account = privateKeyToAccount(privateKey);
     const tree = Tree.create([
       baseOffer({ maker: account.address, maxAssets: 0n }),
@@ -142,7 +138,7 @@ describe("EcrecoverRatifierUtils.ratify", () => {
         client,
         account: account.address,
       }),
-    ).rejects.toThrow(InvalidEcrecoverRatifierSignatureError);
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.ts
+++ b/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.ts
@@ -1,17 +1,28 @@
 import { type BigIntish, deepFreeze } from "@morpho-org/morpho-ts";
 import {
+  type Account,
   type Address,
+  type Chain,
   concat,
   decodeAbiParameters,
   encodeAbiParameters,
   type Hash,
   type Hex,
+  isAddressEqual,
   keccak256,
   parseSignature,
   type Signature,
+  type Transport,
+  verifyTypedData,
+  type WalletClient,
 } from "viem";
 import { EIP712_DOMAIN_TYPEHASH } from "../constants.js";
-import { InvalidTreeError, InvalidTreeHeightError } from "../errors.js";
+import {
+  EcrecoverRatifierAccountMismatchError,
+  InvalidEcrecoverRatifierSignatureError,
+  InvalidTreeError,
+  InvalidTreeHeightError,
+} from "../errors.js";
 import type { OfferStruct } from "../offers/index.js";
 import type { Item as PayloadItem } from "./Payload.js";
 import type { Tree } from "./Tree.js";
@@ -238,21 +249,6 @@ export type EcrecoverSignatureInput =
   | Signature<number, number>;
 
 /**
- * Signing callback accepted by Ecrecover ratifier helpers.
- *
- * @example
- * ```ts
- * import type { EcrecoverSignTypedData } from "@morpho-org/midnight-sdk";
- *
- * const signTypedData: EcrecoverSignTypedData = () => "0x";
- * console.log(signTypedData);
- * ```
- */
-export type EcrecoverSignTypedData = (
-  typedData: EcrecoverRatificationTypedData,
-) => Hex | Promise<Hex>;
-
-/**
  * Parameters for {@link EcrecoverRatifierUtils.typedData}.
  *
  * Use these after `Tree.create` and after the maker route has been classified
@@ -296,8 +292,8 @@ export interface EcrecoverRatifierTypedDataParams {
 /**
  * Parameters for {@link EcrecoverRatifierUtils.ratify}.
  *
- * Use this after tree validation. Provide either a signing callback for the
- * maker wallet or a signature that was produced from `typedData`.
+ * Use this after tree validation. Provide either the maker wallet client or a
+ * signature that was produced from `typedData`.
  *
  * @example
  * ```ts
@@ -328,19 +324,21 @@ export interface EcrecoverRatifierTypedDataParams {
  * ```
  */
 export type EcrecoverRatifierRatifyParams =
-  | (EcrecoverRatifierTypedDataParams & {
-      /** Callback that signs the typed data built from `tree`. */
-      readonly signTypedData: EcrecoverSignTypedData;
-      /** Omit when the SDK should request the signature through `signTypedData`. */
+  | {
+      /** Tree being ratified. */
+      readonly tree: Tree;
+      /** Wallet client that signs the typed data built from `tree`. */
+      readonly walletClient: WalletClient<Transport, Chain, Account>;
+      /** Omit when the SDK should request the signature through `walletClient`. */
       readonly signature?: undefined;
-    })
+    }
   | {
       /** Tree being ratified. */
       readonly tree: Tree;
       /** Precomputed signature for this tree root. */
       readonly signature: EcrecoverSignatureInput;
       /** Omit when a precomputed signature is supplied. */
-      readonly signTypedData?: undefined;
+      readonly walletClient?: undefined;
       /** Omit when a precomputed signature is supplied. */
       readonly chainId?: undefined;
     };
@@ -428,8 +426,8 @@ export namespace EcrecoverRatifierUtils {
    *
    * Use after the tree is built and validated, before requesting the maker's
    * wallet signature. The EIP-712 verifier is derived from the shared ratifier
-   * address on the tree offers. `ratify` calls this for you when given
-   * `signTypedData`.
+   * address on the tree offers. `ratify` calls this for you when given a
+   * `walletClient`.
    *
    * @param params.tree - Ecrecover-ratified offer tree to sign.
    * @param params.chainId - EIP-155 chain id included in the EIP-712 domain.
@@ -549,23 +547,25 @@ export namespace EcrecoverRatifierUtils {
   }
 
   /**
-   * Signs EcrecoverRatifier typed data through an injected signing callback.
+   * Signs EcrecoverRatifier typed data through a wallet client.
    *
    * Use when app code wants the signature separately from payload item
    * construction. If you only need payload items, call `ratify` with the same
-   * `signTypedData` callback.
+   * wallet client.
    *
    * @param params.tree - Ecrecover-ratified offer tree to sign.
-   * @param params.chainId - EIP-155 chain id included in the EIP-712 domain.
-   * @param params.signTypedData - Callback that signs the typed data built from `params.tree`.
-   * @returns Signature returned by the callback.
+   * @param params.walletClient - Wallet client that signs the tree typed data.
+   * @returns Signature returned by the wallet client.
+   * @throws {EcrecoverRatifierAccountMismatchError} when the wallet client's account is not the tree maker.
+   * @throws {InvalidEcrecoverRatifierSignatureError} when EIP-712 verification rejects the returned signature.
    * @throws {InvalidTreeError} when the tree is invalid or contains multiple makers or ratifiers.
    * @throws {InvalidTreeHeightError} when the tree height is unsupported.
    * @example
    * ```ts
    * import { EcrecoverRatifierUtils, Tree } from "@morpho-org/midnight-sdk";
    * import { Offer } from "@morpho-org/midnight-sdk";
-   * import { zeroAddress } from "viem";
+   * import { createWalletClient, http, zeroAddress } from "viem";
+   * import { base } from "viem/chains";
    *
    * const offer = Offer.create({
    *   market: {
@@ -583,21 +583,60 @@ export namespace EcrecoverRatifierUtils {
    *   ratifier: "0x0000000000000000000000000000000000004000",
    *   maxUnits: 100n,
    * });
+   * const walletClient = createWalletClient({
+   *   account: offer.maker,
+   *   chain: base,
+   *   transport: http(),
+   * });
    *
    * const signature = await EcrecoverRatifierUtils.sign({
    *   tree: Tree.create([offer]),
-   *   chainId: 8453n,
-   *   signTypedData: () => "0x",
+   *   walletClient,
    * });
    * console.log(signature);
    * ```
    */
-  export async function sign(
-    params: EcrecoverRatifierTypedDataParams & {
-      readonly signTypedData: EcrecoverSignTypedData;
-    },
-  ) {
-    return params.signTypedData(typedData(params));
+  export async function sign(params: {
+    readonly tree: Tree;
+    readonly walletClient: WalletClient<Transport, Chain, Account>;
+  }): Promise<Hex> {
+    const data = typedData({
+      tree: params.tree,
+      chainId: params.walletClient.chain.id,
+    });
+    const account = params.walletClient.account;
+    const maker = params.tree.offers[0]!.maker;
+    if (!isAddressEqual(account.address, maker)) {
+      throw new EcrecoverRatifierAccountMismatchError(account.address, maker);
+    }
+
+    const signature = await params.walletClient.signTypedData<
+      Record<string, unknown>,
+      "OfferTree"
+    >({
+      account,
+      ...data,
+    });
+
+    let isValid: boolean;
+    try {
+      isValid = await verifyTypedData<Record<string, unknown>, "OfferTree">({
+        ...data,
+        address: maker,
+        signature,
+      });
+    } catch (cause) {
+      throw new InvalidEcrecoverRatifierSignatureError({
+        maker,
+        cause,
+      });
+    }
+
+    if (!isValid) {
+      throw new InvalidEcrecoverRatifierSignatureError({ maker });
+    }
+
+    return signature;
   }
 
   /**
@@ -789,17 +828,19 @@ export namespace EcrecoverRatifierUtils {
    * required by takers. The group id is stored on each inline offer.
    *
    * @param params.tree - Ecrecover-ratified offer tree to ratify.
-   * @param params.chainId - EIP-155 chain id used when `params.signTypedData` signs the tree.
-   * @param params.signTypedData - Optional callback that signs typed data built from `params.tree`.
+   * @param params.walletClient - Optional wallet client that signs typed data built from `params.tree`.
    * @param params.signature - Optional precomputed signature for `params.tree`.
    * @returns Items containing each offer and its ratifier data.
+   * @throws {EcrecoverRatifierAccountMismatchError} when the signing wallet client's account is not the tree maker.
+   * @throws {InvalidEcrecoverRatifierSignatureError} when EIP-712 verification rejects the returned signature.
    * @throws {InvalidTreeError} when the tree is invalid or contains multiple makers or ratifiers.
    * @throws {InvalidTreeHeightError} when the tree height is unsupported.
    * @example
    * ```ts
    * import { EcrecoverRatifierUtils, Tree } from "@morpho-org/midnight-sdk";
    * import { Offer } from "@morpho-org/midnight-sdk";
-   * import { zeroAddress } from "viem";
+   * import { createWalletClient, http, zeroAddress } from "viem";
+   * import { base } from "viem/chains";
    *
    * const offer = Offer.create({
    *   market: {
@@ -817,14 +858,15 @@ export namespace EcrecoverRatifierUtils {
    *   ratifier: "0x0000000000000000000000000000000000004000",
    *   maxUnits: 100n,
    * });
+   * const walletClient = createWalletClient({
+   *   account: offer.maker,
+   *   chain: base,
+   *   transport: http(),
+   * });
    *
    * const items = await EcrecoverRatifierUtils.ratify({
    *   tree: Tree.create([offer]),
-   *   signature: {
-   *     v: 27,
-   *     r: "0x0000000000000000000000000000000000000000000000000000000000000000",
-   *     s: "0x0000000000000000000000000000000000000000000000000000000000000000",
-   *   },
+   *   walletClient,
    * });
    * console.log(items.length);
    * ```
@@ -837,7 +879,7 @@ export namespace EcrecoverRatifierUtils {
       getTreeRatifier(params.tree);
       signature = toSignature(params.signature);
     } else {
-      signature = toSignature(await params.signTypedData(typedData(params)));
+      signature = toSignature(await sign(params));
     }
     const items: PayloadItem[] = [];
 

--- a/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.ts
+++ b/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.ts
@@ -17,11 +17,7 @@ import {
 } from "viem";
 import { signTypedData } from "viem/actions";
 import { EIP712_DOMAIN_TYPEHASH } from "../constants.js";
-import {
-  InvalidEcrecoverRatifierSignatureError,
-  InvalidTreeError,
-  InvalidTreeHeightError,
-} from "../errors.js";
+import { InvalidTreeError, InvalidTreeHeightError } from "../errors.js";
 import type { OfferStruct } from "../offers/index.js";
 import type { Item as PayloadItem } from "./Payload.js";
 import type { Tree } from "./Tree.js";
@@ -556,7 +552,6 @@ export namespace EcrecoverRatifierUtils {
    * @param params.client - Viem client whose transport signs the tree typed data.
    * @param params.account - Account used to sign the tree typed data.
    * @returns Signature returned by the client.
-   * @throws {InvalidEcrecoverRatifierSignatureError} when EIP-712 verification rejects the returned signature.
    * @throws {InvalidTreeError} when the tree is invalid or contains multiple ratifiers.
    * @throws {InvalidTreeHeightError} when the tree height is unsupported.
    * @example
@@ -619,23 +614,11 @@ export namespace EcrecoverRatifierUtils {
       ...data,
     });
 
-    let isValid: boolean;
-    try {
-      isValid = await verifyTypedData<Record<string, unknown>, "OfferTree">({
-        ...data,
-        address: signer,
-        signature,
-      });
-    } catch (cause) {
-      throw new InvalidEcrecoverRatifierSignatureError({
-        signer,
-        cause,
-      });
-    }
-
-    if (!isValid) {
-      throw new InvalidEcrecoverRatifierSignatureError({ signer });
-    }
+    await verifyTypedData<Record<string, unknown>, "OfferTree">({
+      ...data,
+      address: signer,
+      signature,
+    });
 
     return signature;
   }
@@ -833,7 +816,6 @@ export namespace EcrecoverRatifierUtils {
    * @param params.account - Optional account used to sign typed data built from `params.tree`.
    * @param params.signature - Optional precomputed signature for `params.tree`.
    * @returns Items containing each offer and its ratifier data.
-   * @throws {InvalidEcrecoverRatifierSignatureError} when EIP-712 verification rejects the returned signature.
    * @throws {InvalidTreeError} when the tree is invalid or contains multiple ratifiers.
    * @throws {InvalidTreeHeightError} when the tree height is unsupported.
    * @example

--- a/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.ts
+++ b/packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.ts
@@ -3,22 +3,21 @@ import {
   type Account,
   type Address,
   type Chain,
+  type Client,
   concat,
   decodeAbiParameters,
   encodeAbiParameters,
   type Hash,
   type Hex,
-  isAddressEqual,
   keccak256,
   parseSignature,
   type Signature,
   type Transport,
   verifyTypedData,
-  type WalletClient,
 } from "viem";
+import { signTypedData } from "viem/actions";
 import { EIP712_DOMAIN_TYPEHASH } from "../constants.js";
 import {
-  EcrecoverRatifierAccountMismatchError,
   InvalidEcrecoverRatifierSignatureError,
   InvalidTreeError,
   InvalidTreeHeightError,
@@ -131,15 +130,8 @@ const getTreeRatifier = (tree: Tree): Address => {
   }
 
   const ratifier = firstOffer.ratifier;
-  const maker = firstOffer.maker;
   const comparableRatifier = ratifier.toLowerCase();
-  const comparableMaker = maker.toLowerCase();
   for (const offer of offers.slice(1)) {
-    if (offer.maker.toLowerCase() !== comparableMaker) {
-      throw new InvalidTreeError(
-        `All offers in an Ecrecover tree must use one maker; expected "${maker}", got "${offer.maker}". Build separate trees per maker.`,
-      );
-    }
     if (offer.ratifier.toLowerCase() !== comparableRatifier) {
       throw new InvalidTreeError(
         `All offers in an Ecrecover tree must use one ratifier; expected "${ratifier}", got "${offer.ratifier}". Build separate trees per ratifier.`,
@@ -180,8 +172,9 @@ export interface DecodedEcrecoverRatifierData extends TreeProof {
 /**
  * Ecrecover typed-data descriptor returned to signing code.
  *
- * Pass this descriptor to the maker wallet before payload encoding. The
- * resulting signature is later embedded into every payload item for the tree.
+ * Pass this descriptor to the maker or authorized signer before payload
+ * encoding. The resulting signature is later embedded into every payload item
+ * for the tree.
  *
  * @example
  * ```ts
@@ -292,8 +285,8 @@ export interface EcrecoverRatifierTypedDataParams {
 /**
  * Parameters for {@link EcrecoverRatifierUtils.ratify}.
  *
- * Use this after tree validation. Provide either the maker wallet client or a
- * signature that was produced from `typedData`.
+ * Use this after tree validation. Provide either a signing client plus account
+ * or a signature that was produced from `typedData`.
  *
  * @example
  * ```ts
@@ -327,9 +320,11 @@ export type EcrecoverRatifierRatifyParams =
   | {
       /** Tree being ratified. */
       readonly tree: Tree;
-      /** Wallet client that signs the typed data built from `tree`. */
-      readonly walletClient: WalletClient<Transport, Chain, Account>;
-      /** Omit when the SDK should request the signature through `walletClient`. */
+      /** Viem client whose transport signs the typed data built from `tree`. */
+      readonly client: Client<Transport, Chain, Account | undefined>;
+      /** Account that signs the tree root. It may be the maker or an address authorized by each maker. */
+      readonly account: Account | Address;
+      /** Omit when the SDK should request the signature through `client`. */
       readonly signature?: undefined;
     }
   | {
@@ -338,7 +333,9 @@ export type EcrecoverRatifierRatifyParams =
       /** Precomputed signature for this tree root. */
       readonly signature: EcrecoverSignatureInput;
       /** Omit when a precomputed signature is supplied. */
-      readonly walletClient?: undefined;
+      readonly client?: undefined;
+      /** Omit when a precomputed signature is supplied. */
+      readonly account?: undefined;
       /** Omit when a precomputed signature is supplied. */
       readonly chainId?: undefined;
     };
@@ -390,8 +387,9 @@ export interface EcrecoverRatifierDataParams {
  * Use this route for EOA and EIP-7702 makers. The make-side sequence is:
  * create offers with the Ecrecover ratifier address, build the group/tree,
  * validate the tree, sign the typed data, call `ratify`, then pass the returned
- * items to `Payload.encode`. Ecrecover trees must contain one maker and one
- * ratifier; split trees by maker or ratifier before signing.
+ * items to `Payload.encode`. Ecrecover trees must contain one ratifier; split
+ * trees by ratifier before signing. The signer may be the maker or an address
+ * authorized by every maker in the tree.
  *
  * @example
  * ```ts
@@ -424,15 +422,15 @@ export namespace EcrecoverRatifierUtils {
   /**
    * Builds EcrecoverRatifier typed data for a tree.
    *
-   * Use after the tree is built and validated, before requesting the maker's
-   * wallet signature. The EIP-712 verifier is derived from the shared ratifier
-   * address on the tree offers. `ratify` calls this for you when given a
-   * `walletClient`.
+   * Use after the tree is built and validated, before requesting the signer
+   * signature. The EIP-712 verifier is derived from the shared ratifier address
+   * on the tree offers. `ratify` calls this for you when given a client and
+   * account.
    *
    * @param params.tree - Ecrecover-ratified offer tree to sign.
    * @param params.chainId - EIP-155 chain id included in the EIP-712 domain.
    * @returns EIP-712 typed-data descriptor.
-   * @throws {InvalidTreeError} when the tree is invalid or contains multiple makers or ratifiers.
+   * @throws {InvalidTreeError} when the tree is invalid or contains multiple ratifiers.
    * @throws {InvalidTreeHeightError} when the tree height is unsupported.
    * @example
    * ```ts
@@ -495,7 +493,7 @@ export namespace EcrecoverRatifierUtils {
    * @param params.tree - Ecrecover-ratified offer tree to hash.
    * @param params.chainId - EIP-155 chain id included in the EIP-712 domain.
    * @returns EIP-712 digest.
-   * @throws {InvalidTreeError} when the tree contains multiple makers or ratifiers.
+   * @throws {InvalidTreeError} when the tree contains multiple ratifiers.
    * @throws {InvalidTreeHeightError} when height exceeds 20.
    * @example
    * ```ts
@@ -547,18 +545,19 @@ export namespace EcrecoverRatifierUtils {
   }
 
   /**
-   * Signs EcrecoverRatifier typed data through a wallet client.
+   * Signs EcrecoverRatifier typed data through a viem client.
    *
    * Use when app code wants the signature separately from payload item
    * construction. If you only need payload items, call `ratify` with the same
-   * wallet client.
+   * client and account. The account may be the maker or an address authorized
+   * by every maker in the tree; the protocol checks that authorization onchain.
    *
    * @param params.tree - Ecrecover-ratified offer tree to sign.
-   * @param params.walletClient - Wallet client that signs the tree typed data.
-   * @returns Signature returned by the wallet client.
-   * @throws {EcrecoverRatifierAccountMismatchError} when the wallet client's account is not the tree maker.
+   * @param params.client - Viem client whose transport signs the tree typed data.
+   * @param params.account - Account used to sign the tree typed data.
+   * @returns Signature returned by the client.
    * @throws {InvalidEcrecoverRatifierSignatureError} when EIP-712 verification rejects the returned signature.
-   * @throws {InvalidTreeError} when the tree is invalid or contains multiple makers or ratifiers.
+   * @throws {InvalidTreeError} when the tree is invalid or contains multiple ratifiers.
    * @throws {InvalidTreeHeightError} when the tree height is unsupported.
    * @example
    * ```ts
@@ -583,38 +582,40 @@ export namespace EcrecoverRatifierUtils {
    *   ratifier: "0x0000000000000000000000000000000000004000",
    *   maxUnits: 100n,
    * });
-   * const walletClient = createWalletClient({
-   *   account: offer.maker,
+   * const client = createWalletClient({
    *   chain: base,
    *   transport: http(),
    * });
    *
    * const signature = await EcrecoverRatifierUtils.sign({
    *   tree: Tree.create([offer]),
-   *   walletClient,
+   *   client,
+   *   account: offer.maker,
    * });
    * console.log(signature);
    * ```
    */
   export async function sign(params: {
     readonly tree: Tree;
-    readonly walletClient: WalletClient<Transport, Chain, Account>;
+    readonly client: Client<Transport, Chain, Account | undefined>;
+    readonly account: Account | Address;
   }): Promise<Hex> {
+    const signer =
+      typeof params.account === "string"
+        ? params.account
+        : params.account.address;
     const data = typedData({
       tree: params.tree,
-      chainId: params.walletClient.chain.id,
+      chainId: params.client.chain.id,
     });
-    const account = params.walletClient.account;
-    const maker = params.tree.offers[0]!.maker;
-    if (!isAddressEqual(account.address, maker)) {
-      throw new EcrecoverRatifierAccountMismatchError(account.address, maker);
-    }
 
-    const signature = await params.walletClient.signTypedData<
+    const signature = await signTypedData<
       Record<string, unknown>,
-      "OfferTree"
-    >({
-      account,
+      "OfferTree",
+      Chain,
+      Account | undefined
+    >(params.client, {
+      account: params.account,
       ...data,
     });
 
@@ -622,18 +623,18 @@ export namespace EcrecoverRatifierUtils {
     try {
       isValid = await verifyTypedData<Record<string, unknown>, "OfferTree">({
         ...data,
-        address: maker,
+        address: signer,
         signature,
       });
     } catch (cause) {
       throw new InvalidEcrecoverRatifierSignatureError({
-        maker,
+        signer,
         cause,
       });
     }
 
     if (!isValid) {
-      throw new InvalidEcrecoverRatifierSignatureError({ maker });
+      throw new InvalidEcrecoverRatifierSignatureError({ signer });
     }
 
     return signature;
@@ -778,7 +779,7 @@ export namespace EcrecoverRatifierUtils {
    * @param params.leafIndex - Leaf index to prove.
    * @param params.signature - Ecrecover signature for the tree root.
    * @returns ABI-encoded EcrecoverRatifier data.
-   * @throws {InvalidTreeError} when the leaf index is outside the tree or the tree contains multiple makers or ratifiers.
+   * @throws {InvalidTreeError} when the leaf index is outside the tree or the tree contains multiple ratifiers.
    * @example
    * ```ts
    * import { EcrecoverRatifierUtils, Offer, Tree } from "@morpho-org/midnight-sdk";
@@ -828,12 +829,12 @@ export namespace EcrecoverRatifierUtils {
    * required by takers. The group id is stored on each inline offer.
    *
    * @param params.tree - Ecrecover-ratified offer tree to ratify.
-   * @param params.walletClient - Optional wallet client that signs typed data built from `params.tree`.
+   * @param params.client - Optional viem client whose transport signs typed data built from `params.tree`.
+   * @param params.account - Optional account used to sign typed data built from `params.tree`.
    * @param params.signature - Optional precomputed signature for `params.tree`.
    * @returns Items containing each offer and its ratifier data.
-   * @throws {EcrecoverRatifierAccountMismatchError} when the signing wallet client's account is not the tree maker.
    * @throws {InvalidEcrecoverRatifierSignatureError} when EIP-712 verification rejects the returned signature.
-   * @throws {InvalidTreeError} when the tree is invalid or contains multiple makers or ratifiers.
+   * @throws {InvalidTreeError} when the tree is invalid or contains multiple ratifiers.
    * @throws {InvalidTreeHeightError} when the tree height is unsupported.
    * @example
    * ```ts
@@ -858,15 +859,15 @@ export namespace EcrecoverRatifierUtils {
    *   ratifier: "0x0000000000000000000000000000000000004000",
    *   maxUnits: 100n,
    * });
-   * const walletClient = createWalletClient({
-   *   account: offer.maker,
+   * const client = createWalletClient({
    *   chain: base,
    *   transport: http(),
    * });
    *
    * const items = await EcrecoverRatifierUtils.ratify({
    *   tree: Tree.create([offer]),
-   *   walletClient,
+   *   client,
+   *   account: offer.maker,
    * });
    * console.log(items.length);
    * ```


### PR DESCRIPTION
## Summary

- Update `EcrecoverRatifierUtils.ratify`/`sign` to accept a viem `Client` plus explicit `account` for local Ecrecover signing.
- Derive the EIP-712 domain chain id from `client.chain.id`; callers no longer pass `chainId` to `ratify`.
- Support delegated signer accounts and mixed-maker trees, while still rejecting mixed-ratifier trees.
- Verify the returned signature via viem `verifyTypedData` without wrapping viem/noble errors in an SDK-specific error.
- Update README/TIB docs, tests, errors, and changeset language.

## Protocol Check

- Confirmed `morpho-org/midnight` `EcrecoverRatifier` accepts `_signer == offer.maker || IMidnight(MIDNIGHT).isAuthorized(offer.maker, _signer)`.
- Checked local viem source: utility `verifyTypedData` returns `isAddressEqual(getAddress(address), await recoverTypedDataAddress(...))`; malformed signatures throw from the underlying recovery path.

## Validation

- `pnpm --filter @morpho-org/midnight-sdk build`
- `pnpm --filter @morpho-org/midnight-sdk test`
- `pnpm exec biome check packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.ts packages/midnight-sdk/src/signatures/EcrecoverRatifierUtils.test.ts packages/midnight-sdk/src/errors.ts .changeset/add-midnight-sdk.md`