### PR TITLE
fix(evm-simulation): block native ETH retained by bundler3 on Tenderly

### DIFF
--- a/.changeset/native-eth-bundler-retention.md
+++ b/.changeset/native-eth-bundler-retention.md
@@ -1,0 +1,16 @@
+---
+"@morpho-org/evm-simulation": patch
+---
+
+fix(evm-simulation): detect native ETH retained by bundler3 on the Tenderly backend
+
+`assertNoBundlerRetention` only inspected parsed `Transfer` logs, so native ETH
+retained by a bundler3 address slipped through the guard on the Tenderly primary
+backend — native ETH emits no event log, and Tenderly derives it into
+`assetChanges` rather than synthetic transfer logs (Cantina finding 1440).
+
+The retention check now also reads native ETH from `assetChanges` (the
+cross-backend source of truth), while ERC20/WETH retention keeps coming from
+transfer logs. Native transfer logs (the `eth_simulateV1` synthetic sentinel)
+are only used as a fallback for bundler addresses absent from `assetChanges`, so
+native moves are never double-counted on `eth_simulateV1`.

--- a/packages/evm-simulation/src/simulate/pipeline/bundler-retention.spec.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/bundler-retention.spec.ts
@@ -1,5 +1,5 @@
 import { addressesRegistry, getChainAddresses } from "@morpho-org/blue-sdk";
-import { type Address, getAddress } from "viem";
+import { type Address, ethAddress, getAddress } from "viem";
 import { vi } from "vitest";
 
 vi.mock("@morpho-org/blue-sdk", async (importOriginal) => {
@@ -32,7 +32,7 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers }),
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
@@ -43,13 +43,13 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers }),
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
   it("does not throw for empty transfers", () => {
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers: [] }),
+      assertNoBundlerRetention({ chainId: 1, transfers: [], assetChanges: [] }),
     ).not.toThrow();
   });
 
@@ -65,7 +65,11 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 999999, transfers }),
+      assertNoBundlerRetention({
+        chainId: 999999,
+        transfers,
+        assetChanges: [],
+      }),
     ).not.toThrow();
   });
 
@@ -77,7 +81,12 @@ describe("assertNoBundlerRetention", () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers: [], logger }),
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers: [],
+        assetChanges: [],
+        logger,
+      }),
     ).not.toThrow();
 
     expect(logger.warn).toHaveBeenCalledWith(
@@ -102,9 +111,9 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
 
-    expect(() => assertNoBundlerRetention({ chainId: 1, transfers })).toThrow(
-      "unexpected SDK bug",
-    );
+    expect(() =>
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+    ).toThrow("unexpected SDK bug");
   });
 
   it("does not throw when bundler passes tokens through (net zero)", () => {
@@ -125,7 +134,7 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers }),
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
@@ -140,9 +149,9 @@ describe("assertNoBundlerRetention", () => {
         }),
       ]),
     ]);
