### PR TITLE
refactor: extract shared requirement helpers

### DIFF
--- a/.changeset/add-midnight-sdk.md
+++ b/.changeset/add-midnight-sdk.md
@@ -20,6 +20,8 @@ Market hashing canonicalizes non-empty collateral params by token order while pr
 
 `MarketParams` rejects empty collateral lists and duplicate collateral token entries, then normalizes collateral params into onchain token order before offer grouping, tree construction, or signing flows.
 
+`Market.getCollateralByIndex` and `MarketUtils.getCollateralByIndex` return configured collateral entries and throw `UnknownCollateralIndexError` when an index is unconfigured.
+
 Offer creation and payload validation reject `expiry` before `start` while allowing zero-duration time ranges that Midnight can take onchain.
 
 Ecrecover ratification supports direct maker signatures and delegated signer signatures, including mixed-maker trees when the same signer is authorized by every maker onchain.

--- a/.changeset/blue-requirements-helpers.md
+++ b/.changeset/blue-requirements-helpers.md
@@ -8,7 +8,7 @@ Rename Blue requirement entrypoints and isolate Blue-specific requirement module
 
 The public GeneralAdapter requirement entrypoint is now `getGeneralAdapterRequirements`, and `getMorphoAuthorizationRequirement` is now `getBlueAuthorizationRequirement`. GeneralAdapter token permit requirement entrypoints are exported as `getGeneralAdapterRequirementsPermit` and `getGeneralAdapterRequirementsPermit2`, and the Permit2 approval encoder is exported as `encodeErc20Permit2Approve`. Protocol-agnostic approval and EIP-2612 encoding utilities remain exported from the common requirements barrel.
 
-Token signature requirement encoders now derive GeneralAdapter1 as the spender from `chainId`, while ERC-20 approval encoding rejects spenders other than GeneralAdapter1 or Permit2 for the target chain.
+Token signature requirement callers now pass the supported spender explicitly to `encodeErc20Permit`, while ERC-20 permit and approval encoding reject spenders outside the supported chain registry entries for the target chain.
 
 Token-pull builders now preserve Permit2 transfer routing even when the existing Permit2-managed allowance is already sufficient and no fresh Permit2 signature requirement is returned.
 

--- a/.changeset/extract-cross-protocol-utils.md
+++ b/.changeset/extract-cross-protocol-utils.md
@@ -9,13 +9,13 @@
 "@morpho-org/wdk-protocol-lending-morpho-evm": patch
 ---
 
-Move shared Blue and Midnight SDK primitives to `@morpho-org/morpho-ts`: chain metadata, address/deployment registries, fixed-point math helpers, shared bigint types, typed registry/math errors, `ORACLE_PRICE_SCALE`, and `assertNonNegative`.
+Move shared Blue and Midnight SDK primitives to `@morpho-org/morpho-ts`: chain metadata, address/deployment registries, fixed-point math helpers, shared bigint types, typed registry/math errors, `ORACLE_PRICE_SCALE`, `assertNonNegative`, and `_try`.
 
 Expose shared ABI literals through `@morpho-org/morpho-ts/abis` so root utility imports do not load the ABI table.
 
 Model addresses as a unified flat Morpho registry so Blue and Midnight addresses live on the same chain entry and resolve through the protocol-agnostic `getChainAddresses`, `getChainAddress`, and `registerCustomAddresses` helpers.
 
