### PR TITLE
ci: dispatch doc regeneration from the release pipeline

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -1,0 +1,81 @@
+name: Docs dispatch
+
+on:
+  workflow_call:
+    secrets:
+      DOCS_BOT_APP_ID:
+        required: true
+      DOCS_BOT_PRIVATE_KEY:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs-dispatch:
+    name: Dispatch documentation regeneration
+    runs-on: ubuntu-latest
+    # `actions/checkout` reads this repository; nothing else here touches it.
+    # The cross-repository dispatch travels on the down-scoped app token minted
+    # below, never on GITHUB_TOKEN.
+    permissions:
+      contents: read
+    env:
+      DOCS_REPOSITORY: morpho-org/morpho-apps
+      DOCS_WORKFLOW: doc-auto-generation-workflow.yml
+
+    steps:
+      # `fetch-depth: 2` is the minimum that resolves `HEAD^`, which is the base
+      # of the released-package diff. On a merge commit this fetches every
+      # parent, and the diff follows the first one.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+
+      # Only node builtins are used, so this deliberately skips `pnpm install`
+      # and the dependency lifecycle scripts it would run before the app token
+      # is minted.
+      - name: Detect released packages
+        id: released-packages
+        run: node scripts/release/list-released-packages.mjs
+
+      - name: Skip dispatch when no package was released
+        if: steps.released-packages.outputs.has_released_packages == 'false'
+        run: echo "No package version changed in this commit; skipping documentation regeneration."
+
+      # The morpho-docs-bot app is not installed on this repository. The key
+      # exists only to mint an `actions: write` token scoped to the morpho-apps
+      # installation, which can start a workflow there and read nothing else.
+      - name: Generate docs bot token
+        id: docs-bot-token
+        if: steps.released-packages.outputs.has_released_packages == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+          owner: morpho-org
+          repositories: morpho-apps
+          permission-actions: write
+
+      - name: Dispatch documentation regeneration
+        if: steps.released-packages.outputs.has_released_packages == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.docs-bot-token.outputs.token }}
+          RELEASED_PACKAGES: ${{ steps.released-packages.outputs.released_packages }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # `--raw-field`, not `--field`: the latter respects gh's `@` syntax,
+          # and the payload is dense with `@morpho-org/...` package names.
+          gh workflow run "${DOCS_WORKFLOW}" \
+            --repo "${DOCS_REPOSITORY}" \
+            --raw-field source="${RELEASED_PACKAGES}" \
+            --raw-field source_run="${SOURCE_RUN_URL}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,10 @@ name: Publish
 
 on:
   workflow_call:
+    outputs:
+      has_tags:
+        description: Whether this run created package tags that were not already on the remote, i.e. whether packages were published.
+        value: ${{ jobs.publish.outputs.has_tags }}
 
 permissions:
   contents: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -70,3 +70,21 @@ jobs:
       - version-pr
 
     uses: ./.github/workflows/publish.yml
+
+  # Regenerate the `.mdxai`-scaffolded SDK pages in morpho-apps once packages
+  # are actually on npm. Gated on the publish signal rather than on the
+  # version-bump push, so a failed publish never dispatches a doc rebuild for
+  # versions nobody can install.
+  docs-dispatch:
+    if: needs.publish.result == 'success' && needs.publish.outputs.has_tags == 'true'
+
+    permissions:
+      contents: read
+
+    needs:
+      - publish
+
+    uses: ./.github/workflows/docs-dispatch.yml
+    secrets:
+      DOCS_BOT_APP_ID: ${{ secrets.DOCS_BOT_APP_ID }}
+      DOCS_BOT_PRIVATE_KEY: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}

