### PR TITLE
feat(morpho-sdk): make shares-mode repay funding deterministic

### DIFF
--- a/.changeset/deterministic-shares-repay-funding.md
+++ b/.changeset/deterministic-shares-repay-funding.md
@@ -1,0 +1,18 @@
+---
+"@morpho-org/morpho-sdk": minor
+---
+
+Make shares-mode repay funding deterministic and reusable. `MorphoBlue.repay`
+and `MorphoBlue.repayWithdrawCollateral` accept an optional `now` anchor (Unix
+seconds, defaults to the machine clock) for the 2h forward-accrual that sizes
+the loan-token transfer, and the funding math is extracted into the exported
+pure helper `computeSharesRepayFunding` (plus `computeRepayAccrualTimestamp`
+and the `REPAY_ACCRUAL_BUFFER` constant).
+
+Previously the buffered transfer was recomputed from the wall clock inside the
+entity, so an integrator sizing a native/ERC-20 split moments before building
+could land in a later second and get an ERC-20 pull a few wei of interest
+larger than the split it planned — over-pulling a balance drained to the last
+wei by the split and reverting the bundle at simulation/execution. Sizing the
+split with `computeSharesRepayFunding({ market, shares, now })` and passing
+the same `now` to the entity reproduces the pull byte-for-byte.

--- a/packages/morpho-sdk/src/entities/blue/blue.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.test.ts
@@ -13,6 +13,7 @@ import { describe, expect } from "vitest";
 import { CbbtcUsdcBlue, WstethWethBlue } from "../../../test/fixtures/blue.js";
 import { test } from "../../../test/setup.js";
 import { morphoViemExtension } from "../../client/index.js";