-Keep `@morpho-org/blue-sdk` compatible by re-exporting the extracted chain, address, math, and error surfaces from `@morpho-org/morpho-ts`, and remove the now-unused lodash registry merge dependencies from `@morpho-org/blue-sdk`.
+Keep `@morpho-org/blue-sdk` compatible by re-exporting the extracted chain, address, math, `_try`, and error surfaces from `@morpho-org/morpho-ts`, and remove the now-unused lodash registry merge dependencies from `@morpho-org/blue-sdk`.
 
 Expose the shared address registry helpers and registry types through `@morpho-org/morpho-sdk` so integrators can import the cross-protocol address surface from the main SDK package.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Cross-layer leaks (entities encoding calldata, actions reading state, helpers de
 - Every package has one clear job. If a package needs a paragraph to describe, split it.
 - Every module has one responsibility. Files grow by *adding* exports of the same kind, never by stretching scope.
 - Do not extract a local, non-exported helper unless it has at least three call sites. Inline one-off and two-use helpers.
+- When a helper is called only to run validation, throw, or trigger another intentional side effect, add a short call-site comment explaining why its return value is unused.
 - **Single source of truth** per concept: one place per ABI, one place per address registry, one place per error class. Duplication is a refactor, not a feature.
 - Do not export duplicate TypeScript shapes for the same concept. If a domain interface and ABI struct are identical, export one interface and reuse it; only introduce a distinct `*Struct` type when the shapes actually differ.
 - Framework adapters live in explicitly named packages (`*-wagmi`, `*-viem`). Core packages stay framework-free.

--- a/packages/blue-sdk-viem/src/fetch/MarketParams.ts
+++ b/packages/blue-sdk-viem/src/fetch/MarketParams.ts
@@ -1,10 +1,10 @@
 import {
-  _try,
   getChainAddresses,
   type MarketId,
   MarketParams,
   UnknownMarketParamsError,
 } from "@morpho-org/blue-sdk";
+import { _try } from "@morpho-org/morpho-ts";
 import type { Client } from "viem";
 import { getChainId } from "viem/actions";
 import { blueAbi } from "../abis.js";

--- a/packages/blue-sdk/src/errors.ts
+++ b/packages/blue-sdk/src/errors.ts
@@ -1,5 +1,7 @@
 export {
+  _try,
   DivisionByZeroError,
+  type ErrorClass,
   IncompleteChainRegistryError,
   InvalidBitLengthError,
   RegistryValueAlreadyRegisteredError,
@@ -187,58 +189,5 @@ export class UnknownOfFactory extends Error {
     public readonly address: Address,
   ) {
     super(`address "${address}" is not from the ${factory} factory`);
-  }
-}
-
-/** Constructor type for errors accepted by `_try`. */
-export interface ErrorClass<E extends Error = Error> {
-  // biome-ignore lint/suspicious/noExplicitAny: match any type of arg
-  new (...args: any[]): E;
-}
-
-/**
- * Runs an async accessor and returns `undefined` for expected lookup errors.
- *
- * @internal
- */
-export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
-  accessor: () => Promise<T>,
-  ...errorClasses: ErrorClasses
-): Promise<T | undefined>;
-/**
- * Runs a sync accessor and returns `undefined` for expected lookup errors.
- *
- * @internal
- */
-export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
-  accessor: () => T,
-  ...errorClasses: ErrorClasses
-): T | undefined;
-/**
- * Runs an accessor and returns `undefined` for expected lookup errors.
- *
- * @internal
- */
-export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
-  accessor: () => T | Promise<T>,
-  ...errorClasses: ErrorClasses
-): T | undefined | Promise<T | undefined> {
-  const maybeCatchError = (error: unknown): undefined => {
-    if (
-      errorClasses.length === 0 ||
-      errorClasses.some((errorClass) => error instanceof errorClass)
-    )
-      return;
-
-    throw error;
-  };
-
-  try {
-    const res = accessor();
-
-    if (res instanceof Promise) return res.catch(maybeCatchError);
-    return res;
-  } catch (error) {
-    return maybeCatchError(error);
   }
 }