--- a/scripts/release/list-released-packages.mjs
+++ b/scripts/release/list-released-packages.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import {
+  readPackageManifest,
+  readPreviousPackageManifest,
+} from "./compute-pending-tag.mjs";
+import { getErrorMessage } from "./helpers.mjs";
+
+const DEFAULT_BASE_REF = "HEAD^";
+const MANIFEST_PATHSPEC = "packages/*/package.json";
+
+/**
+ * Lists the package manifests touched between a base ref and HEAD.
+ *
+ * Mirrors the pathspec and diff filter the publish workflow uses to create
+ * package tags, so both derive the released set from the same commit range.
+ *
+ * @param {{ baseRef?: string, cwd?: string }} options Git read options.
+ * @returns {string[]} Repository-relative manifest paths, in git's order.
+ */
+export function listChangedManifests(options = {}) {
+  const baseRef = options.baseRef ?? DEFAULT_BASE_REF;
+  const stdout = execFileSync(
+    "git",
+    [
+      "diff",
+      "--name-only",
+      "-z",
+      "--diff-filter=ACMRT",
+      baseRef,
+      "HEAD",
+      "--",
+      MANIFEST_PATHSPEC,
+    ],
+    { cwd: options.cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  return stdout.split("\0").filter((manifestPath) => manifestPath !== "");
+}
+
+/**
+ * Lists the publishable packages whose version changed between a base ref and HEAD.
+ *
+ * Returns an empty list when the base ref does not resolve, which is how an
+ * initial commit with no parent reaches this code.
+ *
+ * @param {{ baseRef?: string, cwd?: string }} options Git read options.
+ * @returns {{ name: string, version: string }[]} Released packages, sorted by name.
+ */
+export function listReleasedPackages(options = {}) {
+  const baseRef = options.baseRef ?? DEFAULT_BASE_REF;
+  const cwd = options.cwd;
+  if (!revisionExists({ cwd, revision: baseRef })) return [];
+
+  const releasedPackages = [];
+  for (const manifestPath of listChangedManifests({ baseRef, cwd })) {
+    const manifest = readPackageManifest({ cwd, manifestPath });
+    if (manifest.private === true) continue;
+    if (manifest.name == null || manifest.version == null) continue;
+
+    const previousManifest = readPreviousPackageManifest({
+      baseRef,
+      cwd,
+      manifestPath,
+    });
+    if (previousManifest?.version === manifest.version) continue;
+
+    releasedPackages.push({ name: manifest.name, version: manifest.version });
+  }
+
+  return releasedPackages.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+}
+
+/**
+ * Renders the GitHub Actions step outputs for a released package list.
+ *
+ * `released_packages` is the JSON payload forwarded to the documentation
+ * regeneration workflow. `JSON.stringify` cannot emit a raw newline, so the
+ * value is always a single line and needs no heredoc delimiter.
+ *
+ * @param {{ name: string, version: string }[]} releasedPackages Released packages.
+ * @returns {string} The `key=value` lines to append to `$GITHUB_OUTPUT`.
+ */
+export function getGitHubOutput(releasedPackages) {
+  const hasReleasedPackages = releasedPackages.length > 0 ? "true" : "false";
+
+  return [
+    `has_released_packages=${hasReleasedPackages}`,
+    `released_packages=${JSON.stringify(releasedPackages)}`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Reports the released packages to `$GITHUB_OUTPUT` and stdout.
+ *
+ * @param {{ baseRef?: string, cwd?: string, outputFile?: string, writeOutput?: (message: string) => void }} options Runtime options.
+ * @returns {{ name: string, version: string }[]} The released packages.
+ */
+export function reportReleasedPackages(options = {}) {
+  const releasedPackages = listReleasedPackages({
+    baseRef: options.baseRef,
+    cwd: options.cwd,
+  });
+  const outputFile = options.outputFile ?? process.env.GITHUB_OUTPUT;
+  const writeOutput =
+    options.writeOutput ?? ((message) => process.stdout.write(message));
+
+  if (outputFile != null && outputFile !== "") {
+    appendFileSync(outputFile, getGitHubOutput(releasedPackages));
+  }
+
+  writeOutput(`${JSON.stringify(releasedPackages, null, 2)}\n`);
+
+  return releasedPackages;
+}
+
+/**
+ * Runs the released package listing CLI.
+ *
+ * @param {{ baseRef?: string, cwd?: string, outputFile?: string, writeOutput?: (message: string) => void }} options Runtime options.
+ * @returns {{ name: string, version: string }[]} The released packages.
+ */
+export function main(options = {}) {
+  return reportReleasedPackages(options);
+}
+
+function revisionExists(options) {
+  try {
+    execFileSync(
+      "git",
+      ["rev-parse", "--verify", "--quiet", `${options.revision}^{commit}`],
+      { cwd: options.cwd, stdio: ["ignore", "ignore", "pipe"] },
+    );
+  } catch (error) {
+    // `--verify --quiet` exits 1 when the revision does not resolve. Every
+    // other failure (git missing, not a repository, corruption, ...) exits
+    // 128 and must propagate rather than be read as "there is no parent
+    // commit", which would silently dispatch nothing on a broken checkout.
+    if (isUnresolvedRevisionError(error)) return false;
+
+    throw error;
+  }
+
+  return true;
+}
+
+function isUnresolvedRevisionError(error) {
+  return (
+    typeof error === "object" &&
+    error != null &&
+    "status" in error &&
+    error.status === 1
+  );
+}
+
+if (
+  process.argv[1] != null &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${getErrorMessage(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release/list-released-packages.test.js
+++ b/scripts/release/list-released-packages.test.js
@@ -1,0 +1,283 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  getGitHubOutput,
+  listChangedManifests,
+  listReleasedPackages,
+  main,
+  reportReleasedPackages,
+} from "./list-released-packages.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+describe("listChangedManifests", () => {
+  test("default", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+      { name: "@morpho-org/beta", version: "2.0.0" },
+    ]);
+    writePackage(root, { name: "@morpho-org/alpha", version: "1.1.0" });
+    commitAll(root, "version alpha");
+
+    expect(listChangedManifests({ cwd: root })).toEqual([
+      "packages/alpha/package.json",
+    ]);
+  });
+
+  test("behavior: ignores non-manifest changes", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    writeFileSync(join(root, "packages/alpha/README.md"), "# alpha\n");
+    commitAll(root, "document alpha");
+
+    expect(listChangedManifests({ cwd: root })).toEqual([]);
+  });
+});
+
+describe("listReleasedPackages", () => {
+  test("default", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+      { name: "@morpho-org/beta", version: "2.0.0" },
+    ]);
+    writePackage(root, { name: "@morpho-org/beta", version: "2.1.0" });
+    writePackage(root, { name: "@morpho-org/alpha", version: "1.1.0" });
+    commitAll(root, "version packages");
+
+    expect(listReleasedPackages({ cwd: root })).toEqual([
+      { name: "@morpho-org/alpha", version: "1.1.0" },
+      { name: "@morpho-org/beta", version: "2.1.0" },
+    ]);
+  });
+
+  test("behavior: skips manifests whose version did not change", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    writePackage(root, {
+      description: "Metadata-only manifest update",
+      name: "@morpho-org/alpha",
+      version: "1.0.0",
+    });
+    commitAll(root, "update alpha metadata");
+
+    expect(listReleasedPackages({ cwd: root })).toEqual([]);
+  });
+
+  test("behavior: skips private packages", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", private: true, version: "1.0.0" },
+    ]);
+    writePackage(root, {
+      name: "@morpho-org/alpha",
+      private: true,
+      version: "1.1.0",
+    });
+    commitAll(root, "version alpha");
+
+    expect(listReleasedPackages({ cwd: root })).toEqual([]);
+  });
+
+  test("behavior: skips manifests without a version", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    writePackage(root, { name: "@morpho-org/alpha" });
+    commitAll(root, "drop alpha version");
+
+    expect(listReleasedPackages({ cwd: root })).toEqual([]);
+  });
+
+  test("behavior: treats a missing previous manifest as a new package", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    writePackage(root, { name: "@morpho-org/beta", version: "0.1.0" });
+    commitAll(root, "add beta");
+
+    expect(listReleasedPackages({ cwd: root })).toEqual([
+      { name: "@morpho-org/beta", version: "0.1.0" },
+    ]);
+  });
+
+  test("behavior: no base ref on an initial commit", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+
+    expect(listReleasedPackages({ cwd: root })).toEqual([]);
+  });
+
+  test("behavior: diffs against the first parent of a merge commit", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    runGit(["checkout", "-b", "release"], root);
+    writePackage(root, { name: "@morpho-org/alpha", version: "1.1.0" });
+    commitAll(root, "version alpha");
+    runGit(["checkout", "main"], root);
+    runGit(
+      [
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "merge",
+        "--no-ff",
+        "-m",
+        "merge release",
+        "release",
+      ],
+      root,
+    );
+
+    expect(listReleasedPackages({ cwd: root })).toEqual([
+      { name: "@morpho-org/alpha", version: "1.1.0" },
+    ]);
+  });
+
+  test("error: rethrows unexpected git failures", () => {
+    const root = createTempDir();
+
+    expect(() => listReleasedPackages({ cwd: root })).toThrow(
+      /not a git repository/,
+    );
+  });
+});
+
+describe("getGitHubOutput", () => {
+  test("default", () => {
+    expect(
+      getGitHubOutput([{ name: "@morpho-org/alpha", version: "1.1.0" }]),
+    ).toBe(
+      'has_released_packages=true\nreleased_packages=[{"name":"@morpho-org/alpha","version":"1.1.0"}]\n',
+    );
+  });
+
+  test("behavior: empty release set", () => {
+    expect(getGitHubOutput([])).toBe(
+      "has_released_packages=false\nreleased_packages=[]\n",
+    );
+  });
+});
+
+describe("reportReleasedPackages", () => {
+  test("default", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    writePackage(root, { name: "@morpho-org/alpha", version: "1.1.0" });
+    commitAll(root, "version alpha");
+    const outputFile = join(createTempDir(), "github-output");
+    writeFileSync(outputFile, "");
+    const writeOutput = vi.fn();
+
+    expect(
+      reportReleasedPackages({ cwd: root, outputFile, writeOutput }),
+    ).toEqual([{ name: "@morpho-org/alpha", version: "1.1.0" }]);
+    expect(readFileSync(outputFile, "utf8")).toBe(
+      'has_released_packages=true\nreleased_packages=[{"name":"@morpho-org/alpha","version":"1.1.0"}]\n',
+    );
+    expect(writeOutput).toHaveBeenCalledWith(
+      `${JSON.stringify([{ name: "@morpho-org/alpha", version: "1.1.0" }], null, 2)}\n`,
+    );
+  });
+
+  test("behavior: skips the output file when it is not configured", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    const writeOutput = vi.fn();
+
+    expect(
+      reportReleasedPackages({ cwd: root, outputFile: "", writeOutput }),
+    ).toEqual([]);
+    expect(writeOutput).toHaveBeenCalledWith("[]\n");
+  });
+});
+
+describe("main", () => {
+  test("default", () => {
+    const root = createGitRepo([
+      { name: "@morpho-org/alpha", version: "1.0.0" },
+    ]);
+    writePackage(root, { name: "@morpho-org/alpha", version: "1.1.0" });
+    commitAll(root, "version alpha");
+    const writeOutput = vi.fn();
+
+    expect(main({ cwd: root, outputFile: "", writeOutput })).toEqual([
+      { name: "@morpho-org/alpha", version: "1.1.0" },
+    ]);
+  });
+});
+
+function createTempDir() {
+  const tempDir = mkdtempSync(join(tmpdir(), "released-packages-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+function createGitRepo(manifests) {
+  const root = createTempDir();
+  for (const manifest of manifests) {
+    writePackage(root, manifest);
+  }
+  runGit(["-c", "init.defaultBranch=main", "init"], root);
+  commitAll(root, "initial");
+
+  return root;
+}
+
+function writePackage(root, manifest) {
+  const packageDir = join(root, "packages", basename(manifest.name));
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+}
+
+function commitAll(root, message) {
+  runGit(["add", "."], root);
+  runGit(
+    [
+      "-c",
+      "commit.gpgsign=false",
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "-m",
+      message,
+    ],
+    root,
+  );
+}
+
+function runGit(args, cwd) {
+  // `git checkout`/`git merge` report progress on stderr; keep it out of the
+  // test reporter output.
+  return execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}


### PR DESCRIPTION
Closes SDK-275. Implements the design of record (TIB-2026-07-04 "One GitHub App for Cross-Repo Docs Automation", morpho-org/morpho-apps#3507 — scenario B + Phase 3). Credential prerequisite SDK-273 is done.

Rings the morpho-apps doc regeneration workflow when a package is published, so `.mdxai`-scaffolded SDK pages regenerate within minutes of a release.

## Trigger: the in-pipeline publish signal

A new `docs-dispatch` job hangs off the existing release pipeline in `push.yml`, gated on the publish job's `has_tags` output. It runs in the same workflow run, on the commit carrying the bumped versions, only after publish succeeds. The three alternatives are all broken:

- **`on: release: types: [published]`** — `publish.yml` creates its GitHub Releases with `GH_TOKEN: ${{ github.token }}`, and events created by `GITHUB_TOKEN` never start workflows. Would silently never fire.
- **`workflow_run`** — `publish.yml` is a reusable workflow (`on: workflow_call`); reusable workflows don't emit their own `workflow_run` events, only the caller does. A `workflow_run` on "Push" fires after every push to `main`/`next`, publish or not, so it needs the same gating anyway — at the cost of a second run and a second checkout.
- **standalone `on: push` + `paths: ['packages/*/package.json']`** (the reference workflow on the closed morpho-apps#3336 branch) — the version-bump commit lands on `main` and `publish.yml` runs on that *same* push, so the dispatch races the npm publish and fires even when publish subsequently fails.

## One correction to the plan

The issue cites `publish.yml:16-17` as already exposing `outputs.has_tags`. Those lines are the **job**-level `outputs:`, consumed by the sibling `github-releases` job. Reusable workflows do **not** propagate job outputs to their callers — a caller reads only what `on.workflow_call.outputs` declares. Without that mapping, `needs.publish.outputs.has_tags` in `push.yml` evaluates to the empty string and the dispatch would never fire.

This PR adds the missing `on.workflow_call.outputs.has_tags` mapping to `publish.yml`. No behavior change for existing jobs.

## Detection

`scripts/release/list-released-packages.mjs` diffs `HEAD^..HEAD` over `packages/*/package.json`, keeps entries whose `version` changed and that are not `private`, and emits `[{name, version}]`. It reuses `readPackageManifest` / `readPreviousPackageManifest` from `compute-pending-tag.mjs` and mirrors the pathspec and `--diff-filter` at `publish.yml:306`, so the dispatched set and the tagged set are derived from one source of truth. Diffing the first parent is robust to changesets' squash-vs-merge.

Verified against real repo history:

| commit | expected | emitted |
|---|---|---|
| `7508d435` `chore: version packages (main)` | the 9 packages that release tagged | exactly those 9, name and version matching `git tag --points-at` |
| `878a5bc4` `feat(morpho-sdk)!: native ETH wrapping` | nothing | `[]` |

The payload stays general even though only `@morpho-org/morpho-sdk` and `@morpho-org/midnight-sdk` carry `.mdxai` scaffolds today — the regen script selects scaffolds by frontmatter `dependencies` and no-ops when nothing matches.

## The key this repo holds

`morpho-docs-bot` is **not installed on sdks**. The private key exists only to mint an `actions: write` token for the **morpho-apps** installation, which can start a workflow there and read nothing else. Per SDK-273, a leaked key (as opposed to a leaked workflow token) can reach private code; that exposure is accepted and bounded, with a documented escape hatch.

Detection runs *before* the token is minted and uses only node builtins — no `pnpm install`, so no dependency lifecycle script executes ahead of the privileged step. When no package was released, the job skips the dispatch without minting a token at all.

## Deviation from the issue snippet

The issue specifies `permissions: {}` on `docs-dispatch.yml` ("no repo scopes needed — the app token makes the cross-repo call"). That overlooks `actions/checkout`, which reads this repository. Empty permissions happen to work for a public repo today, but the behavior is undocumented and would break the moment the repo went private. `contents: read` is exactly what checkout needs, nothing more, and is the documented default in `AGENTS.md` §10. It grants no cross-repo capability — the dispatch still travels on the app token.

`gh workflow run` uses `--raw-field`, not `--field`: the latter respects gh's `@` syntax and the payload is dense with `@morpho-org/...` package names.

## Fork safety

`push.yml` triggers only on `push` (`tags-ignore: ['**']`), and the publish/version jobs are branch-gated to `main`/`next` with `environment: prod`. There is no `pull_request_target` anywhere in the repo. Fork PRs never see the key, and outsiders cannot ring the doorbell.

## Repo constraints (`AGENTS.md` §10)

- Every third-party `uses:` is SHA-pinned with a trailing `# vX.Y.Z` comment; all three SHAs match pins already in use in `publish.yml` / `version-pr.yml`.
- Explicit `permissions:` block. No `secrets: inherit` — both secrets are listed explicitly, as `push.yml:56-57` does.
- Secrets and context are `env:`-bound and referenced as `$VAR` in `run:`; nothing is interpolated into a shell string.
- **No changeset** — the diff is CI and release tooling only, no published package source (`CONTRIBUTING.md:64,78`, `AGENTS.md` §7).

## Input contract with morpho-apps

SDK-276 defines `source` as an overloaded `workflow_dispatch` input: **empty** means regenerate everything, the literal **`openapi`** means a spec-sourced run, and **anything else** is parsed as the released-packages JSON. This job only ever sends a non-empty JSON array — when nothing was released it skips the dispatch entirely rather than sending `source=""`, which would kick off a full regen on every non-release push to `main`. Input names `source` / `source_run` match SDK-276.

**One question for the morpho-apps side.** SDK-276's scaffold inventory grounds `sdks/midnight-sdk.mdxai` on `dependencies: @morpho-org/midnight-sdk@0.1.0`, but the most recent release published `@morpho-org/midnight-sdk@1.0.0` (see `git tag --points-at 7508d435`). If the regen script selects scaffolds by matching `name@version` rather than by name, an sdks release will dispatch successfully and then regenerate nothing — a green pipeline with no output. If it matches on name alone, this is a non-issue. Worth confirming while implementing SDK-276.

## Merge ordering

SDK-273 (`morpho-docs-bot` app + `DOCS_BOT_APP_ID` / `DOCS_BOT_PRIVATE_KEY` repo secrets) is **done** — the credential exists.

SDK-276 adds the dispatch target, `doc-auto-generation-workflow.yml` on morpho-apps, and is still open. Until it lands, `gh workflow run` will 404. The `docs-dispatch` job only executes on a real publish to `main`/`next`, so merging this ahead of SDK-276 is inert on feature branches — but SDK-276 must land before the next release, or this job goes red right after a successful publish.

## Test plan

- [x] `pnpm lint` — biome, jsdoc coverage self-check, checksum-address all clean
- [x] `pnpm exec vitest run --project scripts` — 117 passed (15 new)
- [x] New unit tests cover: version-changed detection, unchanged-version skip, private-package skip, missing-version skip, new-package add, initial commit with no parent, first-parent diff on a merge commit, `$GITHUB_OUTPUT` rendering, and rethrow of unexpected git failures
- [x] Detector cross-checked against `git tag --points-at 7508d435` — output matches the real release exactly
- [ ] Acceptance (post-merge, needs SDK-276): a real release on `main` produces green `publish` → green `docs-dispatch` → queued `doc-auto-generation-workflow` on morpho-apps → draft PR by `morpho-docs-bot[bot]`
- [ ] Acceptance: confirm the minted dispatch token cannot read repo contents
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