+import { computeSharesRepayFunding } from "../../helpers/index.js";
 import {
   isRequirementApproval,
   MutuallyExclusiveRepayAmountsError,
@@ -60,8 +61,13 @@ function makePosition(
 }
 
 // Position on a market whose loan token is wNative (WETH), for native-wrap repays.
+// Pass `rateAtTarget` to make forward accrual effective (it is a no-op without it).
 function makeWethPosition(
-  overrides: { collateral?: bigint; borrowShares?: bigint } = {},
+  overrides: {
+    collateral?: bigint;
+    borrowShares?: bigint;
+    rateAtTarget?: bigint;
+  } = {},
 ) {
   const market = new Market({
     params: new MarketParams(WstethWethBlue),
@@ -72,6 +78,7 @@ function makeWethPosition(
     lastUpdate: 1_700_000_000n,
     fee: 0n,
     price: ORACLE_PRICE_SCALE,
+    rateAtTarget: overrides.rateAtTarget,
   });
 
   return new AccrualPosition(
@@ -429,6 +436,48 @@ describe("MorphoBlue validation", () => {
     expect(approval.action.args.amount).toBe(expectedErc20);
   });
 
+  test("repay native: shares mode `now` pins the ERC-20 pull to a pre-sized split", async ({
+    client,
+  }) => {
+    const market = client
+      .extend(morphoViemExtension({ supportSignature: false }))
+      .morpho.blue(WstethWethBlue, mainnet.id);
+    // Accruing market (rateAtTarget set): without a pinned `now`, the funding
+    // recomputed at build time would drift past a split sized moments earlier.
+    const positionData = makeWethPosition({ rateAtTarget: 10n ** 9n });
+    const now = positionData.market.lastUpdate + 100n;
+
+    // Integrator flow: size the native/ERC-20 split ahead of the entity call,
+    // draining the ERC-20 balance first and wrapping native for the remainder.
+    const funding = computeSharesRepayFunding({
+      market: positionData.market,
+      shares: positionData.borrowShares,
+      now,
+    });
+    const erc20Balance = funding.transferAmount - parseUnits("0.1", 18);
+    const nativeAmount = funding.transferAmount - erc20Balance;
+
+    const repay = market.repay({
+      shares: positionData.borrowShares,
+      nativeAmount,
+      userAddress: USER,
+      positionData,
+      now,
+    });
+
+    // Same `now` ⇒ the entity reproduces the split byte-for-byte: the total
+    // routed is the pre-sized transfer and the ERC-20 pulled is exactly the
+    // balance the split drained — not a clock-drifted recomputation.
+    const tx = repay.buildTx();
+    expect(tx.action.args.transferAmount).toBe(funding.transferAmount);
+    const requirements = await repay.getRequirements();
+    const approval = requirements.find(isRequirementApproval);
+    if (!approval) {
+      throw new Error("Approval requirement not found");
+    }
+    expect(approval.action.args.amount).toBe(erc20Balance);
+  });
+
   test("repayWithdrawCollateral native: rejects nativeAmount when the loan token is not wNative", async ({
     client,
   }) => {
@@ -552,6 +601,43 @@ describe("MorphoBlue validation", () => {
       throw new Error("Approval requirement not found");
     }
     expect(approval.action.args.amount).toBe(expectedErc20);
+  });
+
+  test("repayWithdrawCollateral native: shares mode `now` pins the ERC-20 pull to a pre-sized split", async ({
+    client,
+  }) => {
+    const market = client
+      .extend(morphoViemExtension({ supportSignature: false }))
+      .morpho.blue(WstethWethBlue, mainnet.id);
+    // Accruing market — same determinism contract as the repay sister test.
+    const positionData = makeWethPosition({ rateAtTarget: 10n ** 9n });
+    const now = positionData.market.lastUpdate + 100n;
+
+    const funding = computeSharesRepayFunding({
+      market: positionData.market,
+      shares: positionData.borrowShares,
+      now,
+    });
+    const erc20Balance = funding.transferAmount - parseUnits("0.1", 18);
+    const nativeAmount = funding.transferAmount - erc20Balance;
+
+    const action = market.repayWithdrawCollateral({
+      shares: positionData.borrowShares,
+      nativeAmount,
+      withdrawAmount: positionData.collateral,
+      userAddress: USER,
+      positionData,
+      now,
+    });
+
+    const tx = action.buildTx();
+    expect(tx.action.args.transferAmount).toBe(funding.transferAmount);
+    const requirements = await action.getRequirements();
+    const approval = requirements.find(isRequirementApproval);
+    if (!approval) {
+      throw new Error("Approval requirement not found");
+    }
+    expect(approval.action.args.amount).toBe(erc20Balance);
   });
 
   test("supplyCollateralBorrow rejects invalid collateral and borrow amounts", async ({

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -37,6 +37,8 @@ import {
   computeMinBorrowSharePrice,
   computeMinWithdrawSharePrice,
   computeReallocations,
+  computeRepayAccrualTimestamp,
+  computeSharesRepayFunding,
   validateAccrualPosition,
   validateChainId,
   validateNativeAsset,
@@ -69,7 +71,6 @@ import {
   type MorphoClientType,
   MutuallyExclusiveRepayAmountsError,
   MutuallyExclusiveWithdrawAmountsError,
-  NativeAmountExceedsTransferAmountError,
   NegativeBorrowSharesError,
   NegativeNativeAmountError,
   NegativeSupplyAmountError,
@@ -270,7 +271,10 @@ export interface BlueActions {
    * `getRequirements` returns ERC20 approval for loan token to GeneralAdapter1.
    * Does NOT require Morpho authorization (anyone can repay on behalf of anyone).
    *
-   * **Shares mode:** `slippageTolerance` also caps `transferAmount`.
+   * **Shares mode:** `slippageTolerance` also caps `transferAmount`, and the
+   * loan-token funding is sized by {@link computeSharesRepayFunding} anchored
+   * on `now` — pass the anchor used to pre-size a native/ERC-20 split so the
+   * ERC-20 pull matches it byte-for-byte.
    *
    * @param params - Repay parameters including pre-fetched `positionData`.
    * @returns Object with `buildTx` and `getRequirements`.
@@ -280,6 +284,11 @@ export interface BlueActions {
       userAddress: Address;
       positionData: AccrualPosition;
       slippageTolerance?: bigint;
+      /**
+       * "Now" anchor (Unix seconds) for the shares-mode funding accrual — see
+       * {@link computeSharesRepayFunding}. Defaults to the machine clock.
+       */
+      now?: bigint;
     } & RepayAmountArgs,
   ) => {
     buildTx: (
@@ -336,6 +345,11 @@ export interface BlueActions {
    *
    * **Stale `positionData` risks underestimated debt and unsafe withdrawal.**
    *
+   * **Shares mode:** the loan-token funding is sized by
+   * {@link computeSharesRepayFunding} anchored on `now` — pass the anchor used
+   * to pre-size a native/ERC-20 split so the ERC-20 pull matches it
+   * byte-for-byte.
+   *
    * @param params - Combined parameters including pre-fetched `positionData`.
    * @returns Object with `buildTx` and `getRequirements`.
    */
@@ -345,6 +359,12 @@ export interface BlueActions {
       withdrawAmount: bigint;
       positionData: AccrualPosition;
       slippageTolerance?: bigint;
+      /**
+       * "Now" anchor (Unix seconds) for the funding accrual (shares mode) and
+       * the post-repay health check — see {@link computeSharesRepayFunding}.
+       * Defaults to the machine clock.
+       */
+      now?: bigint;
     } & RepayAmountArgs,
   ) => {
     buildTx: (
@@ -877,6 +897,14 @@ export class MorphoBlue implements BlueActions {
       userAddress: Address;
       positionData: AccrualPosition;
       slippageTolerance?: bigint;
+      /**
+       * "Now" anchor (Unix seconds) for the shares-mode funding accrual — see
+       * {@link computeSharesRepayFunding}. Defaults to the machine clock. Pass
+       * the anchor used to size an external native/ERC-20 funding split so the
+       * ERC-20 pull matches that split byte-for-byte instead of drifting with
+       * the clock between sizing and build.
+       */
+      now?: bigint;
     } & RepayAmountArgs,
   ) {
     validateChainId(this.client.viemClient.chain?.id, this.chainId);
@@ -930,21 +958,16 @@ export class MorphoBlue implements BlueActions {
       repayAssets = 0n;
       repayShares = shares;
       // 2h forward accrual upper-bounds the on-chain repay price; bundle
-      // skims residual back to the receiver.
-      const accrualTimestamp =
-        MathLib.max(Time.timestamp(), positionData.market.lastUpdate) +
-        Time.s.from.h(2n);
-      marketForRepay = positionData.market.accrueInterest(accrualTimestamp);
-      const borrowAssets = marketForRepay.toBorrowAssets(shares, "Up");
-      // Native funds part of the transfer; the ERC-20 pulled is the remainder.
-      if (nativeAmount > borrowAssets) {
-        throw new NativeAmountExceedsTransferAmountError({
-          nativeAmount,
-          transferAmount: borrowAssets,
-          market: this.marketParams.id,
-        });
-      }
-      erc20Amount = borrowAssets - nativeAmount;
+      // skims residual back to the receiver. Native funds part of the
+      // transfer; the ERC-20 pulled is the remainder.
+      const funding = computeSharesRepayFunding({
+        market: positionData.market,
+        shares,
+        nativeAmount,
+        now: params.now ?? Time.timestamp(),
+      });
+      marketForRepay = funding.accruedMarket;
+      erc20Amount = funding.erc20Amount;
     } else {
       // Assets mode is additive, like supply: repaid = amount + nativeAmount.
       const amount = params.amount ?? 0n;
@@ -1089,6 +1112,15 @@ export class MorphoBlue implements BlueActions {
       withdrawAmount: bigint;
       positionData: AccrualPosition;
       slippageTolerance?: bigint;
+      /**
+       * "Now" anchor (Unix seconds) for the funding accrual (shares mode) and
+       * the post-repay health check — see {@link computeSharesRepayFunding}.
+       * Defaults to the machine clock. Pass the anchor used to size an
+       * external native/ERC-20 funding split so the ERC-20 pull matches that
+       * split byte-for-byte instead of drifting with the clock between sizing
+       * and build.
+       */
+      now?: bigint;
     } & RepayAmountArgs,
   ) {
     validateChainId(this.client.viemClient.chain?.id, this.chainId);
@@ -1134,11 +1166,13 @@ export class MorphoBlue implements BlueActions {
     let erc20Amount: bigint;
     let marketForRepay: Market;
 
+    const now = params.now ?? Time.timestamp();
     // 2h forward accrual upper-bounds the on-chain repay price (shares
     // mode) and the post-repay health check; bundle skims residual back.
-    const accrualTimestamp =
-      MathLib.max(Time.timestamp(), positionData.market.lastUpdate) +
-      Time.s.from.h(2n);
+    const accrualTimestamp = computeRepayAccrualTimestamp({
+      now,
+      lastUpdate: positionData.market.lastUpdate,
+    });
 
     if ("shares" in params) {
       const shares = params.shares;
@@ -1152,17 +1186,15 @@ export class MorphoBlue implements BlueActions {
       });
       repayAssets = 0n;
       repayShares = shares;
-      marketForRepay = positionData.market.accrueInterest(accrualTimestamp);
-      const borrowAssets = marketForRepay.toBorrowAssets(shares, "Up");
       // Native funds part of the transfer; the ERC-20 pulled is the remainder.
-      if (nativeAmount > borrowAssets) {
-        throw new NativeAmountExceedsTransferAmountError({
-          nativeAmount,
-          transferAmount: borrowAssets,
-          market: this.marketParams.id,
-        });
-      }
-      erc20Amount = borrowAssets - nativeAmount;
+      const funding = computeSharesRepayFunding({
+        market: positionData.market,
+        shares,
+        nativeAmount,
+        now,
+      });
+      marketForRepay = funding.accruedMarket;
+      erc20Amount = funding.erc20Amount;
     } else {
       // Assets mode is additive, like supply: repaid = amount + nativeAmount.
       const amount = params.amount ?? 0n;

--- a/packages/morpho-sdk/src/helpers/index.ts
+++ b/packages/morpho-sdk/src/helpers/index.ts
@@ -10,6 +10,11 @@ export {
 } from "./constant.js";
 export { addTransactionMetadata } from "./metadata.js";
 export {
+  computeRepayAccrualTimestamp,
+  computeSharesRepayFunding,
+  REPAY_ACCRUAL_BUFFER,
+} from "./repayFunding.js";
+export {
   computeMaxRepaySharePrice,
   computeMaxSupplySharePrice,
   computeMinBorrowSharePrice,

--- a/packages/morpho-sdk/src/helpers/repayFunding.test.ts
+++ b/packages/morpho-sdk/src/helpers/repayFunding.test.ts
@@ -1,0 +1,129 @@
+import { Market, MarketParams } from "@morpho-org/blue-sdk";
+import { describe, expect, test } from "vitest";
+import { WethUsdsBlue } from "../../test/fixtures/blue.js";
+import { NativeAmountExceedsTransferAmountError } from "../types/index.js";
+import {
+  computeRepayAccrualTimestamp,
+  computeSharesRepayFunding,
+  REPAY_ACCRUAL_BUFFER,
+} from "./repayFunding.js";
+
+const LAST_UPDATE = 1_700_000_000n;
+
+/** Accruing market (rateAtTarget set): forward accrual actually grows the debt. */
+const ratedMarket = new Market({
+  params: new MarketParams(WethUsdsBlue),
+  totalSupplyAssets: 10n ** 24n,
+  totalBorrowAssets: 10n ** 24n / 2n,
+  totalSupplyShares: 10n ** 24n,
+  totalBorrowShares: 10n ** 24n / 2n,
+  lastUpdate: LAST_UPDATE,
+  fee: 0n,
+  price: 10n ** 36n,
+  rateAtTarget: 10n ** 9n, // ~3% APR per-second WAD rate
+});
+
+const SHARES = 10n ** 18n;
+
+describe("computeRepayAccrualTimestamp", () => {
+  test("default", () => {
+    const now = LAST_UPDATE + 100n;
+    expect(computeRepayAccrualTimestamp({ now, lastUpdate: LAST_UPDATE })).toBe(
+      now + REPAY_ACCRUAL_BUFFER,
+    );
+  });
+
+  test("behavior: clamps a stale clock to the market's lastUpdate", () => {
+    expect(
+      computeRepayAccrualTimestamp({
+        now: LAST_UPDATE - 100n,
+        lastUpdate: LAST_UPDATE,
+      }),
+    ).toBe(LAST_UPDATE + REPAY_ACCRUAL_BUFFER);
+  });
+});
+
+describe("computeSharesRepayFunding", () => {
+  test("default", () => {
+    const now = LAST_UPDATE + 100n;
+    const { accrualTimestamp, accruedMarket, transferAmount, erc20Amount } =
+      computeSharesRepayFunding({ market: ratedMarket, shares: SHARES, now });
+
+    expect(accrualTimestamp).toBe(now + REPAY_ACCRUAL_BUFFER);
+    expect(transferAmount).toBe(accruedMarket.toBorrowAssets(SHARES, "Up"));
+    // The buffered transfer exceeds the unaccrued debt (interest headroom).
+    expect(transferAmount).toBeGreaterThan(
+      ratedMarket.toBorrowAssets(SHARES, "Up"),
+    );
+    // nativeAmount defaults to 0n: the whole transfer is pulled as ERC-20.
+    expect(erc20Amount).toBe(transferAmount);
+  });
+
+  test("behavior: deterministic for a fixed `now`, grows as `now` advances", () => {
+    const now = LAST_UPDATE + 100n;
+    const first = computeSharesRepayFunding({
+      market: ratedMarket,
+      shares: SHARES,
+      now,
+    });
+    const second = computeSharesRepayFunding({
+      market: ratedMarket,
+      shares: SHARES,
+      now,
+    });
+    expect(second.transferAmount).toBe(first.transferAmount);
+    expect(second.erc20Amount).toBe(first.erc20Amount);
+
+    const later = computeSharesRepayFunding({
+      market: ratedMarket,
+      shares: SHARES,
+      now: now + 3_600n,
+    });
+    expect(later.transferAmount).toBeGreaterThan(first.transferAmount);
+  });
+
+  test("behavior: nativeAmount is carved out of the ERC-20 pull", () => {
+    const now = LAST_UPDATE + 100n;
+    const nativeAmount = 10n ** 15n;
+    const { transferAmount, erc20Amount } = computeSharesRepayFunding({
+      market: ratedMarket,
+      shares: SHARES,
+      nativeAmount,
+      now,
+    });
+    expect(erc20Amount).toBe(transferAmount - nativeAmount);
+  });
+
+  test("behavior: a fully native funding pulls no ERC-20", () => {
+    const now = LAST_UPDATE + 100n;
+    const { transferAmount } = computeSharesRepayFunding({
+      market: ratedMarket,
+      shares: SHARES,
+      now,
+    });
+    const { erc20Amount } = computeSharesRepayFunding({
+      market: ratedMarket,
+      shares: SHARES,
+      nativeAmount: transferAmount,
+      now,
+    });
+    expect(erc20Amount).toBe(0n);
+  });
+
+  test("error: NativeAmountExceedsTransferAmountError", () => {
+    const now = LAST_UPDATE + 100n;
+    const { transferAmount } = computeSharesRepayFunding({
+      market: ratedMarket,
+      shares: SHARES,
+      now,
+    });
+    expect(() =>
+      computeSharesRepayFunding({
+        market: ratedMarket,
+        shares: SHARES,
+        nativeAmount: transferAmount + 1n,
+        now,
+      }),
+    ).toThrow(NativeAmountExceedsTransferAmountError);
+  });
+});

--- a/packages/morpho-sdk/src/helpers/repayFunding.ts
+++ b/packages/morpho-sdk/src/helpers/repayFunding.ts
@@ -1,0 +1,116 @@
+import { type Market, MathLib } from "@morpho-org/blue-sdk";
+import { Time } from "@morpho-org/morpho-ts";
+import { NativeAmountExceedsTransferAmountError } from "../types/index.js";
+
+/**
+ * Forward-accrual buffer (in seconds) applied to shares-mode repay funding: the
+ * loan tokens routed into the adapter are sized on the debt accrued this far
+ * past "now", so the repay stays funded while the transaction waits to execute.
+ * The unconsumed remainder is skimmed back to the receiver by the bundle.
+ */
+export const REPAY_ACCRUAL_BUFFER = Time.s.from.h(2n);
+
+/**
+ * Computes the timestamp a shares-mode repay forward-accrues the market to when
+ * sizing its funding: the "now" anchor (clamped to the market's `lastUpdate`,
+ * which may postdate a stale clock) plus {@link REPAY_ACCRUAL_BUFFER}.
+ *
+ * Pure — callers supply `now` so the result is reproducible byte-for-byte.
+ *
+ * @param params - Computation parameters.
+ * @param params.now - The "now" anchor as a Unix timestamp in seconds.
+ * @param params.lastUpdate - The market's `lastUpdate` timestamp.
+ * @returns The buffered accrual timestamp.
+ *
+ * @example
+ * ```ts
+ * import { computeRepayAccrualTimestamp } from "@morpho-org/morpho-sdk";
+ * import { Time } from "@morpho-org/morpho-ts";
+ *
+ * const accrualTimestamp = computeRepayAccrualTimestamp({
+ *   now: Time.timestamp(),
+ *   lastUpdate: market.lastUpdate,
+ * });
+ * // = max(now, lastUpdate) + 2h
+ * ```
+ */
+export function computeRepayAccrualTimestamp(params: {
+  now: bigint;
+  lastUpdate: bigint;
+}): bigint {
+  return MathLib.max(params.now, params.lastUpdate) + REPAY_ACCRUAL_BUFFER;
+}
+
+/**
+ * Computes the funding envelope of a shares-mode (exact-share / full-close)
+ * repay: the market forward-accrued to {@link computeRepayAccrualTimestamp},
+ * the total loan tokens routed into the adapter (`transferAmount`, the accrued
+ * debt of `shares` rounded up), and the ERC-20 portion pulled from the payer
+ * (`erc20Amount = transferAmount - nativeAmount`).
+ *
+ * Single source of truth for the funding math of `MorphoBlue.repay` /
+ * `MorphoBlue.repayWithdrawCollateral` (shares mode). Pure and deterministic —
+ * callers supply `now`, so an integrator sizing a native/ERC-20 split ahead of
+ * the entity call can pass the same anchor to the entity (its `now` param) and
+ * get the exact `erc20Amount` it planned for, instead of a value that drifts
+ * with the clock between sizing and build and over-pulls the payer's balance.
+ *
+ * @param params - Computation parameters.
+ * @param params.market - The market snapshot to forward-accrue.
+ * @param params.shares - The exact borrow shares the repay burns.
+ * @param params.nativeAmount - Native ETH wrapped toward the transfer (default `0n`).
+ * @param params.now - The "now" anchor as a Unix timestamp in seconds.
+ * @returns `{ accrualTimestamp, accruedMarket, transferAmount, erc20Amount }`.
+ * @throws {NativeAmountExceedsTransferAmountError} when `nativeAmount` exceeds
+ *   the computed `transferAmount`.
+ *
+ * @example
+ * ```ts
+ * import { computeSharesRepayFunding } from "@morpho-org/morpho-sdk";
+ * import { Time } from "@morpho-org/morpho-ts";
+ *
+ * const now = Time.timestamp();
+ * const { transferAmount } = computeSharesRepayFunding({
+ *   market: positionData.market,
+ *   shares: positionData.borrowShares,
+ *   now,
+ * });
+ * // Split transferAmount across ERC-20 balance + native, then build with the
+ * // same anchor: market.repay({ shares, nativeAmount, positionData, now }).
+ * ```
+ */
+export function computeSharesRepayFunding(params: {
+  market: Market;
+  shares: bigint;
+  nativeAmount?: bigint;
+  now: bigint;
+}): {
+  accrualTimestamp: bigint;
+  accruedMarket: Market;
+  transferAmount: bigint;
+  erc20Amount: bigint;
+} {
+  const { market, shares, nativeAmount = 0n, now } = params;
+
+  const accrualTimestamp = computeRepayAccrualTimestamp({
+    now,
+    lastUpdate: market.lastUpdate,
+  });
+  const accruedMarket = market.accrueInterest(accrualTimestamp);
+  const transferAmount = accruedMarket.toBorrowAssets(shares, "Up");
+
+  if (nativeAmount > transferAmount) {
+    throw new NativeAmountExceedsTransferAmountError({
+      nativeAmount,
+      transferAmount,
+      market: market.params.id,
+    });
+  }
+
+  return {
+    accrualTimestamp,
+    accruedMarket,
+    transferAmount,
+    erc20Amount: transferAmount - nativeAmount,
+  };
+}


### PR DESCRIPTION
## Problem

`MorphoBlue.repay` / `repayWithdrawCollateral` (shares mode) size the loan-token funding by forward-accruing the market to `max(Time.timestamp(), lastUpdate) + 2h` **at entity-call time**. An integrator that sizes a native/ERC-20 funding split moments earlier (same formula, its own clock read) can land in an earlier second than the entity call: the entity then computes a buffered transfer a few wei of interest larger, and since the ERC-20 pull is `transfer − nativeAmount`, the whole drift lands on the ERC-20 leg. A split that drained the wallet's ERC-20 balance to the last wei (ERC20-first split, native covering the tail — or a fully-native repay with a zero ERC-20 balance) then over-pulls → `transferFrom` exceeds the balance → the bundle reverts at simulation/execution. On an 18-decimals wNative debt, one second of interest is always ≥ 1 wei, so any second-boundary straddle reproduces it.

Found while auditing the vvrm-app market-actions integration (morpho-org/morpho-apps#3204), where `useMarketRepayNativeWrap` sizes exactly such a split before calling `market.repay({ shares, nativeAmount, … })`.

## Fix

Make the funding math deterministic and reusable instead of clock-coupled:

- **New pure helper `computeSharesRepayFunding({ market, shares, nativeAmount?, now })`** → `{ accrualTimestamp, accruedMarket, transferAmount, erc20Amount }`, plus `computeRepayAccrualTimestamp` and the `REPAY_ACCRUAL_BUFFER` constant (all exported). Single source of truth for the shares-mode funding envelope — it also carries the existing `NativeAmountExceedsTransferAmountError` guard, deduplicating the previously copy-pasted block in the two entity methods.
- **Optional `now` anchor (Unix seconds) on `repay` and `repayWithdrawCollateral`**, defaulting to the machine clock (same pattern as `encodeBlueSignatureAuthorization`'s `deadline`). Integrators size their split with the helper and pass the same `now` to the entity: the ERC-20 pull reproduces the split byte-for-byte. In `repayWithdrawCollateral` the anchor also pins the post-repay health-check accrual, as before.

No behavior change for callers that don't pass `now`.

## Tests

- `helpers/repayFunding.test.ts` (new, colocated, pure): buffer/clamp math, native carve-out, fully-native funding, determinism for a fixed `now` (and growth as `now` advances, on a `rateAtTarget` market), `NativeAmountExceedsTransferAmountError`.
- `entities/blue/blue.test.ts`: two integration tests (repay + repayWithdrawCollateral) proving a pre-sized split is reproduced exactly on an accruing market — `transferAmount` and the approval requirement match the helper's outputs; existing native/shares tests untouched and green.
- Validation: `tsc --noEmit` ✓, `pnpm lint` (biome + jsdoc coverage + address lint) ✓, both test files 29/30 — the one failure ("repayWithdrawCollateral getRequirements includes Blue authorization when missing") is environmental (public RPC refuses archive reads at the pinned fork block) and fails identically on clean `main`.

## Changeset

`minor` — additive public surface (`now` params + 3 exported symbols).

## Follow-up (separate repo)

Once released, vvrm-app's `useMarketRepayNativeWrap` / `useMarketActionBuilder` should size the MAX-repay split via `computeSharesRepayFunding` and thread the same `now` into `market.repay` / `repayWithdrawCollateral`, replacing its hand-rolled copy of the accrual formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)