--- a/packages/midnight-sdk/src/errors.ts
+++ b/packages/midnight-sdk/src/errors.ts
@@ -192,6 +192,41 @@ export class InvalidMarketParameterError extends Error {
 }
 
 /**
+ * Thrown when a Midnight market collateral index is not configured.
+ *
+ * @example
+ * ```ts
+ * import { UnknownCollateralIndexError } from "@morpho-org/midnight-sdk";
+ *
+ * throw new UnknownCollateralIndexError({
+ *   market: "0x1111111111111111111111111111111111111111111111111111111111111111",
+ *   collateralIndex: 2n,
+ * });
+ * ```
+ * @param params.market - Market id whose collateral list was queried.
+ * @param params.collateralIndex - Missing collateral index.
+ */
+export class UnknownCollateralIndexError extends Error {
+  /** Market id whose collateral list was queried. */
+  public readonly market: string;
+
+  /** Missing collateral index. */
+  public readonly collateralIndex: bigint;
+
+  public constructor(params: {
+    readonly market: string;
+    readonly collateralIndex: bigint;
+  }) {
+    super(
+      `Midnight market "${params.market}" has no collateral at index "${params.collateralIndex}". Use a configured collateral index.`,
+    );
+    this.name = "UnknownCollateralIndexError";
+    this.market = params.market;
+    this.collateralIndex = params.collateralIndex;
+  }
+}
+
+/**
  * Thrown when an offer builder receives a parameter that cannot satisfy Midnight protocol rules.
  *
  * @example

--- a/packages/midnight-sdk/src/market/Market.test.ts
+++ b/packages/midnight-sdk/src/market/Market.test.ts
@@ -1,4 +1,4 @@
-import { MathLib } from "@morpho-org/morpho-ts";
+import { _try, MathLib } from "@morpho-org/morpho-ts";
 import type { Address } from "viem";
 import { numberToHex } from "viem";
 import { describe, expect, test } from "vitest";
@@ -17,7 +17,10 @@ import {
   MAX_COLLATERALS,
   SETTLEMENT_FEE_BREAKPOINTS,
 } from "../constants.js";
-import { InvalidMarketParameterError } from "../errors.js";
+import {
+  InvalidMarketParameterError,
+  UnknownCollateralIndexError,
+} from "../errors.js";
 import { Market, MarketParams } from "./Market.js";
 import { MarketUtils } from "./MarketUtils.js";
 
@@ -241,14 +244,22 @@ describe("Market", () => {
   test("behavior: collateral lookup helpers", () => {
     const market = baseMarket();
 
-    expect(market.getCollateralParamsByIndex(0)?.token).toBe(
+    expect(market.getCollateralByIndex(0).token).toBe(
       addresses.collateralToken,
     );
     expect(market.getCollateralIndexByToken(addresses.collateralToken)).toBe(0);
     expect(
       market.getCollateralParamsByToken(addresses.collateralToken)?.lltv,
     ).toBe(770000000000000000n);
-    expect(market.getCollateralParamsByIndex(1)).toBeUndefined();
+    expect(
+      _try(() => market.getCollateralByIndex(1), UnknownCollateralIndexError),
+    ).toBeUndefined();
+    expect(() => market.getCollateralByIndex(1)).toThrow(
+      UnknownCollateralIndexError,
+    );
+    expect(() => MarketUtils.getCollateralByIndex(market, 1)).toThrow(
+      UnknownCollateralIndexError,
+    );
   });
 
   test("error: invalid bigint input", () => {

--- a/packages/midnight-sdk/src/market/Market.ts
+++ b/packages/midnight-sdk/src/market/Market.ts
@@ -681,10 +681,11 @@ export class Market {
   }
 
   /**
-   * Returns collateral params by numeric index.
+   * Returns collateral by numeric index.
    *
    * @param index - Collateral index.
-   * @returns Collateral params, or undefined when the index is not configured.
+   * @returns Collateral entry for the configured index.
+   * @throws {UnknownCollateralIndexError} when the index is not configured.
    * @example
    * ```ts
    * import { registerCustomAddresses } from "@morpho-org/morpho-ts";
@@ -730,19 +731,12 @@ export class Market {
    *   continuousFee: 10,
    *   tickSpacing: 4,
    * });
-   * const params = market.getCollateralParamsByIndex(0);
-   * console.log(params?.token);
+   * const collateral = market.getCollateralByIndex(0);
+   * console.log(collateral.token);
    * ```
    */
