### PR TITLE
feat(morpho-sdk): allow borrow/withdraw up to lltv

### DIFF
--- a/.changeset/borrow-withdraw-up-to-lltv.md
+++ b/.changeset/borrow-withdraw-up-to-lltv.md
@@ -1,0 +1,9 @@
+---
+"@morpho-org/morpho-sdk": minor
+---
+
+Allow borrowing and withdrawing collateral up to (just under) the market LLTV.
+
+`validatePositionHealth` and `validatePositionHealthAfterWithdraw` previously rejected any resulting position above `LLTV − DEFAULT_LLTV_BUFFER` (0.5%). They now only reject positions that would reach or exceed the true LLTV (i.e. become immediately liquidatable), keeping the `+ 1n` share-to-asset rounding guard so a position is never built at or above LLTV.
+
+The 0.5% buffer is no longer enforced by the transaction builders. It remains exported as `DEFAULT_LLTV_BUFFER` as a recommended UI default (e.g. a "max borrow" button), so integrators can let users opt into borrowing closer to LLTV behind an explicit risk acknowledgment. The `BorrowExceedsSafeLtvError` message was updated to match.

--- a/packages/morpho-sdk/src/helpers/constant.ts
+++ b/packages/morpho-sdk/src/helpers/constant.ts
@@ -4,7 +4,14 @@ import { type Address, maxUint96 } from "viem";
 /** Maximum slippage tolerance: 10% */
 export const MAX_SLIPPAGE_TOLERANCE = MathLib.WAD / 10n;
 
-/** Default LLTV buffer: 0.5% below LLTV. Prevents instant liquidation on new positions. */
+/**
+ * Recommended UI buffer: 0.5% below LLTV. A safe default for a "max borrow"
+ * button so fresh positions don't sit at the liquidation edge. This is NOT
+ * enforced by the transaction builders — `validatePositionHealth` /
+ * `validatePositionHealthAfterWithdraw` only reject positions at or above the
+ * true LLTV — so integrators may let users borrow past this buffer (up to just
+ * under LLTV) behind an explicit risk acknowledgment.
+ */
 export const DEFAULT_LLTV_BUFFER = MathLib.WAD / 200n;
 
 /** Maximum absolute share price cap (100 RAY). Prevents absurd maxSharePrice values in repay. */

--- a/packages/morpho-sdk/src/helpers/validate.test.ts
+++ b/packages/morpho-sdk/src/helpers/validate.test.ts
@@ -244,15 +244,16 @@ describe("validatePositionHealth", () => {
       borrowShares: 0n,
       market: makeMarket({ price: ORACLE_PRICE_SCALE }),
     });
-    // 1:1 price ⇒ collateral value == collateral, so the on-chain liquidation
-    // boundary is wMulDown(collateral, lltv). Borrowing 2 wei below it lands well
-    // inside the old 0.5% buffer band (which used to throw); it must now pass.
+    // 1:1 price ⇒ collateral value == collateral, so maxBorrow = wMulDown(collateral, lltv)
+    // is the on-chain liquidation boundary. maxBorrow - 1 is the largest passing amount: it
+    // sits inside the old 0.5% buffer band (which used to throw), and with the +1 rounding guard
+    // the resulting debt lands at exactly maxBorrow - healthy (inclusive).
     const maxBorrow = MathLib.wMulDown(collateral, lltv);
     expect(() =>
       validatePositionHealth({
         positionData: pos,
         additionalCollateral: 0n,
-        borrowAmount: maxBorrow - 2n,
+        borrowAmount: maxBorrow - 1n,
         marketId: marketParams.id,
         lltv,
       }),
@@ -266,8 +267,8 @@ describe("validatePositionHealth", () => {
       borrowShares: 0n,
       market: makeMarket({ price: ORACLE_PRICE_SCALE }),
     });
-    // Borrowing exactly the boundary trips the +1n rounding guard, so a position
-    // can never be built at or above LLTV.
+    // Requesting the full boundary trips the +1n guard: the rounded on-chain debt could
+    // exceed maxBorrow (liquidatable), so it is rejected - never built above the LLTV.
     const maxBorrow = MathLib.wMulDown(collateral, lltv);
     expect(() =>
       validatePositionHealth({
@@ -487,6 +488,37 @@ describe("validatePositionHealthAfterWithdraw", () => {
         marketId: marketParams.id,
       }),
     ).not.toThrow();
+  });
+
+  test("is inclusive at the LLTV boundary (exactly at LLTV passes, one wei above throws)", () => {
+    // 1:1 price + 50% LLTV ⇒ maxBorrow = collateralAfter / 2. Size collateralAfter so the
+    // unchanged debt lands exactly on the boundary: exactly at LLTV is healthy (inclusive),
+    // mirroring the borrow path.
+    const halfLltv = MathLib.WAD / 2n;
+    const collateral = 10n ** 18n;
+    const market = makeMarket({ price: ORACLE_PRICE_SCALE });
+    const pos = makePosition({ collateral, borrowShares: 10n ** 17n, market });
+    const debt = pos.borrowAssets;
+
+    // collateralAfter = 2·debt ⇒ maxBorrow == debt ⇒ position exactly at LLTV → allowed.
+    expect(() =>
+      validatePositionHealthAfterWithdraw({
+        positionData: pos,
+        withdrawAmount: collateral - 2n * debt,
+        lltv: halfLltv,
+        marketId: marketParams.id,
+      }),
+    ).not.toThrow();
+
+    // One wei less collateral ⇒ maxBorrow == debt − 1 ⇒ debt exceeds it → throws.
+    expect(() =>
+      validatePositionHealthAfterWithdraw({
+        positionData: pos,
+        withdrawAmount: collateral - (2n * debt - 1n),
+        lltv: halfLltv,
+        marketId: marketParams.id,
+      }),
+    ).toThrow(WithdrawMakesPositionUnhealthyError);
   });
 });
 

