### PR TITLE
fix(morpho-sdk): bound in-kind redeem allowance

### DIFF
--- a/.changeset/calm-vaults-redeem.md
+++ b/.changeset/calm-vaults-redeem.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-sdk": patch
+---
+
+Include Vault V2 per-market rounding headroom in bounded in-kind redeem share permits and approvals.

--- a/packages/morpho-sdk/src/entities/vaultV2/vaultV2.inKindRedeem.test.ts
+++ b/packages/morpho-sdk/src/entities/vaultV2/vaultV2.inKindRedeem.test.ts
@@ -396,7 +396,7 @@ describe("MorphoVaultV2.inKindRedeem", () => {
 
     expect(approval?.action).toEqual({
       type: "erc20Approval",
-      args: { spender: IN_KIND_BUNDLER, amount: 500n },
+      args: { spender: IN_KIND_BUNDLER, amount: 501n },
     });
   });
 
@@ -454,7 +454,7 @@ describe("MorphoVaultV2.inKindRedeem", () => {
 
     expect(requirement?.action).toMatchObject({
       type: "permit",
-      args: { spender: IN_KIND_BUNDLER, amount: 500n },
+      args: { spender: IN_KIND_BUNDLER, amount: 501n },
     });
   });
 
@@ -478,7 +478,7 @@ describe("MorphoVaultV2.inKindRedeem", () => {
       })
       .getRequirements();
 
-    expect(approval?.action).toMatchObject({ args: { amount: 4n } });
+    expect(approval?.action).toMatchObject({ args: { amount: 6n } });
   });
 
   test("behavior: current preview bounds interest-driven share-price growth", async () => {
@@ -507,7 +507,7 @@ describe("MorphoVaultV2.inKindRedeem", () => {
       })
       .getRequirements();
 
-    expect(approval?.action).toMatchObject({ args: { amount } });
+    expect(approval?.action).toMatchObject({ args: { amount: amount + 1n } });
   });
 
   test("behavior: deadline preview bounds management-fee dilution", async () => {
@@ -543,7 +543,9 @@ describe("MorphoVaultV2.inKindRedeem", () => {
         ? approval.action.args.amount
         : 0n;
     const { vault: deadlineVault } = vaultData.accrueInterest(deadline);
-    expect(approvalAmount).toBe(deadlineVault.toShares(amount, "Up"));
+    expect(approvalAmount).toBe(
+      deadlineVault.toShares(amount, "Up") + deadlineVault.toShares(1n, "Up"),
+    );
   });
 
   test("error: InsufficientBlueBalanceForInKindRedeemError", async () => {
@@ -569,7 +571,7 @@ describe("MorphoVaultV2.inKindRedeem", () => {
   test("behavior: Blue balance covers the peak market chunk instead of the total", async () => {
     const handle = createMockClient(mainnet);
     mockV2Requirements(handle, {
-      allowance: 1_500n,
+      allowance: 1_502n,
       blueBalance: 1_000n,
     });
     const vault = handle.client
@@ -589,7 +591,7 @@ describe("MorphoVaultV2.inKindRedeem", () => {
 
   test("behavior: exact bounded allowance returns no authorization", async () => {
     const handle = createMockClient(mainnet);
-    mockV2Requirements(handle, { allowance: 500n });
+    mockV2Requirements(handle, { allowance: 501n });
     const vault = handle.client
       .extend(morphoViemExtension())
       .morpho.vaultV2(IN_KIND_VAULT, mainnet.id);

--- a/packages/morpho-sdk/src/entities/vaultV2/vaultV2.ts
+++ b/packages/morpho-sdk/src/entities/vaultV2/vaultV2.ts
@@ -146,7 +146,7 @@ export interface VaultV2Actions {
    * multiple share burns. The SDK intentionally does not validate the user's share balance; size
    * it so `amount + BigInt(marketParamsList.length) <= vault.previewRedeem(sharesHeld)`. The
    * per-market term covers V2 withdrawal rounding and is not needed for V1. The share allowance
-   * includes the penalty burns and accrual through the bundle deadline.
+   * includes that buffer, the penalty burns, and accrual through the bundle deadline.
    *
    * Idle balance, penalty, and adapter positions can drift after the snapshot, so an on-chain
    * under-coverage panic remains possible if vault state changes between preparation and inclusion.
@@ -557,7 +557,6 @@ export class MorphoVaultV2 implements VaultV2Actions {
 
     let remaining = assetsToDeallocate;
     let peak = 0n;
-    let requiredShareAllowance = 0n;
     const consumedMarketIds = new Set<string>();
     const { vault: allowanceVault } = vaultData.accrueInterest(deadline);
     // Interest can lower the burn, while management fees can raise it; bound both endpoints.
@@ -567,6 +566,9 @@ export class MorphoVaultV2 implements VaultV2Actions {
         allowanceVault.toShares(assets, "Up"),
       );
 
+    let requiredShareAllowance = previewAllowance(
+      BigInt(marketParamsListSnapshot.length),
+    );
     // Pre-burn previews upper-bound each separately rounded idle, penalty, and main burn.
     requiredShareAllowance += previewAllowance(idleAssets);
     for (const id of marketIdListSnapshot) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,7 +26,8 @@ export default defineConfig({
       ],
     },
     sequence: {
-      concurrent: true,
+      // ponytail: serialize within files in CI until fork RPC throughput is reliable.
+      concurrent: !process.env.CI,
     },
     globalSetup: "vitest.setup.ts",
     retry: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Motivation

Vault V2 in-kind redemption can burn one more base-unit-equivalent of shares than its bounded permit or approval when market accrual shifts assets between separately rounded penalty legs. The resulting allowance underflow surfaces as EVM panic 0x11. Fork CI also sends excessive RPC traffic when tests within every file run concurrently.

## Solution

- Include the documented per-market V2 rounding buffer in bounded share permits and approvals.
- Cover the adjusted allowance bounds in unit and fork-backed integration tests.
- Serialize tests within each file only on CI while retaining file-level parallelism.

## Validation

- `pnpm lint`
- `pnpm --filter @morpho-org/morpho-sdk build`
- Full CI-mode morpho-sdk suite: 1,163 tests passed
- In-kind redemption integration test passed three times with concurrency forced on