-  public getCollateralParamsByIndex(index: BigIntish) {
-    const normalizedIndex = BigInt(index);
-    if (
-      normalizedIndex < 0n ||
-      normalizedIndex > BigInt(Number.MAX_SAFE_INTEGER)
-    )
-      return undefined;
-
-    return this.params.collateralParams[Number(normalizedIndex)];
+  public getCollateralByIndex(index: BigIntish) {
+    return MarketUtils.getCollateralByIndex(this, index);
   }
 
   /**

--- a/packages/midnight-sdk/src/market/MarketUtils.ts
+++ b/packages/midnight-sdk/src/market/MarketUtils.ts
@@ -10,7 +10,10 @@ import {
   MARKET_TYPEHASH,
   SETTLEMENT_FEE_BREAKPOINTS,
 } from "../constants.js";
-import { InvalidMarketParameterError } from "../errors.js";
+import {
+  InvalidMarketParameterError,
+  UnknownCollateralIndexError,
+} from "../errors.js";
 import {
   type CollateralParams,
   type ICollateralParams,
@@ -171,6 +174,55 @@ export namespace MarketUtils {
       enterGate: params.enterGate,
       liquidatorGate: params.liquidatorGate,
     };
+  }
+
+  /**
+   * Returns configured collateral by index.
+   *
+   * @param market - Market params or hydrated market.
+   * @param index - Collateral index to look up.
+   * @returns Collateral entry for the configured index.
+   * @throws {UnknownCollateralIndexError} when the index is not configured.
+   * @example
+   * ```ts
+   * import { MarketUtils } from "@morpho-org/midnight-sdk";
+   *
+   * const collateral = MarketUtils.getCollateralByIndex({
+   *   chainId: 8453,
+   *   midnight: "0x0000000000000000000000000000000000001000",
+   *   loanToken: "0x0000000000000000000000000000000000000001",
+   *   collateralParams: [
+   *     {
+   *       token: "0x0000000000000000000000000000000000000002",
+   *       lltv: 770000000000000000n,
+   *       liquidationCursor: 250000000000000000n,
+   *       oracle: "0x0000000000000000000000000000000000000003",
+   *     },
+   *   ],
+   *   maturity: 1n,
+   *   rcfThreshold: 0n,
+   *   enterGate: "0x0000000000000000000000000000000000000000",
+   *   liquidatorGate: "0x0000000000000000000000000000000000000000",
+   * }, 0n);
+   * console.log(collateral.token);
+   * ```
+   */
+  export function getCollateralByIndex(market: MarketInput, index: BigIntish) {
+    const normalizedIndex = BigInt(index);
+    const params = MarketParams.from(market);
+    const collateral =
+      normalizedIndex >= 0n &&
+      normalizedIndex <= BigInt(Number.MAX_SAFE_INTEGER)
+        ? params.collateralParams[Number(normalizedIndex)]
+        : undefined;
+    if (collateral == null) {
+      throw new UnknownCollateralIndexError({
+        market: toId(params),
+        collateralIndex: normalizedIndex,
+      });
+    }
+
+    return collateral;
   }
 
   /**

--- a/packages/midnight-sdk/src/market/Position.ts
+++ b/packages/midnight-sdk/src/market/Position.ts
@@ -1,5 +1,6 @@
-import { type BigIntish, MathLib } from "@morpho-org/morpho-ts";
+import { _try, type BigIntish, MathLib } from "@morpho-org/morpho-ts";
 import type { Address } from "viem";
+import { UnknownCollateralIndexError } from "../errors.js";
 import { type IMarket, Market } from "./Market.js";
 import { PositionUtils } from "./PositionUtils.js";
 
@@ -252,7 +253,12 @@ export class AccrualPosition extends Position {
    */
   public getCollateralBalanceByIndex(index: BigIntish) {
     const normalizedIndex = BigInt(index);
-    if (this.market.getCollateralParamsByIndex(normalizedIndex) == null)
+    if (
+      _try(
+        () => this.market.getCollateralByIndex(normalizedIndex),
+        UnknownCollateralIndexError,
+      ) == null
+    )
       return undefined;
 
     return this.collateral[Number(normalizedIndex)] ?? 0n;

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.test.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.test.ts
@@ -9,6 +9,7 @@ import {
   AddressMismatchError,
   ChainIdMismatchError,
   InvalidSignatureError,
+  UnsupportedErc20ApprovalSpenderError,
 } from "../../../types/index.js";
 import { encodeErc20Permit } from "./encodeErc20Permit.js";
 
@@ -32,6 +33,7 @@ describe("encodeErc20Permit", () => {
       await expect(
         encodeErc20Permit(client, {
           token: usdc,
+          spender: generalAdapter1,
           amount: mockAmount,
           chainId: mainnet.id + 1,
           nonce: mockNonce,
@@ -39,11 +41,28 @@ describe("encodeErc20Permit", () => {
       ).rejects.toThrow(ChainIdMismatchError);
     });
 
+    test("should throw UnsupportedErc20ApprovalSpenderError when spender is not supported", async ({
+      client,
+    }) => {
+      const spender = "0x0000000000000000000000000000000000000001" as Address;
+
+      await expect(
+        encodeErc20Permit(client, {
+          token: usdc,
+          spender,
+          amount: mockAmount,
+          chainId: mainnet.id,
+          nonce: mockNonce,
+        }),
+      ).rejects.toThrow(UnsupportedErc20ApprovalSpenderError);
+    });
+
     test("should sign permit for non-DAI token", async ({ client }) => {
       const userAddress = client.account.address;
 
       const permit = await encodeErc20Permit(client, {
         token: usdc,
+        spender: generalAdapter1,
         amount: mockAmount,
         chainId: mainnet.id,
         nonce: mockNonce,
@@ -64,6 +83,7 @@ describe("encodeErc20Permit", () => {
 
       const permit = await encodeErc20Permit(client, {
         token: usdc,
+        spender: generalAdapter1,
         amount: mockAmount,
         chainId: mainnet.id,
         nonce: mockNonce,
@@ -90,6 +110,7 @@ describe("encodeErc20Permit", () => {
       };
       const permit = await encodeErc20Permit(client, {
         token: usdc,
+        spender: generalAdapter1,
         amount: mockAmount,
         chainId: mainnet.id,
         nonce: mockNonce,
@@ -107,6 +128,7 @@ describe("encodeErc20Permit", () => {
 
       const permit = await encodeErc20Permit(client, {
         token: usdc,
+        spender: generalAdapter1,
         amount: mockAmount,
         chainId: mainnet.id,
         nonce: mockNonce,
@@ -134,6 +156,7 @@ describe("encodeErc20Permit", () => {
 
       const permit = await encodeErc20Permit(client, {
         token: usdc,
+        spender: generalAdapter1,
         amount: mockAmount,
         chainId: mainnet.id,
         nonce: mockNonce,
@@ -158,6 +181,7 @@ describe("encodeErc20Permit", () => {
     test("should have correct action structure", async ({ client }) => {
       const permit = await encodeErc20Permit(client, {
         token: usdc,
+        spender: generalAdapter1,
         amount: mockAmount,
         chainId: mainnet.id,
         nonce: mockNonce,

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
@@ -1,7 +1,12 @@
 import { type Address, getChainAddresses } from "@morpho-org/blue-sdk";
 import { fetchToken, getPermitTypedData } from "@morpho-org/blue-sdk-viem";
 import { deepFreeze, Time } from "@morpho-org/morpho-ts";
-import { type Client, verifyTypedData, type WalletClient } from "viem";
+import {
+  type Client,
+  isAddressEqual,
+  verifyTypedData,
+  type WalletClient,
+} from "viem";
 import { signTypedData } from "viem/actions";
 import { validateUserAddress } from "../../../helpers/validate.js";
 import {
@@ -10,11 +15,13 @@ import {
   type PermitAction,
   type PermitRequirementSignature,
   type Requirement,
+  UnsupportedErc20ApprovalSpenderError,
 } from "../../../types/index.js";
 
 /** Parameters for {@link encodeErc20Permit}. */
 interface EncodeErc20PermitParams {
   token: Address;
+  spender: Address;
   amount: bigint;
   chainId: number;
   nonce: bigint;
@@ -22,8 +29,8 @@ interface EncodeErc20PermitParams {
 }
 
 /**
- * Builds an EIP-2612 permit `Requirement` that, once signed, lets GeneralAdapter1 pull `amount`
- * of `token`.
+ * Builds an EIP-2612 permit `Requirement` that, once signed, lets a supported SDK spender pull
+ * `amount` of `token`.
  *
  * Reads token metadata via `fetchToken`. The returned `Requirement.sign()` produces the EIP-712
  * signature, verifies it against the connected account, and returns a `RequirementSignature`
@@ -32,12 +39,15 @@ interface EncodeErc20PermitParams {
  * @param viemClient - Connected viem `Client` whose `chain.id` matches `params.chainId`.
  * @param params - Permit encoding parameters.
  * @param params.token - ERC-20 token address (must support EIP-2612).
+ * @param params.spender - Permit spender. Must be GeneralAdapter1 or MidnightBundles for the chain.
  * @param params.amount - Permit allowance amount.
  * @param params.chainId - Target chain id.
  * @param params.nonce - The user's current EIP-2612 nonce on `token`.
  * @param params.supportDeployless - Whether `fetchToken` should use deployless multicall.
  * @returns A `Requirement` whose `sign(client, userAddress)` produces the deep-frozen signature.
  * @throws {ChainIdMismatchError} when `viemClient.chain?.id !== params.chainId`.
+ * @throws {UnsupportedErc20ApprovalSpenderError} when `spender` is not GeneralAdapter1 or
+ *   MidnightBundles for `chainId`.
  * @throws {MissingClientPropertyError} from `sign()` when the client has no `account.address`.
  * @throws {AddressMismatchError} from `sign()` when the client account differs from `userAddress`.
  * @throws {InvalidSignatureError} from `sign()` when EIP-712 verification fails.
@@ -50,6 +60,7 @@ interface EncodeErc20PermitParams {
  * const client = createWalletClient({ chain: mainnet, transport: http() });
  * const requirement = await encodeErc20Permit(client, {
  *   token: USDC, // Must implement standard ERC-2612. DAI is routed through Permit2 by requirement helpers.
+ *   spender: generalAdapter1,
  *   amount: 1_000_000n,
  *   chainId: 1,
  *   nonce: 0n,
@@ -61,15 +72,28 @@ export const encodeErc20Permit = async (
   viemClient: Client,
   params: EncodeErc20PermitParams,
 ): Promise<Requirement<PermitRequirementSignature>> => {
-  const { token, amount, chainId, nonce, supportDeployless } = params;
+  const { token, spender, amount, chainId, nonce, supportDeployless } = params;
 
   if (viemClient.chain?.id !== chainId) {
     throw new ChainIdMismatchError(viemClient.chain?.id, chainId);
   }
 
   const {
+    midnightBundles,
     bundler3: { generalAdapter1 },
   } = getChainAddresses(chainId);
+  if (
+    !isAddressEqual(spender, generalAdapter1) &&
+    (midnightBundles == null || !isAddressEqual(spender, midnightBundles))
+  ) {
+    throw new UnsupportedErc20ApprovalSpenderError({
+      spender,
+      chainId,
+      generalAdapter1,
+      midnightBundles,
+      supportedSpenders: [generalAdapter1, midnightBundles],
+    });
+  }
 
   const now = Time.timestamp();
   const deadline = now + Time.s.from.h(2n);
@@ -81,7 +105,7 @@ export const encodeErc20Permit = async (
   const action: PermitAction = {
     type: "permit",
     args: {
-      spender: generalAdapter1,
+      spender,
       amount,
       deadline,
     },
@@ -96,7 +120,7 @@ export const encodeErc20Permit = async (
         {
           erc20: tokenData,
           owner: userAddress,
-          spender: generalAdapter1,
+          spender,
           allowance: amount,
           nonce,
           deadline,

--- a/packages/morpho-sdk/src/actions/requirements/generalAdapter/getGeneralAdapterRequirementsPermit.ts
+++ b/packages/morpho-sdk/src/actions/requirements/generalAdapter/getGeneralAdapterRequirementsPermit.ts
@@ -1,3 +1,4 @@
+import { getChainAddresses } from "@morpho-org/blue-sdk";
 import type { Address, Client } from "viem";
 import { encodeErc20Permit } from "../encode/index.js";
 
@@ -45,6 +46,9 @@ export const getGeneralAdapterRequirementsPermit = async (
     nonce,
     supportDeployless,
   } = params;
+  const {
+    bundler3: { generalAdapter1 },
+  } = getChainAddresses(chainId);
 
   // Existing direct ERC-20 allowance is intentionally not an input here. ERC-2612 overwrites the
   // allowance with the signed amount, and the bundle spends exactly `amount`, leaving no residual
@@ -52,6 +56,7 @@ export const getGeneralAdapterRequirementsPermit = async (
   return [
     await encodeErc20Permit(viemClient, {
       token,
+      spender: generalAdapter1,
       amount,
       chainId,
       nonce,

--- a/packages/morpho-sdk/src/entities/reallocationData.ts
+++ b/packages/morpho-sdk/src/entities/reallocationData.ts
@@ -1,5 +1,4 @@
 import {
-  _try,
   AccrualPosition,
   Market,
   type MarketId,
@@ -11,7 +10,7 @@ import {
   VaultMarketConfig,
   VaultMarketPublicAllocatorConfig,
 } from "@morpho-org/blue-sdk";
-import { bigIntComparator } from "@morpho-org/morpho-ts";
+import { _try, bigIntComparator } from "@morpho-org/morpho-ts";
 import type { Address } from "viem";
 import {
   DEFAULT_SUPPLY_TARGET_UTILIZATION,

--- a/packages/morpho-sdk/src/errors.ts
+++ b/packages/morpho-sdk/src/errors.ts
@@ -1,6 +1,4 @@
-export type { ErrorClass } from "@morpho-org/blue-sdk";
 export {
-  _try,
   BlueErrors,
   IncompleteChainRegistryError,
   InvalidMarketParamsError,
@@ -17,3 +15,5 @@ export {
   UnsupportedVaultV2AdapterError,
   VaultV2Errors,
 } from "@morpho-org/blue-sdk";
+export type { ErrorClass } from "@morpho-org/morpho-ts";
+export { _try } from "@morpho-org/morpho-ts";

--- a/packages/morpho-sdk/src/types/error.ts
+++ b/packages/morpho-sdk/src/types/error.ts
@@ -178,19 +178,29 @@ export class ApprovalAmountLessThanSpendAmountError extends Error {
   }
 }
 
-/** Thrown when an ERC-20 approval requirement targets an unsupported spender. */
+/** Thrown when a requirement encoder targets an unsupported spender. */
 export class UnsupportedErc20ApprovalSpenderError extends Error {
   constructor(params: {
     readonly spender: Address;
     readonly chainId: number;
     readonly generalAdapter1: Address;
     readonly permit2?: Address;
+    readonly midnight?: Address;
+    readonly midnightBundles?: Address;
+    readonly supportedSpenders?: readonly (Address | undefined)[];
   }) {
-    const supported = [params.generalAdapter1, params.permit2]
+    const supported = (
+      params.supportedSpenders ?? [
+        params.generalAdapter1,
+        params.permit2,
+        params.midnight,
+        params.midnightBundles,
+      ]
+    )
       .filter((address) => address != null)
       .join('", "');
     super(
-      `ERC-20 approval spender "${params.spender}" is not supported on chain "${params.chainId}". Use "${supported}".`,
+      `Requirement spender "${params.spender}" is not supported on chain "${params.chainId}". Use "${supported}".`,
     );
   }
 }

--- a/packages/morpho-ts/src/errors.test.ts
+++ b/packages/morpho-ts/src/errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  _try,
   DivisionByZeroError,
   IncompleteChainRegistryError,
   InvalidBitLengthError,
@@ -9,6 +10,10 @@ import {
   UnknownAddressError,
   UnsupportedChainIdError,
 } from "./errors.js";
+
+class TestDataError extends Error {}
+
+class TestMissingError extends TestDataError {}
 
 describe("UnsupportedChainIdError", () => {
   test("default", () => {
@@ -98,5 +103,63 @@ describe("UnknownAddressError", () => {
     expect(error.label).toBe("midnight");
     expect(error.message).toContain("31337");
     expect(error.message).toContain("midnight");
+  });
+});
+
+describe("_try", () => {
+  test("returns the value when sync accessor succeeds", () => {
+    expect(_try(() => 42)).toBe(42);
+  });
+
+  test("returns undefined when sync accessor throws and no error class given", () => {
+    expect(
+      _try(() => {
+        throw new Error("oops");
+      }),
+    ).toBe(undefined);
+  });
+
+  test("returns undefined for matching error class", () => {
+    expect(
+      _try(() => {
+        throw new UnknownAddressError({ chainId: 1, label: "midnight" });
+      }, UnknownAddressError),
+    ).toBe(undefined);
+  });
+
+  test("re-throws when error class does not match", () => {
+    expect(() =>
+      _try(() => {
+        throw new TypeError("not me");
+      }, UnknownAddressError),
+    ).toThrow(TypeError);
+  });
+
+  test("matches subclasses", () => {
+    expect(
+      _try(() => {
+        throw new TestMissingError("missing");
+      }, TestDataError),
+    ).toBe(undefined);
+  });
+
+  test("returns the resolved value for async accessor success", async () => {
+    expect(await _try(async () => "ok")).toBe("ok");
+  });
+
+  test("returns undefined for async rejection on matching error class", async () => {
+    expect(
+      await _try(async () => {
+        throw new UnknownAddressError({ chainId: 1, label: "midnight" });
+      }, UnknownAddressError),
+    ).toBe(undefined);
+  });
+
+  test("re-throws on async rejection when no class matches", async () => {
+    await expect(
+      _try(async () => {
+        throw new TypeError("nope");
+      }, UnknownAddressError),
+    ).rejects.toThrow(TypeError);
   });
 });

--- a/packages/morpho-ts/src/errors.ts
+++ b/packages/morpho-ts/src/errors.ts
@@ -164,3 +164,89 @@ export class UnknownAddressError extends Error {
     this.name = "UnknownAddressError";
   }
 }
+
+/** Constructor type for errors accepted by `_try`. */
+export interface ErrorClass<E extends Error = Error> {
+  // biome-ignore lint/suspicious/noExplicitAny: match any type of error constructor arg.
+  new (...args: any[]): E;
+}
+
+/**
+ * Runs an async accessor and returns `undefined` for expected lookup errors.
+ *
+ * @param accessor - Async accessor to run.
+ * @param errorClasses - Optional error classes to catch. When omitted, all errors are caught.
+ * @returns The accessor result, or `undefined` when the accessor throws a matching error.
+ * @example
+ * ```ts
+ * import { _try, UnknownAddressError } from "@morpho-org/morpho-ts";
+ *
+ * const address = await _try(async () => {
+ *   throw new UnknownAddressError({ chainId: 1, label: "midnight" });
+ * }, UnknownAddressError);
+ * console.log(address);
+ * ```
+ */
+export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
+  accessor: () => Promise<T>,
+  ...errorClasses: ErrorClasses
+): Promise<T | undefined>;
+/**
+ * Runs a sync accessor and returns `undefined` for expected lookup errors.
+ *
+ * @param accessor - Sync accessor to run.
+ * @param errorClasses - Optional error classes to catch. When omitted, all errors are caught.
+ * @returns The accessor result, or `undefined` when the accessor throws a matching error.
+ * @example
+ * ```ts
+ * import { _try, UnknownAddressError } from "@morpho-org/morpho-ts";
+ *
+ * const address = _try(() => {
+ *   throw new UnknownAddressError({ chainId: 1, label: "midnight" });
+ * }, UnknownAddressError);
+ * console.log(address);
+ * ```
+ */
+export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
+  accessor: () => T,
+  ...errorClasses: ErrorClasses
+): T | undefined;
+/**
+ * Runs an accessor and returns `undefined` for expected lookup errors.
+ *
+ * @param accessor - Accessor to run.
+ * @param errorClasses - Optional error classes to catch. When omitted, all errors are caught.
+ * @returns The accessor result, or `undefined` when the accessor throws a matching error.
+ * @example
+ * ```ts
+ * import { _try, UnknownAddressError } from "@morpho-org/morpho-ts";
+ *
+ * const address = _try(() => {
+ *   throw new UnknownAddressError({ chainId: 1, label: "midnight" });
+ * }, UnknownAddressError);
+ * console.log(address);
+ * ```
+ */
+export function _try<T, ErrorClasses extends readonly ErrorClass[] = []>(
+  accessor: () => T | Promise<T>,
+  ...errorClasses: ErrorClasses
+): T | undefined | Promise<T | undefined> {
+  const maybeCatchError = (error: unknown): undefined => {
+    if (
+      errorClasses.length === 0 ||
+      errorClasses.some((errorClass) => error instanceof errorClass)
+    )
+      return;
+
+    throw error;
+  };
+
+  try {
+    const res = accessor();
+
+    if (res instanceof Promise) return res.catch(maybeCatchError);
+    return res;
+  } catch (error) {
+    return maybeCatchError(error);
+  }
+}


### PR DESCRIPTION
## Summary

Extracts the shared `_try` helper from `@morpho-org/blue-sdk` into `@morpho-org/morpho-ts` while keeping the Blue SDK re-export for compatibility.

Adds the canonical Midnight `getCollateralByIndex` lookup that throws `UnknownCollateralIndexError` for unconfigured indexes, and updates optional consumers to wrap it with `_try`.

Makes `encodeErc20Permit` require an explicit supported spender and updates the GeneralAdapter caller to pass `generalAdapter1` directly.

## Validation

- `pnpm exec biome check --write ...`
- `pnpm exec vitest run --root . packages/morpho-ts/src/errors.test.ts packages/blue-sdk/src/errors.test.ts packages/midnight-sdk/src/market/Market.test.ts packages/midnight-sdk/src/market/Position.test.ts`
- `pnpm --filter @morpho-org/morpho-ts exec tsc --noEmit`
- `pnpm --filter @morpho-org/blue-sdk exec tsc --noEmit`
- `pnpm --filter @morpho-org/blue-sdk-viem exec tsc --noEmit`
- `pnpm --filter @morpho-org/midnight-sdk exec tsc --noEmit`
- `pnpm --filter @morpho-org/morpho-sdk exec tsc --noEmit`

The morpho-sdk `encodeErc20Permit.test.ts` fork test was not run locally because `MAINNET_RPC_URL` is not set in this workspace.