--- a/packages/morpho-sdk/src/helpers/validate.test.ts
+++ b/packages/morpho-sdk/src/helpers/validate.test.ts
@@ -170,8 +170,7 @@ describe("validatePositionHealth", () => {
       borrowShares: 0n,
       market: makeMarket({ price: ORACLE_PRICE_SCALE }),
     });
-    // With 1:1 price and 86% LLTV (- 0.5% buffer ≈ 85.5%),
-    // borrowing 80% of collateral should be safe.
+    // With 1:1 price and 86% LLTV, borrowing ~8% of collateral is well within range.
     const borrowAmount = (8n * 10n ** 17n) / 10n; // 0.08 in 18-dec ≈ 8%
     expect(() =>
       validatePositionHealth({
@@ -205,7 +204,7 @@ describe("validatePositionHealth", () => {
       borrowShares: 0n,
       market: makeMarket({ price: ORACLE_PRICE_SCALE }),
     });
-    // With 1:1 price, borrowing 90% of collateral exceeds the 85.5% effective LLTV.
+    // With 1:1 price, borrowing 90% of collateral exceeds the 86% LLTV.
     const borrowAmount = (9n * 10n ** 18n) / 10n;
     expect(() =>
       validatePositionHealth({
@@ -238,20 +237,45 @@ describe("validatePositionHealth", () => {
     ).not.toThrow();
   });
 
-  test("should use zero effective LLTV when LLTV is below the buffer", () => {
+  test("should allow borrowing up to just under LLTV (no 0.5% safety buffer)", () => {
+    const collateral = 10n ** 18n;
     const pos = makePosition({
-      collateral: 10n ** 18n,
+      collateral,
       borrowShares: 0n,
       market: makeMarket({ price: ORACLE_PRICE_SCALE }),
     });
-
+    // 1:1 price ⇒ collateral value == collateral, so the on-chain liquidation
+    // boundary is wMulDown(collateral, lltv). Borrowing 2 wei below it lands well
+    // inside the old 0.5% buffer band (which used to throw); it must now pass.
+    const maxBorrow = MathLib.wMulDown(collateral, lltv);
     expect(() =>
       validatePositionHealth({
         positionData: pos,
         additionalCollateral: 0n,
-        borrowAmount: 1n,
+        borrowAmount: maxBorrow - 2n,
         marketId: marketParams.id,
-        lltv: 1n,
+        lltv,
+      }),
+    ).not.toThrow();
+  });
+
+  test("should still throw when the borrow would reach LLTV (strict +1n guard)", () => {
+    const collateral = 10n ** 18n;
+    const pos = makePosition({
+      collateral,
+      borrowShares: 0n,
+      market: makeMarket({ price: ORACLE_PRICE_SCALE }),
+    });
+    // Borrowing exactly the boundary trips the +1n rounding guard, so a position
+    // can never be built at or above LLTV.
+    const maxBorrow = MathLib.wMulDown(collateral, lltv);
+    expect(() =>
+      validatePositionHealth({
+        positionData: pos,
+        additionalCollateral: 0n,
+        borrowAmount: maxBorrow,
+        marketId: marketParams.id,
+        lltv,
       }),
     ).toThrow(BorrowExceedsSafeLtvError);
   });
@@ -445,22 +469,24 @@ describe("validatePositionHealthAfterWithdraw", () => {
     ).toThrow(WithdrawExceedsCollateralError);
   });
 
-  test("should use zero effective LLTV when LLTV is below the buffer", () => {
+  test("should allow a withdrawal that leaves the position just under LLTV (no buffer)", () => {
+    const collateral = 10n ** 18n;
     const market = makeMarket({ price: ORACLE_PRICE_SCALE });
-    const pos = makePosition({
-      collateral: 10n ** 18n,
-      borrowShares: 1n,
-      market,
-    });
-
+    const pos = makePosition({ collateral, borrowShares: 10n ** 17n, market });
+    const debt = pos.borrowAssets;
+    // Keep just enough collateral to stay strictly healthy at the true LLTV
+    // (1 wei above the exact boundary). This sits inside the old 0.5% buffer band,
+    // which used to throw, and must now pass.
+    const minCollateralAfter = MathLib.wDivUp(debt, lltv) + 1n;
+    const withdrawAmount = collateral - minCollateralAfter;
     expect(() =>
       validatePositionHealthAfterWithdraw({
         positionData: pos,
-        withdrawAmount: 0n,
-        lltv: 1n,
+        withdrawAmount,
+        lltv,
         marketId: marketParams.id,
       }),
-    ).toThrow(WithdrawMakesPositionUnhealthyError);
+    ).not.toThrow();
   });
 });
 

--- a/packages/morpho-sdk/src/helpers/validate.ts
+++ b/packages/morpho-sdk/src/helpers/validate.ts
@@ -126,8 +126,10 @@ export const validateAccrualPosition = (params: {
 };
 
 /**
- * Validates that the resulting position stays strictly below the liquidation
- * threshold (LLTV) after supplying additional collateral and borrowing.
+ * Validates a supply-collateral + borrow, rejecting it only if the resulting debt
+ * would exceed the LLTV (become liquidatable). Morpho's health check is inclusive,
+ * so a position landing exactly at the LLTV is allowed. The 0.5% DEFAULT_LLTV_BUFFER
+ * is a UI default, not enforced here.
  *
  * @param params - Validation parameters.
  * @param params.positionData - The current accrual position with market data.
@@ -158,13 +160,13 @@ export const validatePositionHealth = (params: {
     ORACLE_PRICE_SCALE,
   );
 
-  // Reject only borrows that would leave the position at or above the true LLTV
-  // (immediately liquidatable). No 0.5% safety buffer is subtracted here anymore
-  // — that lives as a UI default (DEFAULT_LLTV_BUFFER); callers may let users
-  // borrow up to just under LLTV behind an explicit acknowledgment.
+  // On-chain liquidation boundary (collateralValue × LLTV). No 0.5% buffer here:
+  // DEFAULT_LLTV_BUFFER is a UI default, not enforced.
   const maxSafeBorrowAfter = MathLib.wMulDown(collateralValueAfter, lltv);
 
-  const totalBorrowAfter = positionData.borrowAssets + borrowAmount + 1n; // +1 to account for share-to-asset rounding (happens when the borrow amount doesn't divide evenly into shares)
+  // +1: converting borrowAmount to shares rounds the resulting debt up by at most
+  // 1 wei, so reserving it keeps the built debt within maxBorrow (never liquidatable).
+  const totalBorrowAfter = positionData.borrowAssets + borrowAmount + 1n;
 
   if (totalBorrowAfter > maxSafeBorrowAfter) {
     const maxSafeAdditionalBorrow = MathLib.zeroFloorSub(
@@ -212,8 +214,9 @@ export const validateNativeAsset = (chainId: number, asset: Address): void => {
 };
 
 /**
- * Validates that the resulting position stays strictly below the liquidation
- * threshold (LLTV) after withdrawing collateral.
+ * Validates a collateral withdrawal, rejecting it only if the remaining debt would
+ * exceed the LLTV for the reduced collateral (become liquidatable). Mirrors
+ * {@link validatePositionHealth}; the 0.5% buffer is a UI default, not enforced.
  *
  * @param params - Validation parameters.
  * @param params.positionData - The current accrual position with market data.
@@ -258,8 +261,8 @@ export const validatePositionHealthAfterWithdraw = (params: {
     ORACLE_PRICE_SCALE,
   );
 
-  // Only reject when the remaining debt would sit at or above the true LLTV. The
-  // 0.5% buffer is a UI default only (DEFAULT_LLTV_BUFFER), not enforced here.
+  // Same on-chain liquidation boundary as validatePositionHealth. No +1 guard here:
+  // borrowAssets is the existing (already exact) debt, not a freshly-minted amount.
   const maxSafeBorrowAfter = MathLib.wMulDown(collateralValueAfter, lltv);
 
   if (positionData.borrowAssets > maxSafeBorrowAfter) {

--- a/packages/morpho-sdk/src/helpers/validate.ts
+++ b/packages/morpho-sdk/src/helpers/validate.ts
@@ -32,7 +32,7 @@ import {
   WithdrawMakesPositionUnhealthyError,
   WithdrawSharesExceedSupplyError,
 } from "../types/index.js";
-import { DEFAULT_LLTV_BUFFER, MAX_SLIPPAGE_TOLERANCE } from "./constant.js";
+import { MAX_SLIPPAGE_TOLERANCE } from "./constant.js";
 
 /** @internal */
 export const compareMarketIds = (idA: MarketId, idB: MarketId) => {
@@ -126,8 +126,8 @@ export const validateAccrualPosition = (params: {
 };
 
 /**
- * Validates that the resulting position stays within the safe LTV threshold
- * (LLTV minus buffer) after supplying additional collateral and borrowing.
+ * Validates that the resulting position stays strictly below the liquidation
+ * threshold (LLTV) after supplying additional collateral and borrowing.
  *
  * @param params - Validation parameters.
  * @param params.positionData - The current accrual position with market data.
@@ -158,13 +158,11 @@ export const validatePositionHealth = (params: {
     ORACLE_PRICE_SCALE,
   );
 
-  const effectiveLltv =
-    lltv > DEFAULT_LLTV_BUFFER ? lltv - DEFAULT_LLTV_BUFFER : 0n;
-
-  const maxSafeBorrowAfter = MathLib.wMulDown(
-    collateralValueAfter,
-    effectiveLltv,
-  );
+  // Reject only borrows that would leave the position at or above the true LLTV
+  // (immediately liquidatable). No 0.5% safety buffer is subtracted here anymore
+  // — that lives as a UI default (DEFAULT_LLTV_BUFFER); callers may let users
+  // borrow up to just under LLTV behind an explicit acknowledgment.
+  const maxSafeBorrowAfter = MathLib.wMulDown(collateralValueAfter, lltv);
 
   const totalBorrowAfter = positionData.borrowAssets + borrowAmount + 1n; // +1 to account for share-to-asset rounding (happens when the borrow amount doesn't divide evenly into shares)
 
@@ -214,8 +212,8 @@ export const validateNativeAsset = (chainId: number, asset: Address): void => {
 };
 
 /**
- * Validates that the resulting position stays within the safe LTV threshold
- * (LLTV minus buffer) after withdrawing collateral.
+ * Validates that the resulting position stays strictly below the liquidation
+ * threshold (LLTV) after withdrawing collateral.
  *
  * @param params - Validation parameters.
  * @param params.positionData - The current accrual position with market data.
@@ -260,12 +258,9 @@ export const validatePositionHealthAfterWithdraw = (params: {
     ORACLE_PRICE_SCALE,
   );
 
-  const effectiveLltv =
-    lltv > DEFAULT_LLTV_BUFFER ? lltv - DEFAULT_LLTV_BUFFER : 0n;
-  const maxSafeBorrowAfter = MathLib.wMulDown(
-    collateralValueAfter,
-    effectiveLltv,
-  );
+  // Only reject when the remaining debt would sit at or above the true LLTV. The
+  // 0.5% buffer is a UI default only (DEFAULT_LLTV_BUFFER), not enforced here.
+  const maxSafeBorrowAfter = MathLib.wMulDown(collateralValueAfter, lltv);
 
   if (positionData.borrowAssets > maxSafeBorrowAfter) {
     throw new WithdrawMakesPositionUnhealthyError({

--- a/packages/morpho-sdk/src/types/error.ts
+++ b/packages/morpho-sdk/src/types/error.ts
@@ -491,7 +491,7 @@ export type NativeAmountOnNonWNativeCollateralError =
 export class BorrowExceedsSafeLtvError extends Error {
   constructor(borrowAmount: bigint, maxSafeBorrow: bigint) {
     super(
-      `Borrow amount ${borrowAmount} exceeds maximum ${maxSafeBorrow} (would reach or exceed the liquidation LTV). Reduce borrow or increase collateral.`,
+      `Borrow amount ${borrowAmount} exceeds maximum ${maxSafeBorrow} (would exceed the liquidation LTV). Reduce borrow or increase collateral.`,
     );
   }
 }

--- a/packages/morpho-sdk/src/types/error.ts
+++ b/packages/morpho-sdk/src/types/error.ts
@@ -491,7 +491,7 @@ export type NativeAmountOnNonWNativeCollateralError =
 export class BorrowExceedsSafeLtvError extends Error {
   constructor(borrowAmount: bigint, maxSafeBorrow: bigint) {
     super(
-      `Borrow amount ${borrowAmount} exceeds safe maximum ${maxSafeBorrow} (LLTV minus buffer). Reduce borrow or increase collateral.`,
+      `Borrow amount ${borrowAmount} exceeds maximum ${maxSafeBorrow} (would reach or exceed the liquidation LTV). Reduce borrow or increase collateral.`,
     );
   }
 }


### PR DESCRIPTION
## Context

Users can no longer increase a borrow while their LTV is still below the LLTV. The builder rejects any resulting position above `LLTV − DEFAULT_LLTV_BUFFER` (0.5%), which removed the ability — present in the app before — to borrow closer to LLTV behind a risk acknowledgment. The product decision is to make the 0.5% offset a UI default, not a hard build-time floor.

## Change

`validatePositionHealth` (borrow) and `validatePositionHealthAfterWithdraw` (withdraw) now validate against the **true LLTV** instead of `LLTV − DEFAULT_LLTV_BUFFER`:

- Only positions that would reach or exceed the LLTV (i.e. immediately liquidatable) are rejected.
- The `+ 1n` share↔asset rounding guard and the strict `>` comparison are kept, so a position is **never** built at or above LLTV.
- `DEFAULT_LLTV_BUFFER` stays exported as a recommended **UI default** (e.g. a "max borrow" button); integrators can let users borrow closer to LLTV behind an explicit acknowledgment.
- `BorrowExceedsSafeLtvError`'s message updated to match.

## Safety

Reviewed against Morpho Blue `_isHealthy`:

- Healthy is inclusive (`maxBorrow >= borrowed`), liquidatable is strict (`borrowed > maxBorrow`). The SDK's `maxSafeBorrowAfter = wMulDown(collateralValue, lltv)` is now bit-identical to the contract's `maxBorrow` (same roundings, scale, lltv).
- With `+ 1n` + strict `>`, the builder rejects iff `borrowed ≥ maxBorrow`, so a built position is always strictly `< maxBorrow` → never liquidatable at build time.
- The contract re-accrues interest and re-checks health atomically at execution, so the SDK can never cause an unhealthy on-chain borrow. The removed buffer guarded **no** protocol invariant — it was purely a UX margin against interest/oracle drift, which now lives as the UI default.

## Tests

`validate.test.ts`: added tests that borrowing/withdrawing into the former buffer band (just under LLTV) now passes, plus a strict-boundary test that reaching LLTV still throws (the `+ 1n` guard). All 49 tests pass; verified the new "up to LLTV" test fails when the buffer is reintroduced.

## Companion

Paired with a vvrm change in `morpho-org/morpho-apps` that keeps the MAX button at the safe offset but allows manual entry up to the SDK ceiling behind the existing acknowledgment checkbox. Until this SDK release is published and pinned there, vvrm's interim ceiling is `LLTV − buffer`; it moves to `LLTV` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
