### PR TITLE
fix(morpho-sdk): forward-accrue supply maxSharePrice

### DIFF
--- a/.changeset/supply-forward-accrual.md
+++ b/.changeset/supply-forward-accrual.md
@@ -1,0 +1,18 @@
+---
+"@morpho-org/morpho-sdk": patch
+---
+
+Fix loan-asset supply reverting on quiet markets. `MorphoBlue.supply` now
+derives `maxSharePrice` from the 2h-forward-accrued market instead of the raw
+`marketData` snapshot.
+
+Previously the supply path computed the slippage bound from the un-accrued
+`marketData` snapshot (as of the market's on-chain `lastUpdate`), while on-chain
+`morphoSupply` accrues interest `lastUpdate → execution` before enforcing the
+bound. Accrual raises the supply share price, so on a market that hasn't accrued
+recently the accrued price rose past the default 0.03% `slippageTolerance`
+ceiling and the bundle reverted on `maxSharePrice` — e.g. at ~10% APR / 90%
+utilization, ~0.03% is only a few days of accrual, so a quiet market reverted
+systematically. This is the supply counterpart of the repay fix (VAU-1206); the
+`withdraw` / `borrow` paths use a lower `minSharePrice` bound that accrual only
+relaxes, so they were unaffected.

--- a/packages/morpho-sdk/src/entities/blue/blue.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.test.ts
@@ -807,10 +807,8 @@ describe("MorphoBlue repay maxSharePrice forward-accrual (VAU-1206)", () => {
   });
 });
 
