### PR TITLE
feat(morpho-sdk)!: remove deprecated getAvailableLiquidityToTargetUtilization

### DIFF
--- a/.changeset/remove-deprecated-available-liquidity-alias.md
+++ b/.changeset/remove-deprecated-available-liquidity-alias.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": major
+---
+
+Remove the deprecated `ReallocationData.getAvailableLiquidityToTargetUtilization` alias. Use `getAvailableLiquidityToUtilization` instead — it has the same signature and behavior; only the method name (and its `targetUtilization` parameter, now `utilization`) changed.

--- a/packages/morpho-sdk/src/entities/reallocationData.metrics.test.ts
+++ b/packages/morpho-sdk/src/entities/reallocationData.metrics.test.ts
@@ -246,29 +246,4 @@ describe("ReallocationData.getAvailableLiquidityToUtilization", () => {
       data.getAvailableLiquidityToUtilization(sourceParamsA.id),
     ).toThrow(UnknownReallocationMarketError);
   });
-
-  test("behavior: deprecated getAvailableLiquidityToTargetUtilization alias delegates", () => {
-    const data = makeData();
-    stubReallocations(data, [
-      { id: sourceParamsA.id, vault: VAULT_A, assets: 200n * MathLib.WAD },
-    ]);
-    const options = {
-      timestamp: TIMESTAMP,
-      defaultSupplyTargetUtilization: NINETY_PERCENT,
-    };
-
-    expect(
-      data.getAvailableLiquidityToTargetUtilization(
-        targetParams.id,
-        NINETY_PERCENT,
-        options,
-      ),
-    ).toBe(
-      data.getAvailableLiquidityToUtilization(
-        targetParams.id,
-        NINETY_PERCENT,
-        options,
-      ),
-    );
-  });
 });

--- a/packages/morpho-sdk/src/entities/reallocationData.ts
+++ b/packages/morpho-sdk/src/entities/reallocationData.ts
@@ -604,62 +604,6 @@ export class ReallocationData implements InputReallocationData {
   }
 
   /**
-   * Computes the liquidity available to bring `marketId` to `utilization`,
-   * counting the public-allocator liquidity reallocatable into it.
-   *
-   * @deprecated Renamed to {@link getAvailableLiquidityToUtilization} — the
-   * `target` wording wrongly implied a market's configured supply-target
-   * utilization, whereas the argument is an arbitrary utilization ceiling.
-   * Delegates to the new method; will be removed in the next major.
-   *
-   * @param marketId - Target market to borrow from.
-   * @param targetUtilization - Utilization to bring the market to, scaled by WAD. Defaults to {@link DEFAULT_SUPPLY_TARGET_UTILIZATION}.
-   * @param options - Optional reallocation options (supply target utilization trigger, timestamp, withdrawal caps).
-   * @returns Available liquidity to the given utilization in loan-token units; `0n` when none is available.
-   * @throws {@link UnknownReallocationMarketError} when the target market is absent.
-   * @example
-   * ```ts
-   * import { createPublicClient, http, parseEther } from "viem";
-   * import { mainnet } from "viem/chains";
-   * import { markets, vaults } from "@morpho-org/morpho-test";
-   * import { morphoViemExtension } from "@morpho-org/morpho-sdk";
-   *
-   * const client = createPublicClient({
-   *   chain: mainnet,
-   *   transport: http(),
-   * }).extend(morphoViemExtension());
-   *
-   * const marketParams = markets[mainnet.id].usdc_wbtc;
-   * const market = client.morpho.blue(marketParams, mainnet.id);
-   * const block = await client.getBlock();
-   * const reallocationData = await market.getReallocationData({
-   *   vaultAddresses: [vaults[mainnet.id].steakUsdc.address],
-   *   block: { number: block.number, timestamp: block.timestamp },
-   * });
-   *
-   * // Deprecated: prefer reallocationData.getAvailableLiquidityToUtilization.
-   * const available: bigint =
-   *   reallocationData.getAvailableLiquidityToTargetUtilization(
-   *     marketParams.id,
-   *     parseEther("0.9"),
-   *     { timestamp: block.timestamp },
-   *   );
-   * ```
-   */
-  // biome-ignore lint/complexity/useMaxParams: (marketId, targetUtilization, options) is the metric's public API
-  public getAvailableLiquidityToTargetUtilization(
-    marketId: MarketId,
-    targetUtilization: bigint = DEFAULT_SUPPLY_TARGET_UTILIZATION,
-    options?: ReallocationComputeOptions,
-  ): bigint {
-    return this.getAvailableLiquidityToUtilization(
-      marketId,
-      targetUtilization,
-      options,
-    );
-  }
-
-  /**
    * Gets the largest currently valid source-market withdrawal for a vault.
    *
    * @param params - Candidate vault, target market, prior withdrawals, and allocator limits.


### PR DESCRIPTION
## What

Removes the deprecated `ReallocationData.getAvailableLiquidityToTargetUtilization` method.

It was introduced in #813 purely as a backwards-compatible alias when `getAvailableLiquidityToTargetUtilization` (published in `morpho-sdk@4.1.0`) was renamed to `getAvailableLiquidityToUtilization`. The alias simply delegated to the renamed method.

## Migration

```diff
- reallocationData.getAvailableLiquidityToTargetUtilization(marketId, targetUtilization, options)
+ reallocationData.getAvailableLiquidityToUtilization(marketId, utilization, options)
```

Same signature, same behavior — only the method name and the second parameter name (`targetUtilization` → `utilization`) differ.

## Not touched

- `getAvailableLiquidityToUtilization` — the read-only liquidity-to-utilization metric.
- `getPublicReallocationLiquidity` — the shared-liquidity sum metric.
- `getSupplyTargetUtilization` helper (`helpers/utilization.ts`).
- `getMarketPublicReallocations` and the `computeReallocations` write path.

## Semver

Removing a public method that shipped in `morpho-sdk@4.1.0`/`4.2.0` is a breaking change → **major** changeset included (root `AGENTS.md` §7).

## Verification

- `tsc --noEmit` passes.
- Biome clean on changed files.
- `reallocationData.metrics` unit suite passes (12 tests) after dropping the obsolete alias-delegation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)