### PR TITLE
feat(midnight-sdk): type mempool validation issues

### DIFF
--- a/.changeset/smooth-moles-validate.md
+++ b/.changeset/smooth-moles-validate.md
@@ -1,0 +1,6 @@
+---
+"@morpho-org/midnight-sdk": minor
+"@morpho-org/morpho-sdk": patch
+---
+
+Expose known Midnight mempool validation rules and normalize the `min_offer_assets_usd` details. Preserve unknown rules and non-null detail shapes so router policy additions remain compatible with older SDK clients.

--- a/packages/midnight-sdk/src/api/MidnightApi.test.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.test.ts
@@ -2,7 +2,7 @@ import packageJson from "@morpho-org/midnight-sdk/package.json" with {
   type: "json",
 };
 import { ChainId, getChainAddress, MathLib } from "@morpho-org/morpho-ts";
-import type { Hex } from "viem";
+import { type Hex, maxUint256 } from "viem";
 import { describe, expect, test } from "vitest";
 
 import { createFixtures } from "../__test__/fixtures.js";
@@ -13,7 +13,11 @@ import {
 import { TickLib } from "../math/index.js";
 import type { IOffer } from "../offers/index.js";
 import { Payload } from "../signatures/Payload.js";
-import { MidnightApi, type MidnightApiFetch } from "./MidnightApi.js";
+import {
+  MempoolPayloadValidationRule,
+  MidnightApi,
+  type MidnightApiFetch,
+} from "./MidnightApi.js";
 
 const { baseMarketParamsInput, baseOffer } = createFixtures({
   midnight: getChainAddress(ChainId.BaseMainnet, "midnight"),
@@ -214,6 +218,50 @@ const expectedTakeableOffer = {
 };
 
 describe("MidnightApi.validateMempoolPayload", () => {
+  test("behavior: exposes every documented validation rule", () => {
+    const documentedRules = [
+      "payload_version",
+      "payload_frame",
+      "payload_gzip_length",
+      "payload_suffix_too_large",
+      "payload_decompression",
+      "payload_abi_decode",
+      "empty_payload",
+      "max_offers_per_tree",
+      "duplicate_offer_hash",
+      "unsupported_chain",
+      "market_chain_mismatch",
+      "maturity",
+      "loan_token",
+      "collateral_token",
+      "oracle",
+      "market_triplet",
+      "rcf_threshold",
+      "collateral_lltv",
+      "max_lif",
+      "max_collaterals",
+      "amount_missing",
+      "amount_conflict",
+      "min_offer_assets_usd",
+      "min_tick",
+      "max_tick",
+      "tick_spacing",
+      "min_duration",
+      "ratifier",
+      "mixed_maker",
+      "mixed_ratifier",
+      "group_identity",
+      "group_consistency",
+      "non_empty_callback",
+      "buy_empty_callback",
+      "sell_empty_callback",
+    ];
+
+    expect(Object.values(MempoolPayloadValidationRule).toSorted()).toEqual(
+      documentedRules.toSorted(),
+    );
+  });
+
   test("default", async () => {
     const payload = "0x0100000000" as Hex;
     const timestamp = "2026-06-01T16:00:00Z";
@@ -265,6 +313,119 @@ describe("MidnightApi.validateMempoolPayload", () => {
     expect(headers.get("content-type")).toBe("application/json");
     expect(headers.get("sdk-version")).toBe(packageJson.version);
     expect(headers.get("x-app")).toBe("markets-v2");
+  });
+
+  test("behavior: parses known non-null details", async () => {
+    const { fetch } = createJsonFetch({
+      data: {
+        issues: [
+          {
+            rule: "min_offer_assets_usd",
+            details: {
+              loan_token: LOAN_TOKEN,
+              min_assets: "100014791",
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await MidnightApi.validateMempoolPayload({
+      chainId: 8453,
+      payload: "0x0100000000" as Hex,
+      fetch,
+    });
+
+    expect(result.issues).toEqual([
+      {
+        rule: MempoolPayloadValidationRule.MinOfferAssetsUsd,
+        details: {
+          type: "minOfferAssetsUsd",
+          loanToken: LOAN_TOKEN,
+          minAssets: 100014791n,
+        },
+      },
+    ]);
+  });
+
+  test.each([
+    ["null", { rule: "tick_spacing", details: null }],
+    ["omitted", { rule: "tick_spacing" }],
+  ])("behavior: preserves the existing shape for %s details", async (_, issue) => {
+    const { fetch } = createJsonFetch({ data: { issues: [issue] } });
+
+    const result = await MidnightApi.validateMempoolPayload({
+      chainId: 8453,
+      payload: "0x0100000000" as Hex,
+      fetch,
+    });
+
+    expect(result.issues).toEqual([
+      { rule: MempoolPayloadValidationRule.TickSpacing },
+    ]);
+  });
+
+  test("behavior: retains future rules and details", async () => {
+    const futureDetails = { next_allowed_tick: 4 };
+    const futureRuleDetails = { threshold: "1000" };
+    const { fetch } = createJsonFetch({
+      data: {
+        issues: [
+          { rule: "tick_spacing", details: futureDetails },
+          { rule: "future_router_policy", details: futureRuleDetails },
+        ],
+      },
+    });
+
+    const result = await MidnightApi.validateMempoolPayload({
+      chainId: 8453,
+      payload: "0x0100000000" as Hex,
+      fetch,
+    });
+
+    expect(result.issues).toEqual([
+      {
+        rule: MempoolPayloadValidationRule.TickSpacing,
+        details: { type: "unknown", raw: futureDetails },
+      },
+      {
+        rule: "future_router_policy",
+        details: { type: "unknown", raw: futureRuleDetails },
+      },
+    ]);
+  });
+
+  test.each([
+    ["malformed", { loan_token: LOAN_TOKEN, min_assets: null }],
+    ["oversized", { loan_token: LOAN_TOKEN, min_assets: "9".repeat(79) }],
+    [
+      "above uint256",
+      { loan_token: LOAN_TOKEN, min_assets: (maxUint256 + 1n).toString() },
+    ],
+  ])("behavior: retains %s known details without rejecting the response", async (_, unrecognizedDetails) => {
+    const { fetch } = createJsonFetch({
+      data: {
+        issues: [
+          {
+            rule: "min_offer_assets_usd",
+            details: unrecognizedDetails,
+          },
+        ],
+      },
+    });
+
+    const result = await MidnightApi.validateMempoolPayload({
+      chainId: 8453,
+      payload: "0x0100000000" as Hex,
+      fetch,
+    });
+
+    expect(result.issues).toEqual([
+      {
+        rule: MempoolPayloadValidationRule.MinOfferAssetsUsd,
+        details: { type: "unknown", raw: unrecognizedDetails },
+      },
+    ]);
   });
 
   test("behavior: uses baseUrl override", async () => {
@@ -338,10 +499,14 @@ describe("MidnightApi.validateMempoolPayload", () => {
     expect.unreachable("Expected malformed API error body to throw.");
   });
 
-  test("error: InvalidMidnightApiResponseError", async () => {
-    const { fetch } = createJsonFetch({
-      data: { issues: [{ field: "rule" }] },
-    });
+  test.each([
+    ["missing data", {}],
+    ["missing issues", { data: {} }],
+    ["non-array issues", { data: { issues: {} } }],
+    ["non-object issue", { data: { issues: [null] } }],
+    ["missing rule", { data: { issues: [{ field: "rule" }] } }],
+  ])("error: InvalidMidnightApiResponseError for %s", async (_, response) => {
+    const { fetch } = createJsonFetch(response);
 
     await expect(
       MidnightApi.validateMempoolPayload({

--- a/packages/midnight-sdk/src/api/MidnightApi.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.ts
@@ -45,6 +45,7 @@ export type {
   FetchBookTakeableOffersParams,
   FetchTakeableOffersParams,
   MempoolPayloadValidationIssue,
+  MempoolPayloadValidationIssueDetails,
   MempoolPayloadValidationResult,
   MempoolPayloadValidationSuccess,
   MidnightApiBookMarket,
@@ -76,6 +77,7 @@ export type {
   ValidateMempoolItemsParams,
   ValidateMempoolPayloadParams,
 } from "./types.js";
+export { MempoolPayloadValidationRule } from "./types.js";
 
 /**
  * Midnight API client and stateless helper surface for books and mempool data.

--- a/packages/midnight-sdk/src/api/helpers.ts
+++ b/packages/midnight-sdk/src/api/helpers.ts
@@ -1,26 +1,34 @@
 import { BLUE_API_BASE_URL, isHexEqual } from "@morpho-org/morpho-ts";
-import { type Address, type Hash, isAddressEqual } from "viem";
+import {
+  type Address,
+  type Hash,
+  isAddress,
+  isAddressEqual,
+  maxUint256,
+} from "viem";
 import {
   InvalidMidnightApiResponseError,
   MidnightApiError,
 } from "../errors.js";
 import { MarketUtils } from "../market/index.js";
-import type {
-  ApiBookMarketResponse,
-  ApiCollateralResponse,
-  ApiPriceLevelResponse,
-  ApiRequestParams,
-  ApiTakeableOfferResponse,
-  MempoolPayloadValidationResult,
-  MidnightApiBookMarket,
-  MidnightApiBookSide,
-  MidnightApiCollateral,
-  MidnightApiPriceLevel,
-  MidnightApiTake,
+import {
+  type ApiBookMarketResponse,
+  type ApiCollateralResponse,
+  type ApiPriceLevelResponse,
+  type ApiRequestParams,
+  type ApiTakeableOfferResponse,
+  type MempoolPayloadValidationResult,
+  MempoolPayloadValidationRule,
+  type MidnightApiBookMarket,
+  type MidnightApiBookSide,
+  type MidnightApiCollateral,
+  type MidnightApiPriceLevel,
+  type MidnightApiTake,
 } from "./types.js";
 import { MIDNIGHT_SDK_VERSION } from "./version.generated.js";
 
 const DEFAULT_MIDNIGHT_API_URL = new URL("/v0/midnight", BLUE_API_BASE_URL);
+const MAX_UINT256_DECIMAL_LENGTH = maxUint256.toString().length;
 
 /** @internal Sends one Midnight API request and maps non-2xx responses to SDK errors. */
 export async function requestMidnightApi<Response = unknown>(
@@ -301,7 +309,43 @@ export function parseValidationResponse(
       );
     }
 
-    return { rule };
+    const details = record.details;
+    if (details == null) return { rule };
+
+    if (
+      rule === MempoolPayloadValidationRule.MinOfferAssetsUsd &&
+      isRecord(details)
+    ) {
+      const loanToken = details.loan_token;
+      const rawMinAssets = details.min_assets;
+      if (
+        typeof loanToken === "string" &&
+        isAddress(loanToken) &&
+        typeof rawMinAssets === "string" &&
+        rawMinAssets.length <= MAX_UINT256_DECIMAL_LENGTH &&
+        /^\d+$/.test(rawMinAssets)
+      ) {
+        const minAssets = BigInt(rawMinAssets);
+        if (minAssets <= maxUint256) {
+          return {
+            rule,
+            details: {
+              type: "minOfferAssetsUsd" as const,
+              loanToken,
+              minAssets,
+            },
+          };
+        }
+      }
+    }
+
+    return {
+      rule,
+      details: {
+        type: "unknown" as const,
+        raw: details,
+      },
+    };
   });
 
   return {

--- a/packages/midnight-sdk/src/api/types.ts
+++ b/packages/midnight-sdk/src/api/types.ts
@@ -227,11 +227,86 @@ export interface FetchTakeableOffersParams extends MidnightApiConfig {
 }
 
 /**
- * One API validation issue.
+ * `MempoolPayloadValidationRule` lists known Midnight mempool validation rules.
+ */
+export const MempoolPayloadValidationRule = {
+  MinOfferAssetsUsd: "min_offer_assets_usd",
+  PayloadVersion: "payload_version",
+  PayloadFrame: "payload_frame",
+  PayloadGzipLength: "payload_gzip_length",
+  PayloadSuffixTooLarge: "payload_suffix_too_large",
+  PayloadDecompression: "payload_decompression",
+  PayloadAbiDecode: "payload_abi_decode",
+  EmptyPayload: "empty_payload",
+  MaxOffersPerTree: "max_offers_per_tree",
+  DuplicateOfferHash: "duplicate_offer_hash",
+  UnsupportedChain: "unsupported_chain",
+  MarketChainMismatch: "market_chain_mismatch",
+  Maturity: "maturity",
+  LoanToken: "loan_token",
+  CollateralToken: "collateral_token",
+  Oracle: "oracle",
+  MarketTriplet: "market_triplet",
+  RcfThreshold: "rcf_threshold",
+  CollateralLltv: "collateral_lltv",
+  MaxLif: "max_lif",
+  MaxCollaterals: "max_collaterals",
+  AmountMissing: "amount_missing",
+  AmountConflict: "amount_conflict",
+  MinTick: "min_tick",
+  MaxTick: "max_tick",
+  TickSpacing: "tick_spacing",
+  MinDuration: "min_duration",
+  Ratifier: "ratifier",
+  MixedMaker: "mixed_maker",
+  MixedRatifier: "mixed_ratifier",
+  GroupIdentity: "group_identity",
+  GroupConsistency: "group_consistency",
+  NonEmptyCallback: "non_empty_callback",
+  BuyEmptyCallback: "buy_empty_callback",
+  SellEmptyCallback: "sell_empty_callback",
+} as const satisfies Readonly<Record<string, string>>;
+
+/**
+ * `MempoolPayloadValidationRule` represents a rule returned by the API.
+ *
+ * Known values have autocomplete through the matching constant; the open
+ * string branch keeps newer API rules forward-compatible.
+ */
+export type MempoolPayloadValidationRule =
+  | (typeof MempoolPayloadValidationRule)[keyof typeof MempoolPayloadValidationRule]
+  | (string & Record<never, never>);
+
+/**
+ * `MempoolPayloadValidationIssueDetails` represents parsed issue details.
+ *
+ * Unrecognized non-null details are retained verbatim so API additions do not
+ * make older SDK clients reject the entire validation response.
+ */
+export type MempoolPayloadValidationIssueDetails =
+  | {
+      /** Identifies details for the `min_offer_assets_usd` rule. */
+      readonly type: "minOfferAssetsUsd";
+      /** Loan token of the first offer below its configured minimum. */
+      readonly loanToken: Address;
+      /** Configured minimum in raw loan-token assets. */
+      readonly minAssets: bigint;
+    }
+  | {
+      /** Identifies details whose schema is not known by this SDK version. */
+      readonly type: "unknown";
+      /** Unmodified JSON value returned by the API. */
+      readonly raw: unknown;
+    };
+
+/**
+ * `MempoolPayloadValidationIssue` represents one API validation issue.
  */
 export interface MempoolPayloadValidationIssue {
   /** API rule violated by the payload. */
-  readonly rule: string;
+  readonly rule: MempoolPayloadValidationRule;
+  /** Parsed non-null details, when the API provides them. */
+  readonly details?: MempoolPayloadValidationIssueDetails;
 }
 
 /**


### PR DESCRIPTION
## Summary

- expose enum-like constants for every documented mempool validation rule while keeping the rule type open to future router additions
- normalize `min_offer_assets_usd` details to `{ type, loanToken, minAssets }`
- preserve null/omitted details and retain unknown non-null shapes as `{ type: "unknown", raw }` instead of rejecting the response

## Rationale

Router policy can evolve independently of SDK releases. A closed enum or null-only details union would make older clients unsafe or brittle. This keeps autocomplete for known rules without turning future rules or detail schemas into runtime failures.

## Validation

- `pnpm lint`
- `pnpm --filter @morpho-org/midnight-sdk test --run` — 307 tests passed
- `pnpm --filter @morpho-org/midnight-sdk exec tsc --noEmit -p tsconfig.build.esm.json`
- full `pnpm test --run` attempted; unrelated fork suites were blocked by public RPC HTTP 429 rate limits

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->