-// Regression for the supply counterpart of VAU-1206: a loan-asset supply on a quiet market
-// reverted on-chain because `maxSharePrice` was computed from the un-accrued snapshot while
-// `morphoSupply` accrues `lastUpdate → execution` first (which raises the supply share price).
-// The bound must be derived from the forward-accrued market, mirroring the repay path.
+// Supply counterpart of VAU-1206: `maxSharePrice` must come from the forward-accrued market,
+// else a supply on a quiet market reverts against `morphoSupply`'s on-chain guard.
 describe("MorphoBlue supply maxSharePrice forward-accrual", () => {
   const RATE_AT_TARGET = 3_170_979_198n; // ~10% APR per-second
   const NOW_SEC = 1_800_000_000n;
@@ -821,8 +819,7 @@ describe("MorphoBlue supply maxSharePrice forward-accrual", () => {
     vi.useRealTimers();
   });
 
-  // A WETH-loan market (wNative) last accrued 5 days ago — far enough that accrued interest
-  // exceeds the 0.03% default slippage, i.e. the case that reverted on `morphoSupply`.
+  // WETH-loan market last accrued 5 days ago — accrual then exceeds the 0.03% default slippage.
   function staleMarket() {
     return new Market({
       params: new MarketParams(WstethWethBlue),
@@ -837,8 +834,7 @@ describe("MorphoBlue supply maxSharePrice forward-accrual", () => {
     });
   }
 
-  // Local public client: `buildTx` is fully synchronous and makes no RPC call for a native-only
-  // supply, so this needs no anvil fork (keeps the regression hermetic).
+  // Native-only `buildTx` is synchronous and makes no RPC call, so this needs no anvil fork.
   const localClient = createPublicClient({ chain: mainnet, transport: http() });
 
   test("native-only supply derives maxSharePrice from the forward-accrued market", () => {
@@ -863,19 +859,19 @@ describe("MorphoBlue supply maxSharePrice forward-accrual", () => {
       market: accruedMarket,
       slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
     });
-    // The pre-fix bound, computed from the un-accrued snapshot — what reverted.
+    // The pre-fix bound, from the un-accrued snapshot — what reverted.
     const stale = computeMaxSupplySharePrice({
       supplyAssets: nativeAmount,
       market: marketData,
       slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
     });
 
-    // 1. supply() derives the bound from the forward-accrued market.
+    // Bound comes from the forward-accrued market.
     expect(tx.action.args.maxSharePrice).toBe(expected);
     expect(tx.action.args.maxSharePrice).toBeGreaterThan(stale);
 
-    // 2. the on-chain `morphoSupply` guard (suppliedAssets.rDivDown(suppliedShares) <=
-    //    maxSharePrice) computed against the accrued market no longer reverts...
+    // On-chain guard `suppliedAssets.rDivDown(suppliedShares) <= maxSharePrice`: the accrued
+    // price clears the fixed bound but exceeds the stale one.
     const onchainSharePrice = rDivDown(
       nativeAmount,
       accruedMarket.toSupplyShares(nativeAmount, "Down"),
@@ -883,7 +879,6 @@ describe("MorphoBlue supply maxSharePrice forward-accrual", () => {
     expect(tx.action.args.maxSharePrice).toBeGreaterThanOrEqual(
       onchainSharePrice,
     );
-    // 3. ...whereas the stale bound would have reverted.
     expect(onchainSharePrice).toBeGreaterThan(stale);
   });
 });

--- a/packages/morpho-sdk/src/entities/blue/blue.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.test.ts
@@ -4,9 +4,11 @@ import {
   getChainAddresses,
   Market,
   MarketParams,
+  MathLib,
   ORACLE_PRICE_SCALE,
 } from "@morpho-org/blue-sdk";
 import { blueAbi } from "@morpho-org/blue-sdk-viem";
+import { Time } from "@morpho-org/morpho-ts";
 import { createMockClient, mockRead } from "@morpho-org/test/mock";
 import { type Address, createPublicClient, http, parseUnits } from "viem";
 import { mainnet } from "viem/chains";
@@ -14,7 +16,10 @@ import { afterEach, describe, expect, vi } from "vitest";
 import { CbbtcUsdcBlue, WstethWethBlue } from "../../../test/fixtures/blue.js";
 import { test } from "../../../test/setup.js";
 import { morphoViemExtension } from "../../client/index.js";
-import { computeMaxRepaySharePrice } from "../../helpers/index.js";
+import {
+  computeMaxRepaySharePrice,
+  computeMaxSupplySharePrice,
+} from "../../helpers/index.js";
 import {
   isRequirementApproval,
   MutuallyExclusiveRepayAmountsError,
@@ -799,5 +804,86 @@ describe("MorphoBlue repay maxSharePrice forward-accrual (VAU-1206)", () => {
 
     expect(tx.action.args.maxSharePrice).toBe(expected);
     expect(tx.action.args.maxSharePrice).toBeGreaterThan(stale);
+  });
+});
+
+// Regression for the supply counterpart of VAU-1206: a loan-asset supply on a quiet market
+// reverted on-chain because `maxSharePrice` was computed from the un-accrued snapshot while
+// `morphoSupply` accrues `lastUpdate → execution` first (which raises the supply share price).
+// The bound must be derived from the forward-accrued market, mirroring the repay path.
+describe("MorphoBlue supply maxSharePrice forward-accrual", () => {
+  const RATE_AT_TARGET = 3_170_979_198n; // ~10% APR per-second
+  const NOW_SEC = 1_800_000_000n;
+  const RAY = MathLib.RAY;
+  const rDivDown = (a: bigint, b: bigint) => (a * RAY) / b;
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // A WETH-loan market (wNative) last accrued 5 days ago — far enough that accrued interest
+  // exceeds the 0.03% default slippage, i.e. the case that reverted on `morphoSupply`.
+  function staleMarket() {
+    return new Market({
+      params: new MarketParams(WstethWethBlue),
+      totalSupplyAssets: 10n ** 24n,
+      totalBorrowAssets: (10n ** 24n * 9n) / 10n, // 90% utilization
+      totalSupplyShares: 10n ** 30n,
+      totalBorrowShares: (10n ** 30n * 9n) / 10n,
+      lastUpdate: NOW_SEC - 5n * 24n * 3_600n,
+      fee: 0n,
+      price: ORACLE_PRICE_SCALE,
+      rateAtTarget: RATE_AT_TARGET,
+    });
+  }
+
+  // Local public client: `buildTx` is fully synchronous and makes no RPC call for a native-only
+  // supply, so this needs no anvil fork (keeps the regression hermetic).
+  const localClient = createPublicClient({ chain: mainnet, transport: http() });
+
+  test("native-only supply derives maxSharePrice from the forward-accrued market", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Number(NOW_SEC) * 1_000);
+
+    const marketData = staleMarket();
+    const nativeAmount = parseUnits("10", 18);
+    const market = localClient
+      .extend(morphoViemExtension())
+      .morpho.blue(WstethWethBlue, mainnet.id);
+
+    const tx = market
+      .supply({ nativeAmount, userAddress: USER, marketData })
+      .buildTx();
+
+    const accruedMarket = marketData.accrueInterest(
+      MathLib.max(Time.timestamp(), marketData.lastUpdate) + Time.s.from.h(2n),
+    );
+    const expected = computeMaxSupplySharePrice({
+      supplyAssets: nativeAmount,
+      market: accruedMarket,
+      slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
+    });
+    // The pre-fix bound, computed from the un-accrued snapshot — what reverted.
+    const stale = computeMaxSupplySharePrice({
+      supplyAssets: nativeAmount,
+      market: marketData,
+      slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
+    });
+
+    // 1. supply() derives the bound from the forward-accrued market.
+    expect(tx.action.args.maxSharePrice).toBe(expected);
+    expect(tx.action.args.maxSharePrice).toBeGreaterThan(stale);
+
+    // 2. the on-chain `morphoSupply` guard (suppliedAssets.rDivDown(suppliedShares) <=
+    //    maxSharePrice) computed against the accrued market no longer reverts...
+    const onchainSharePrice = rDivDown(
+      nativeAmount,
+      accruedMarket.toSupplyShares(nativeAmount, "Down"),
+    );
+    expect(tx.action.args.maxSharePrice).toBeGreaterThanOrEqual(
+      onchainSharePrice,
+    );
+    // 3. ...whereas the stale bound would have reverted.
+    expect(onchainSharePrice).toBeGreaterThan(stale);
   });
 });

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -142,8 +142,9 @@ export interface BlueActions {
   /**
    * Prepares a loan-asset supply transaction.
    *
-   * Routed through bundler via GeneralAdapter1. Computes `maxSharePrice` from market supply
-   * state and `slippageTolerance` to protect against share-price inflation.
+   * Routed through bundler via GeneralAdapter1. Computes `maxSharePrice` from the supply state of
+   * `marketData` forward-accrued to execution and `slippageTolerance` to protect against
+   * share-price inflation.
    * `getRequirements` returns ERC20 approval or permit for `GeneralAdapter1` on the loan token.
    * When `nativeAmount` is provided, native token is wrapped; the loan token must be wNative.
    *
@@ -594,9 +595,17 @@ export class MorphoBlue implements BlueActions {
       validateNativeAsset(this.chainId, this.marketParams.loanToken);
     }
 
+    // Forward-accrue (2h) before deriving `maxSharePrice`: on-chain `morphoSupply` accrues
+    // `lastUpdate → execution`, which raises the supply share price, so a bound derived from the
+    // un-accrued snapshot reverts on quiet markets once accrued interest exceeds the slippage
+    // tolerance. Mirrors the repay path (VAU-1206).
+    const accrualTimestamp =
+      MathLib.max(Time.timestamp(), marketData.lastUpdate) + Time.s.from.h(2n);
+    const marketForSupply = marketData.accrueInterest(accrualTimestamp);
+
     const maxSharePrice = computeMaxSupplySharePrice({
       supplyAssets: totalAssets,
-      market: marketData,
+      market: marketForSupply,
       slippageTolerance,
     });
     return {

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -595,10 +595,7 @@ export class MorphoBlue implements BlueActions {
       validateNativeAsset(this.chainId, this.marketParams.loanToken);
     }
 
-    // Forward-accrue (2h) before deriving `maxSharePrice`: on-chain `morphoSupply` accrues
-    // `lastUpdate → execution`, which raises the supply share price, so a bound derived from the
-    // un-accrued snapshot reverts on quiet markets once accrued interest exceeds the slippage
-    // tolerance. Mirrors the repay path (VAU-1206).
+    // Forward-accrue (2h) before deriving `maxSharePrice`: on-chain `morphoSupply` accrues `lastUpdate → execution`, raising the supply share price, so an un-accrued bound reverts on quiet markets.
     const accrualTimestamp =
       MathLib.max(Time.timestamp(), marketData.lastUpdate) + Time.s.from.h(2n);
     const marketForSupply = marketData.accrueInterest(accrualTimestamp);


### PR DESCRIPTION
## Motivation

`MorphoBlue.supply` reverts on-chain on the `morphoSupply` `maxSharePrice` guard for quiet markets. It derived the bound from the un-accrued `marketData` snapshot (as of the market's `lastUpdate`), while on-chain `morphoSupply` accrues interest `lastUpdate → execution` first — which raises the supply share price. Once accrued interest exceeds the default 0.03% `slippageTolerance` (only a few days at ~10% APR), the accrued price exceeds the stale bound and the bundle reverts. This is the supply counterpart of the repay fix (VAU-1206), which had been missed; the native-ETH-only path just surfaced it first.

## Solution

`supply()` now forward-accrues `marketData` to `max(now, lastUpdate) + 2h` before computing `maxSharePrice`, mirroring `repay`/`repayWithdrawCollateral`. Added a hermetic regression test (5-day-stale WETH market, native supply) asserting the bound is derived from the accrued market and is `>=` the on-chain accrued share price, plus a patch changeset. `withdraw`/`borrow` use a lower `minSharePrice` bound that accrual only relaxes, so they were unaffected and are left unchanged.