-    expect(() => assertNoBundlerRetention({ chainId: 1, transfers })).toThrow(
-      BlacklistViolationError,
-    );
+    expect(() =>
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+    ).toThrow(BlacklistViolationError);
   });
 
   it("throws when bundler retains partial amount above dust", () => {
@@ -163,9 +172,9 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     // Net retention: 500000 > DUST_THRESHOLD (100)
-    expect(() => assertNoBundlerRetention({ chainId: 1, transfers })).toThrow(
-      BlacklistViolationError,
-    );
+    expect(() =>
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+    ).toThrow(BlacklistViolationError);
   });
 
   it("does not throw when bundler retention is below dust threshold", () => {
@@ -182,7 +191,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
     // Net retention: 50 <= DUST_THRESHOLD (100)
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers }),
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
@@ -203,7 +212,12 @@ describe("assertNoBundlerRetention", () => {
     ]);
 
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, logger }),
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers,
+        assetChanges: [],
+        logger,
+      }),
     ).not.toThrow();
     expect(logger.warn).toHaveBeenCalledWith(
       "Simulation detected pre-existing bundler balance being swept",
@@ -246,7 +260,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
 
     try {
-      assertNoBundlerRetention({ chainId: 1, transfers });
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] });
       expect.fail("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(BlacklistViolationError);
@@ -266,7 +280,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
 
     try {
-      assertNoBundlerRetention({ chainId: 1, transfers });
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] });
       expect.fail("should have thrown");
     } catch (err) {
       const changes = (err as BlacklistViolationError).assetChanges ?? [];
@@ -275,6 +289,130 @@ describe("assertNoBundlerRetention", () => {
       expect(entry.address?.toLowerCase()).toBe(BUNDLER.toLowerCase());
       expect(entry.token?.toLowerCase()).toBe(USDC.toLowerCase());
       expect(entry.netRetained).toBe("777");
+    }
+  });
+
+  // ─── Native ETH ──────────────────────────────────────────────────────────
+  // Native ETH emits no event log, so it never reaches `transfers` on the
+  // Tenderly primary backend — it must be read from `assetChanges`. Regression
+  // suite for Cantina finding 1440 (native ETH retained by bundler3 silently
+  // passing the guard).
+  const ONE_ETH = 1_000000000000000000n;
+
+  it("behavior: throws when bundler retains native ETH reported only in assetChanges (Tenderly path)", () => {
+    // Tenderly derives native ETH into assetChanges and emits no transfer log.
+    // Before the fix this resolved instead of throwing (finding 1440).
+    expect(() =>
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers: [],
+        assetChanges: [
+          { account: BUNDLER, changes: [{ token: ethAddress, diff: ONE_ETH }] },
+        ],
+      }),
+    ).toThrow(BlacklistViolationError);
+  });
+
+  it("behavior: counts native ETH once when present in both a transfer log and assetChanges (eth_simulateV1 path)", () => {
+    // eth_simulateV1 synthesizes native moves as `ethAddress` transfer logs and
+    // derives assetChanges from them. The guard must not sum both sources.
+    const transfers = [
+      { token: ethAddress, from: USER, to: BUNDLER, amount: ONE_ETH, txIdx: 0 },
+    ];
+    try {
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers,
+        assetChanges: [
+          { account: BUNDLER, changes: [{ token: ethAddress, diff: ONE_ETH }] },
+        ],
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BlacklistViolationError);
+      const changes = (err as BlacklistViolationError).assetChanges ?? [];
+      expect(changes).toHaveLength(1);
+      expect(changes[0]!.token?.toLowerCase()).toBe(ethAddress.toLowerCase());
+      // Counted once (assetChanges), not doubled with the synthetic log.
+      expect(changes[0]!.netRetained).toBe(ONE_ETH.toString());
+    }
+  });
+
+  it("behavior: falls back to native transfer logs when assetChanges has no native entry", () => {
+    // Defense in depth: a backend that populates native transfers but not
+    // assetChanges must still trip the guard.
+    const transfers = [
+      { token: ethAddress, from: USER, to: BUNDLER, amount: ONE_ETH, txIdx: 0 },
+    ];
+    expect(() =>
+      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+    ).toThrow(BlacklistViolationError);
+  });
+
+  it("behavior: does not throw when native ETH passes through the bundler (net zero)", () => {
+    expect(() =>
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers: [],
+        assetChanges: [
+          { account: BUNDLER, changes: [{ token: ethAddress, diff: 0n }] },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("behavior: does not throw for native ETH retention below dust threshold", () => {
+    expect(() =>
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers: [],
+        assetChanges: [
+          { account: BUNDLER, changes: [{ token: ethAddress, diff: 50n }] },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("behavior: ignores native ETH assetChanges for non-bundler accounts", () => {
+    expect(() =>
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers: [],
+        assetChanges: [
+          { account: VAULT, changes: [{ token: ethAddress, diff: ONE_ETH }] },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("behavior: reports both ERC20 (from logs) and native ETH (from assetChanges) retention together", () => {
+    // Mixed bundle: WETH stuck via a log, native ETH stuck via assetChanges.
+    const transfers = parseTransfers([
+      makeCall([
+        makeTransferLog({
+          token: USDC,
+          from: USER,
+          to: BUNDLER,
+          amount: 1000000n,
+        }),
+      ]),
+    ]);
+    try {
+      assertNoBundlerRetention({
+        chainId: 1,
+        transfers,
+        assetChanges: [
+          { account: BUNDLER, changes: [{ token: ethAddress, diff: ONE_ETH }] },
+        ],
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BlacklistViolationError);
+      const changes = (err as BlacklistViolationError).assetChanges ?? [];
+      const tokens = changes.map((c) => c.token?.toLowerCase()).sort();
+      expect(tokens).toEqual(
+        [USDC.toLowerCase(), ethAddress.toLowerCase()].sort(),
+      );
     }
   });
 });

--- a/packages/evm-simulation/src/simulate/pipeline/bundler-retention.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/bundler-retention.ts
@@ -3,9 +3,13 @@ import {
   UnsupportedChainIdError,
 } from "@morpho-org/blue-sdk";
 import { isDefined } from "@morpho-org/morpho-ts";
-import { type Address, getAddress } from "viem";
+import { type Address, ethAddress, getAddress } from "viem";
 import { BlacklistViolationError } from "../../errors.js";
-import type { SimulationLogger, Transfer } from "../../types.js";
+import type {
+  AccountAssetChanges,
+  SimulationLogger,
+  Transfer,
+} from "../../types.js";
 
 /**
  * Dust tolerance for bundler retention, in raw token units.
@@ -62,6 +66,7 @@ function getBundlerAddresses(
 interface AssertNoBundlerRetentionParams {
   chainId: number;
   transfers: Transfer[];
+  assetChanges: readonly AccountAssetChanges[];
   logger?: SimulationLogger;
 }
 
@@ -71,15 +76,30 @@ interface AssertNoBundlerRetentionParams {
  * Uses net flow (inbound minus outbound) per (bundler address, token) pair.
  * Bundler3 legitimately receives tokens as an intermediary (user → bundler3 →
  * vault), so gross inbound would fire false positives. We only block positive
- * net flow above `DUST_THRESHOLD` — tokens stuck in a bundler address. Negative
+ * net flow above `DUST_THRESHOLD` — value stuck in a bundler address. Negative
  * net flow means the simulated bundle sweeps a pre-existing or state-overridden
  * bundler balance. That is useful telemetry, but not current-bundle retention,
  * so it is warned instead of raising a blacklist violation.
+ *
+ * **Two flow sources, one per asset class.** ERC20 / WETH9 retention is read
+ * from parsed `transfers` (log-derived, identical across backends). Native ETH
+ * emits no event log, so it can never appear in `transfers` on the Tenderly
+ * primary backend — Tenderly derives native moves into `assetChanges` instead.
+ * Native ETH is therefore read from `assetChanges`, the cross-backend source of
+ * truth for native value: Tenderly derives it from its trace, and
+ * `eth_simulateV1` derives it from the synthetic `traceTransfers` logs. Without
+ * this, native ETH stuck in bundler3 would pass the guard undetected on the
+ * Tenderly path (Cantina finding 1440).
+ *
+ * To avoid double-counting native ETH on `eth_simulateV1` — where the same
+ * native move exists both as a synthetic `ethAddress` transfer log *and* in the
+ * `assetChanges` derived from it — native transfer logs are only used as a
+ * fallback for bundler addresses that carry no native `assetChanges` entry.
  */
 export function assertNoBundlerRetention(
   params: AssertNoBundlerRetentionParams,
 ): void {
-  const { chainId, transfers, logger } = params;
+  const { chainId, transfers, assetChanges, logger } = params;
   const bundlerAddresses = getBundlerAddresses(chainId, logger);
   if (bundlerAddresses.size === 0) return;
 
@@ -101,9 +121,30 @@ export function assertNoBundlerRetention(
     }
   };
 
+  // Native ETH from `assetChanges` (authoritative, cross-backend). Track which
+  // bundlers already have a native entry here so the transfer-log pass below
+  // does not re-add the same native move on `eth_simulateV1`.
+  const nativeFromAssetChanges = new Set<string>();
+  for (const { account, changes } of assetChanges) {
+    if (!bundlerAddresses.has(account)) continue;
+    for (const change of changes) {
+      if (change.token !== ethAddress) continue;
+      recordFlow(account, ethAddress, change.diff);
+      nativeFromAssetChanges.add(account.toLowerCase());
+    }
+  }
+
+  // ERC20 / WETH9 retention from transfer logs. Native ETH transfers (the
+  // `eth_simulateV1` synthetic sentinel) only backfill a bundler endpoint that
+  // is absent from `nativeFromAssetChanges`, so native is never summed on top
+  // of the `assetChanges` value already recorded for that address.
+  const usesAssetChangeNative = (t: Transfer, addr: Address): boolean =>
+    t.token === ethAddress && nativeFromAssetChanges.has(addr.toLowerCase());
   for (const t of transfers) {
-    if (bundlerAddresses.has(t.to)) recordFlow(t.to, t.token, t.amount);
-    if (bundlerAddresses.has(t.from)) recordFlow(t.from, t.token, -t.amount);
+    if (bundlerAddresses.has(t.to) && !usesAssetChangeNative(t, t.to))
+      recordFlow(t.to, t.token, t.amount);
+    if (bundlerAddresses.has(t.from) && !usesAssetChangeNative(t, t.from))
+      recordFlow(t.from, t.token, -t.amount);
   }
 
   const entries = [...flow.values()];

--- a/packages/evm-simulation/src/simulate/simulate.spec.ts
+++ b/packages/evm-simulation/src/simulate/simulate.spec.ts
@@ -1,5 +1,5 @@
 import { getChainAddresses } from "@morpho-org/blue-sdk";
-import { type Address, type Hex, zeroAddress } from "viem";
+import { type Address, ethAddress, type Hex, zeroAddress } from "viem";
 import { vi } from "vitest";
 import {
   BlacklistViolationError,
@@ -199,6 +199,24 @@ describe.sequential("simulate — success", () => {
       }),
     ];
     mockTenderlyRpc.mockResolvedValueOnce(makeSuccessResult(logs));
+
+    await expect(simulate(makeConfig(), makeParams())).rejects.toThrow(
+      BlacklistViolationError,
+    );
+  });
+
+  it("throws BlacklistViolationError end-to-end when Tenderly reports native ETH retention via assetChanges only (finding 1440)", async () => {
+    // Tenderly derives native ETH into assetChanges and emits no transfer log.
+    // With logs empty, only assetChanges carries the retained ETH — the guard
+    // must still fire. Before the fix, simulate() resolved instead of throwing.
+    const BUNDLER = getChainAddresses(1).bundler3.bundler3;
+    const assetChanges: AccountAssetChanges[] = [
+      {
+        account: BUNDLER,
+        changes: [{ token: ethAddress, diff: 1_000000000000000000n }],
+      },
+    ];
+    mockTenderlyRpc.mockResolvedValueOnce(makeSuccessResult([], assetChanges));
 
     await expect(simulate(makeConfig(), makeParams())).rejects.toThrow(
       BlacklistViolationError,

--- a/packages/evm-simulation/src/simulate/simulate.ts
+++ b/packages/evm-simulation/src/simulate/simulate.ts
@@ -97,6 +97,7 @@ export async function simulate(
   assertNoBundlerRetention({
     chainId: params.chainId,
     transfers,
+    assetChanges: result.assetChanges,
     logger: config.logger,
   });
 


### PR DESCRIPTION
## Context

Cantina **finding 1440** — *`simulate()` reports no funds retained by bundler3 while native ETH is retained* (SDK-277, Sev 2 High). Confirmed as a real code bug on `main`.

`assertNoBundlerRetention` only inspected parsed `Transfer` logs. Native ETH **emits no event log**, so it never reaches `transfers` on the **Tenderly primary backend** — Tenderly derives native value into `assetChanges` instead. As a result, native ETH stuck in a bundler3 address silently passed the "never bypassable" retention guard on the default path. The `eth_simulateV1` fallback caught it (via `traceTransfers` synthetic `ethAddress` logs), but that is the fallback, not the primary path.

Verified against Tenderly docs + EVM fundamentals: a native ETH transfer produces no `LOG`, so a log-only parser structurally cannot see raw native retention on Tenderly.

## Fix

- `assertNoBundlerRetention` now reads **native ETH from `assetChanges`** (the normalized, cross-backend source of truth — both backends populate it with `ethAddress`), while **ERC20/WETH retention keeps coming from transfer logs** (unchanged behavior).
- **No double-counting on `eth_simulateV1`**: native moves exist there both as a synthetic `ethAddress` transfer log *and* in the `assetChanges` derived from it. Native transfer logs are only used to backfill bundler endpoints **absent** from `assetChanges`.
- `assetChanges` is now a required parameter of the internal check; `simulate()` passes `result.assetChanges` through.

## Tests

Added regression coverage in `bundler-retention.spec.ts` and an end-to-end case in `simulate.spec.ts`:

- **Tenderly path**: native ETH present only in `assetChanges` (no logs) → throws `BlacklistViolationError` (the exact finding-1440 scenario).
- **eth_simulateV1 path**: native ETH in both a log and `assetChanges` → counted **once** (`netRetained` == amount, not doubled).
- Fallback (native log, empty `assetChanges`) → throws.
- Native pass-through / below-dust / non-bundler account → no throw.
- Mixed ERC20-log + native-assetChanges retention reported together.

**Proof the tests have teeth**: with the `assetChanges` path disabled, exactly the 3 native-ETH Tenderly regression tests fail; restored → `234 passed`. `tsc --noEmit`, `biome check`, and the full `evm-simulation` suite pass.

Patch changeset included. No package depends on `@morpho-org/evm-simulation`, so no dependency cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->