### PR TITLE
fix(morpho-sdk): forward-accrue assets-mode repay maxSharePrice

### DIFF
--- a/.changeset/repay-assets-forward-accrual.md
+++ b/.changeset/repay-assets-forward-accrual.md
@@ -1,0 +1,17 @@
+---
+"@morpho-org/morpho-sdk": patch
+---
+
+Fix assets-mode repay reverting on quiet markets. `MorphoBlue.repay` and
+`MorphoBlue.repayWithdrawCollateral` now derive `maxSharePrice` from the
+2h-forward-accrued market in **both** repay modes, not just shares mode.
+
+Previously the assets path computed the slippage bound from the un-accrued
+`positionData.market` snapshot (as of the market's on-chain `lastUpdate`),
+while on-chain `morphoRepay` accrues interest `lastUpdate → execution` before
+enforcing the bound. On a market that hasn't accrued recently, the accrued
+borrow share price rose past the default 0.03% `slippageTolerance` ceiling and
+the bundle reverted — e.g. at ~8% APR, 0.03% is only ~1.3 days of accrual, so a
+quiet market reverted systematically. Direct core `repay` (no bundler, no
+bound) was unaffected, which is why the fallback path succeeded while
+app.morpho.org did not.

--- a/packages/morpho-sdk/src/entities/blue/blue.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.test.ts
@@ -1,5 +1,6 @@
 import {
   AccrualPosition,
+  DEFAULT_SLIPPAGE_TOLERANCE,
   getChainAddresses,
   Market,
   MarketParams,
@@ -9,10 +10,11 @@ import { blueAbi } from "@morpho-org/blue-sdk-viem";
 import { createMockClient, mockRead } from "@morpho-org/test/mock";
 import { type Address, createPublicClient, http, parseUnits } from "viem";
 import { mainnet } from "viem/chains";
-import { describe, expect } from "vitest";
+import { afterEach, describe, expect, vi } from "vitest";
 import { CbbtcUsdcBlue, WstethWethBlue } from "../../../test/fixtures/blue.js";
 import { test } from "../../../test/setup.js";
 import { morphoViemExtension } from "../../client/index.js";
+import { computeMaxRepaySharePrice } from "../../helpers/index.js";
 import {
   isRequirementApproval,
   MutuallyExclusiveRepayAmountsError,
@@ -674,5 +676,128 @@ describe("MorphoBlue validation", () => {
         options: { enabled: false },
       }),
     ).toEqual([]);
+  });
+});
+
+// Regression for VAU-1206: an assets-mode repay on a quiet market reverted on
+// app.morpho.org because `maxSharePrice` was computed from the un-accrued
+// snapshot while on-chain `morphoRepay` accrues `lastUpdate → execution` first.
+// The bound must be derived from the forward-accrued market, mirroring the
+// shares-mode path.
+describe("MorphoBlue repay maxSharePrice forward-accrual (VAU-1206)", () => {
+  // Per-second rate at target (~10% APR) so `accrueInterest` is not a no-op and
+  // the borrow share price rises measurably between `lastUpdate` and execution.
+  const RATE_AT_TARGET = 3_170_979_198n;
+  const TWO_HOURS = 7_200n;
+  // Fixed wall clock so `Time.timestamp()` (= Date.now()) is deterministic.
+  const NOW_SEC = 1_800_000_000n;
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // A CbBTC/USDC position on a market that last accrued 5 days ago — far enough
+  // that accrued interest exceeds the 0.03% default slippage, i.e. the case that
+  // used to revert against `morphoRepay`'s `maxSharePrice` guard.
+  function makeStalePosition() {
+    const market = new Market({
+      params: MARKET_PARAMS,
+      totalSupplyAssets: 10n ** 24n,
+      totalBorrowAssets: 10n ** 24n / 2n,
+      totalSupplyShares: 10n ** 24n,
+      totalBorrowShares: 10n ** 24n / 2n,
+      lastUpdate: NOW_SEC - 5n * 24n * 3_600n,
+      fee: 0n,
+      price: ORACLE_PRICE_SCALE,
+      rateAtTarget: RATE_AT_TARGET,
+    });
+
+    return new AccrualPosition(
+      {
+        user: USER,
+        supplyShares: 0n,
+        borrowShares: 10n ** 18n,
+        collateral: 10n ** 24n,
+      },
+      market,
+    );
+  }
+
+  // Local public client: `buildTx` is fully synchronous and makes no RPC call,
+  // so this needs no anvil fork (keeps the regression hermetic).
+  const localClient = createPublicClient({ chain: mainnet, transport: http() });
+
+  test("repay assets mode derives maxSharePrice from the forward-accrued market", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Number(NOW_SEC) * 1_000);
+
+    const positionData = makeStalePosition();
+    const market = localClient
+      .extend(morphoViemExtension())
+      .morpho.blue(CbbtcUsdcBlue, mainnet.id);
+    const amount = parseUnits("1000", 6);
+
+    const tx = market
+      .repay({ amount, userAddress: USER, positionData })
+      .buildTx();
+
+    const accruedMarket = positionData.market.accrueInterest(
+      NOW_SEC + TWO_HOURS,
+    );
+    const expected = computeMaxRepaySharePrice({
+      repayAssets: amount,
+      repayShares: 0n,
+      market: accruedMarket,
+      slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
+    });
+    // The pre-fix bound, computed from the un-accrued snapshot — what reverted.
+    const stale = computeMaxRepaySharePrice({
+      repayAssets: amount,
+      repayShares: 0n,
+      market: positionData.market,
+      slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
+    });
+
+    expect(tx.action.args.maxSharePrice).toBe(expected);
+    expect(tx.action.args.maxSharePrice).toBeGreaterThan(stale);
+  });
+
+  test("repayWithdrawCollateral assets mode derives maxSharePrice from the forward-accrued market", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Number(NOW_SEC) * 1_000);
+
+    const positionData = makeStalePosition();
+    const market = localClient
+      .extend(morphoViemExtension())
+      .morpho.blue(CbbtcUsdcBlue, mainnet.id);
+    const amount = parseUnits("1000", 6);
+
+    const tx = market
+      .repayWithdrawCollateral({
+        amount,
+        withdrawAmount: 1n,
+        userAddress: USER,
+        positionData,
+      })
+      .buildTx();
+
+    const accruedMarket = positionData.market.accrueInterest(
+      NOW_SEC + TWO_HOURS,
+    );
+    const expected = computeMaxRepaySharePrice({
+      repayAssets: amount,
+      repayShares: 0n,
+      market: accruedMarket,
+      slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
+    });
+    const stale = computeMaxRepaySharePrice({
+      repayAssets: amount,
+      repayShares: 0n,
+      market: positionData.market,
+      slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
+    });
+
+    expect(tx.action.args.maxSharePrice).toBe(expected);
+    expect(tx.action.args.maxSharePrice).toBeGreaterThan(stale);
   });
 });

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -940,7 +940,17 @@ export class MorphoBlue implements BlueActions {
     let repayAssets: bigint;
     let repayShares: bigint;
     let erc20Amount: bigint;
-    let marketForRepay: Market;
+
+    // 2h forward accrual upper-bounds the on-chain repay price for BOTH modes:
+    // on-chain `morphoRepay` accrues `lastUpdate → execution` before enforcing
+    // `maxSharePrice`, so deriving the bound from the un-accrued market makes a
+    // quiet market (long since `lastUpdate`) revert once accrued interest
+    // exceeds `slippageTolerance`. Accrue before computing the bound; the bundle
+    // skims any residual back to the receiver.
+    const accrualTimestamp =
+      MathLib.max(Time.timestamp(), positionData.market.lastUpdate) +
+      Time.s.from.h(2n);
+    const marketForRepay = positionData.market.accrueInterest(accrualTimestamp);
 
     if ("shares" in params) {
       validateRepayShares({
@@ -950,12 +960,6 @@ export class MorphoBlue implements BlueActions {
       });
       repayAssets = 0n;
       repayShares = shares;
-      // 2h forward accrual upper-bounds the on-chain repay price; bundle
-      // skims residual back to the receiver.
-      const accrualTimestamp =
-        MathLib.max(Time.timestamp(), positionData.market.lastUpdate) +
-        Time.s.from.h(2n);
-      marketForRepay = positionData.market.accrueInterest(accrualTimestamp);
       const borrowAssets = marketForRepay.toBorrowAssets(shares, "Up");
       // Native funds the transfer first; the ERC-20 pulled is the remainder.
       // When native covers the full (2h-forward-accrued, rounded-up) borrow
@@ -973,7 +977,6 @@ export class MorphoBlue implements BlueActions {
       });
       repayShares = 0n;
       erc20Amount = amount;
-      marketForRepay = positionData.market;
     }
 
     const maxSharePrice = computeMaxRepaySharePrice({
@@ -1161,13 +1164,16 @@ export class MorphoBlue implements BlueActions {
     let repayAssets: bigint;
     let repayShares: bigint;
     let erc20Amount: bigint;
-    let marketForRepay: Market;
 
-    // 2h forward accrual upper-bounds the on-chain repay price (shares
-    // mode) and the post-repay health check; bundle skims residual back.
+    // 2h forward accrual upper-bounds the on-chain repay price for BOTH modes
+    // and the post-repay health check: on-chain `morphoRepay` accrues
+    // `lastUpdate → execution` before enforcing `maxSharePrice`, so deriving the
+    // bound from the un-accrued market makes a quiet market revert once accrued
+    // interest exceeds `slippageTolerance`. Bundle skims residual back.
     const accrualTimestamp =
       MathLib.max(Time.timestamp(), positionData.market.lastUpdate) +
       Time.s.from.h(2n);
+    const marketForRepay = positionData.market.accrueInterest(accrualTimestamp);
 
     if ("shares" in params) {
       validateRepayShares({
@@ -1177,7 +1183,6 @@ export class MorphoBlue implements BlueActions {
       });
       repayAssets = 0n;
       repayShares = shares;
-      marketForRepay = positionData.market.accrueInterest(accrualTimestamp);
       const borrowAssets = marketForRepay.toBorrowAssets(shares, "Up");
       // Native funds the transfer first; the ERC-20 pulled is the remainder.
       // When native covers the full (2h-forward-accrued, rounded-up) borrow
@@ -1195,7 +1200,6 @@ export class MorphoBlue implements BlueActions {
       });
       repayShares = 0n;
       erc20Amount = amount;
-      marketForRepay = positionData.market;
     }
 
     if (withdrawAmount > positionData.collateral) {

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -941,12 +941,7 @@ export class MorphoBlue implements BlueActions {
     let repayShares: bigint;
     let erc20Amount: bigint;
 
-    // 2h forward accrual upper-bounds the on-chain repay price for BOTH modes:
-    // on-chain `morphoRepay` accrues `lastUpdate → execution` before enforcing
-    // `maxSharePrice`, so deriving the bound from the un-accrued market makes a
-    // quiet market (long since `lastUpdate`) revert once accrued interest
-    // exceeds `slippageTolerance`. Accrue before computing the bound; the bundle
-    // skims any residual back to the receiver.
+    // Forward-accrue (2h) before deriving `maxSharePrice` (both modes): on-chain `morphoRepay` accrues `lastUpdate → execution`, so an un-accrued bound reverts on quiet markets.
     const accrualTimestamp =
       MathLib.max(Time.timestamp(), positionData.market.lastUpdate) +
       Time.s.from.h(2n);
@@ -1165,11 +1160,7 @@ export class MorphoBlue implements BlueActions {
     let repayShares: bigint;
     let erc20Amount: bigint;
 
-    // 2h forward accrual upper-bounds the on-chain repay price for BOTH modes
-    // and the post-repay health check: on-chain `morphoRepay` accrues
-    // `lastUpdate → execution` before enforcing `maxSharePrice`, so deriving the
-    // bound from the un-accrued market makes a quiet market revert once accrued
-    // interest exceeds `slippageTolerance`. Bundle skims residual back.
+    // Forward-accrue (2h) for `maxSharePrice` (both modes) and the post-repay health check: on-chain `morphoRepay` accrues `lastUpdate → execution`, so an un-accrued bound reverts on quiet markets.
     const accrualTimestamp =
       MathLib.max(Time.timestamp(), positionData.market.lastUpdate) +
       Time.s.from.h(2n);


### PR DESCRIPTION
## Summary

Fixes an assets-mode repay reverting on quiet markets (VAU-1206): a user could not repay on app.morpho.org (`execution reverted`) on the sUSDai/USDC Arbitrum market, while the fallback app succeeded.

**Root cause.** The bundler path (`Bundler3`/`GeneralAdapter1.morphoRepay`) enforces a `maxSharePrice` slippage bound; core `repay` (used by the fallback app) has none — hence "fallback OK, app KO". In `MorphoBlue.repay` / `repayWithdrawCollateral`, the **assets** path computed `maxSharePrice` from the un-accrued `positionData.market` snapshot (as of the on-chain `lastUpdate`), while the **shares** path already forward-accrued the market by 2h. On-chain, `morphoRepay` accrues interest `lastUpdate → execution` *before* enforcing the bound, so on a market not accrued recently the borrow share price rose past the default `0.03%` `slippageTolerance` ceiling and the bundle reverted. At ~8% APR, 0.03% is only ~1.3 days of accrual → a quiet market reverts systematically.

**Fix.** Forward-accrue the market for **both** repay modes before deriving `maxSharePrice`, mirroring the shares path. Scope is deliberately limited to the repay `max` bounds — the `min` bounds (borrow/withdraw) are unaffected because accrual moves the price *away* from their floor.

## Changes

- `entities/blue/blue.ts` — hoist the 2h forward-accrual out of the shares-only branch in `repay` and `repayWithdrawCollateral` so assets mode uses the accrued market too. `erc20Amount` / `transferAmount` and the post-repay health check are unchanged (the latter already used `accrualTimestamp`); only `maxSharePrice` widens.
- `entities/blue/blue.test.ts` — 2 hermetic regression tests (deterministic clock, market with non-zero `rateAtTarget` + stale `lastUpdate`) asserting the built `maxSharePrice` equals the forward-accrued bound and is strictly looser than the pre-fix (un-accrued) bound.
- changeset: `patch`.

## Test plan

- [x] `tsc --noEmit` (morpho-sdk): clean
- [x] `biome check` on changed files: clean
- [x] Regression tests pass; confirmed non-vacuous (reverting the fix fails them: stale `1000300…` ≠ accrued `1001102…`, ~0.08% > 0.03% ceiling)
- [ ] Full morpho-sdk fork suite not run locally — needs an archive RPC at the fork block (public endpoints 403 on archive). New tests are fork-independent.

## Follow-up

- After release, bump `@morpho-org/morpho-sdk` in `morpho-org/morpho-apps` `apps/vvrm-app` (currently pinned `5.2.0`) to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)