### PR TITLE
ci: bound and shard fork test workloads

### DIFF
--- a/.changeset/quiet-anvils-fail.md
+++ b/.changeset/quiet-anvils-fail.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/test": patch
+---
+
+Stop retrying failed JSON-RPC requests from Vitest clients to local Anvil processes so transport errors surface without duplicating RPC work.

--- a/.changeset/quiet-anvils-fail.md
+++ b/.changeset/quiet-anvils-fail.md
@@ -1,5 +1,5 @@
 ---
-"@morpho-org/test": patch
+"@morpho-org/test": minor
 ---
 
 Stop retrying failed JSON-RPC requests from Vitest clients to local Anvil processes so transport errors surface without duplicating RPC work.

--- a/.changeset/quiet-anvils-fail.md
+++ b/.changeset/quiet-anvils-fail.md
@@ -3,3 +3,5 @@
 ---
 
 Stop retrying failed JSON-RPC requests from Vitest clients to local Anvil processes so transport errors surface without duplicating RPC work.
+
+Support Anvil's Optimism Karst hardfork so Base fork tests can execute Osaka EVM bytecode with Foundry v1.8.0.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,6 +31,9 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   test:
+    concurrency:
+      group: morpho-sdk-rpc-tests
+      queue: max
     permissions:
       contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,52 @@ permissions:
   contents: read
 
 jobs:
-  vitest:
+  package:
+    name: Package (${{ matrix.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          # Pure and fork projects from one package share a single runner.
+          - name: scripts
+            projects: scripts
+            uses_foundry: false
+          - name: agents-engine
+            projects: agents-engine
+            uses_foundry: false
+          - name: morpho-ts
+            projects: morpho-ts
+            uses_foundry: false
+          - name: blue-sdk
+            projects: blue-sdk blue-sdk-fork
+            uses_foundry: true
+          - name: midnight-sdk
+            projects: midnight-sdk midnight-sdk-fork
+            uses_foundry: true
+          - name: morpho-sdk
+            projects: morpho-sdk morpho-sdk-fork
+            uses_foundry: true
+          - name: evm-simulation
+            projects: evm-simulation evm-simulation-fork
+            uses_foundry: true
+          - name: blue-sdk-viem
+            projects: blue-sdk-viem blue-sdk-viem-fork
+            uses_foundry: true
+          - name: liquidity-sdk-viem
+            projects: liquidity-sdk-viem liquidity-sdk-viem-fork
+            uses_foundry: true
+          - name: test
+            projects: test test-fork
+            uses_foundry: true
+          - name: morpho-test
+            projects: morpho-test
+            uses_foundry: false
+          - name: wdk-protocol-lending-morpho-evm
+            projects: wdk-protocol-lending-morpho-evm wdk-protocol-lending-morpho-evm-fork
+            uses_foundry: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -30,28 +74,60 @@ jobs:
           cache: pnpm
 
       - name: Restore Foundry cache
+        id: foundry-cache
+        if: matrix.uses_foundry
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.foundry/cache/rpc
-          key: foundry-${{ github.job }}-${{ github.sha }}
-          restore-keys: foundry-${{ github.job }}-
+          key: foundry-${{ github.job }}-${{ matrix.name }}-${{ github.sha }}-${{ github.run_attempt }}
+          restore-keys: |
+            foundry-${{ github.job }}-${{ matrix.name }}-${{ github.sha }}-
+            foundry-${{ github.job }}-${{ matrix.name }}-
 
       - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        if: matrix.uses_foundry
         with:
           cache: false # Disable built-in cache to always save it.
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm run test:ci
+      - name: Test
+        id: test
         env:
-          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
-          BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
-          ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL }}
+          MAINNET_RPC_URL: ${{ matrix.uses_foundry && secrets.MAINNET_RPC_URL || '' }}
+          BASE_RPC_URL: ${{ matrix.uses_foundry && secrets.BASE_RPC_URL || '' }}
+          ARBITRUM_RPC_URL: ${{ matrix.uses_foundry && secrets.ARBITRUM_RPC_URL || '' }}
           IS_LOGGING_DISABLED: true
+          VITEST_PROJECTS: ${{ matrix.projects }}
+        run: |
+          project_args=()
+          for project in $VITEST_PROJECTS; do
+            project_args+=(--project "$project")
+          done
+          pnpm exec vitest run --coverage \
+            "${project_args[@]}" \
+            --reporter=default --reporter=github-actions
 
       - name: Save Foundry cache
-        if: always()
+        if: >-
+          matrix.uses_foundry &&
+          steps.test.outcome == 'success' &&
+          steps.foundry-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.foundry/cache/rpc
-          key: foundry-${{ github.job }}-${{ github.sha }}
+          key: ${{ steps.foundry-cache.outputs.cache-primary-key }}
+
+  vitest:
+    name: vitest
+    if: always()
+    needs:
+      - package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check shards
+        env:
+          PACKAGE_RESULT: ${{ needs.package.result }}
+        run: test "$PACKAGE_RESULT" = success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,12 +99,14 @@ jobs:
           ARBITRUM_RPC_URL: ${{ matrix.uses_foundry && secrets.ARBITRUM_RPC_URL || '' }}
           IS_LOGGING_DISABLED: true
           VITEST_PROJECTS: ${{ matrix.projects }}
+          COVERAGE_ROOT: ${{ matrix.name == 'scripts' && 'scripts/release' || format('packages/{0}/src', matrix.name) }}
         run: |
           project_args=()
           for project in $VITEST_PROJECTS; do
             project_args+=(--project "$project")
           done
           pnpm exec vitest run --coverage \
+            --coverage.include="$COVERAGE_ROOT/**/*.{js,mjs,ts,tsx}" \
             "${project_args[@]}" \
             --reporter=default --reporter=github-actions
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         if: matrix.uses_foundry
         with:
+          version: v1.7.1
           cache: false # Disable built-in cache to always save it.
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         if: matrix.uses_foundry
         with:
-          version: v1.7.1
+          version: v1.8.0
           cache: false # Disable built-in cache to always save it.
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         include:
           # Pure and fork projects from one package share a single runner.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,17 +22,42 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: unit
-            projects: >-
-              scripts agents-engine morpho-ts blue-sdk midnight-sdk morpho-sdk
-              evm-simulation blue-sdk-viem liquidity-sdk-viem test morpho-test
-              wdk-protocol-lending-morpho-evm
+          # Pure and fork projects from one package share a single runner.
+          - name: scripts
+            projects: scripts
             uses_foundry: false
-          - name: integration
-            projects: >-
-              blue-sdk-fork midnight-sdk-fork morpho-sdk-fork
-              evm-simulation-fork blue-sdk-viem-fork liquidity-sdk-viem-fork
-              test-fork wdk-protocol-lending-morpho-evm-fork
+          - name: agents-engine
+            projects: agents-engine
+            uses_foundry: false
+          - name: morpho-ts
+            projects: morpho-ts
+            uses_foundry: false
+          - name: blue-sdk
+            projects: blue-sdk blue-sdk-fork
+            uses_foundry: true
+          - name: midnight-sdk
+            projects: midnight-sdk midnight-sdk-fork
+            uses_foundry: true
+          - name: morpho-sdk
+            projects: morpho-sdk morpho-sdk-fork
+            uses_foundry: true
+          - name: evm-simulation
+            projects: evm-simulation evm-simulation-fork
+            uses_foundry: true
+          - name: blue-sdk-viem
+            projects: blue-sdk-viem blue-sdk-viem-fork
+            uses_foundry: true
+          - name: liquidity-sdk-viem
+            projects: liquidity-sdk-viem liquidity-sdk-viem-fork
+            uses_foundry: true
+          - name: test
+            projects: test test-fork
+            uses_foundry: true
+          - name: morpho-test
+            projects: morpho-test
+            uses_foundry: false
+          - name: wdk-protocol-lending-morpho-evm
+            projects: wdk-protocol-lending-morpho-evm wdk-protocol-lending-morpho-evm-fork
             uses_foundry: true
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,42 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Pure and fork projects from one package share a single runner.
-          - name: scripts
-            projects: scripts
+          - name: unit
+            projects: >-
+              scripts agents-engine morpho-ts blue-sdk midnight-sdk morpho-sdk
+              evm-simulation blue-sdk-viem liquidity-sdk-viem test morpho-test
+              wdk-protocol-lending-morpho-evm
             uses_foundry: false
-          - name: agents-engine
-            projects: agents-engine
-            uses_foundry: false
-          - name: morpho-ts
-            projects: morpho-ts
-            uses_foundry: false
-          - name: blue-sdk
-            projects: blue-sdk blue-sdk-fork
-            uses_foundry: true
-          - name: midnight-sdk
-            projects: midnight-sdk midnight-sdk-fork
-            uses_foundry: true
-          - name: morpho-sdk
-            projects: morpho-sdk morpho-sdk-fork
-            uses_foundry: true
-          - name: evm-simulation
-            projects: evm-simulation evm-simulation-fork
-            uses_foundry: true
-          - name: blue-sdk-viem
-            projects: blue-sdk-viem blue-sdk-viem-fork
-            uses_foundry: true
-          - name: liquidity-sdk-viem
-            projects: liquidity-sdk-viem liquidity-sdk-viem-fork
-            uses_foundry: true
-          - name: test
-            projects: test test-fork
-            uses_foundry: true
-          - name: morpho-test
-            projects: morpho-test
-            uses_foundry: false
-          - name: wdk-protocol-lending-morpho-evm
-            projects: wdk-protocol-lending-morpho-evm wdk-protocol-lending-morpho-evm-fork
+          - name: integration
+            projects: >-
+              blue-sdk-fork midnight-sdk-fork morpho-sdk-fork
+              evm-simulation-fork blue-sdk-viem-fork liquidity-sdk-viem-fork
+              test-fork wdk-protocol-lending-morpho-evm-fork
             uses_foundry: true
 
     steps:

--- a/packages/morpho-sdk/test/actions/midnight/requirements.integration.test.ts
+++ b/packages/morpho-sdk/test/actions/midnight/requirements.integration.test.ts
@@ -36,7 +36,7 @@ import {
 const test = createViemTest(base, {
   forkUrl: process.env.BASE_RPC_URL,
   forkBlockNumber: 48_287_000n,
-  hardfork: "Osaka",
+  hardfork: "Karst",
   stepsTracing: false,
 });
 

--- a/packages/test/src/anvil.ts
+++ b/packages/test/src/anvil.ts
@@ -163,6 +163,7 @@ export interface AnvilArgs {
     | "Cancun"
     | "Prague"
     | "Osaka"
+    | "Karst"
     | "Latest"
     | undefined;
   /**

--- a/packages/test/src/vitest.test.ts
+++ b/packages/test/src/vitest.test.ts
@@ -153,6 +153,8 @@ describe("createViemTest", () => {
   );
 
   afterAll(() => {
+    const [transport] = createAnvilTestClientMock.mock.calls[0]!;
+    expect(transport({ chain: mainnet }).config.retryCount).toBe(0);
     expect(spawnedProcesses).toBe(4);
     expect(retryProcesses).toBe(2);
     expect(retryBodies).toBe(2);

--- a/packages/test/src/vitest.test.ts
+++ b/packages/test/src/vitest.test.ts
@@ -28,7 +28,9 @@ let peakActiveProcesses = 0;
 let spawnedProcesses = 0;
 let retryBodies = 0;
 let retryProcesses = 0;
+let timeoutProcesses = 0;
 const retryForkBlockNumber = 1n;
+const timeoutForkBlockNumber = 2n;
 const fakeClient = {
   account: { address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" },
   getCode: vi.fn().mockResolvedValue(undefined),
@@ -47,6 +49,15 @@ spawnAnvilMock.mockImplementation(async (parameters) => {
           throw new AnvilProcessError("Anvil exited unexpectedly");
         return true;
       },
+    };
+  }
+
+  if (parameters.forkBlockNumber === timeoutForkBlockNumber) {
+    timeoutProcesses += 1;
+    return {
+      rpcUrl: "http://localhost:32003" as const,
+      stop: () => true,
+      stopAndWait: async () => true,
     };
   }
 
@@ -77,6 +88,10 @@ const extendedViemTest = viemTest.extend<{ readonly label: string }>({
 });
 const retryViemTest = createViemTest(mainnet, {
   forkBlockNumber: retryForkBlockNumber,
+  forkUrl: "https://rpc.example",
+});
+const timeoutViemTest = createViemTest(mainnet, {
+  forkBlockNumber: timeoutForkBlockNumber,
   forkUrl: "https://rpc.example",
 });
 
@@ -128,10 +143,20 @@ describe("createViemTest", () => {
     },
   );
 
+  timeoutViemTest(
+    "error: does not retry a timed-out fixture context",
+    { fails: true, timeout: 10 },
+    async ({ client }) => {
+      expect(client).toBe(fakeClient);
+      await new Promise<never>(() => {});
+    },
+  );
+
   afterAll(() => {
     expect(spawnedProcesses).toBe(4);
     expect(retryProcesses).toBe(2);
     expect(retryBodies).toBe(2);
+    expect(timeoutProcesses).toBe(1);
     expect(peakActiveProcesses).toBe(4);
     expect(activeProcesses).toBe(0);
   });

--- a/packages/test/src/vitest.ts
+++ b/packages/test/src/vitest.ts
@@ -117,9 +117,7 @@ export const createViemTest = <chain extends Chain>(
           stopAndWait = anvil.stopAndWait;
           const client = createAnvilTestClient(
             http(anvil.rpcUrl, {
-              fetchOptions: {
-                cache: "force-cache",
-              },
+              retryCount: 0,
               timeout: 30_000,
             }),
             chain,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "vitest/config";
 
-// Fork projects get extra time for Anvil startup and remote RPC reads.
+// Queue fork tests before their timeout starts while keeping pure tests unconstrained.
 const forkTestConfig = {
+  ...(process.env.CI
+    ? {
+        maxConcurrency: 1,
+        sequence: { groupOrder: 1 }, // Separate from unconstrained unit projects.
+      }
+    : {}),
   testTimeout: 120_000,
 } as const;
 
@@ -35,7 +41,12 @@ export default defineConfig({
       concurrent: !process.env.CI,
     },
     globalSetup: "vitest.setup.ts",
-    retry: process.env.CI ? 2 : 0,
+    retry: process.env.CI
+      ? {
+          count: 2,
+          condition: /^(?!(?:Test|Hook) timed out in \d+ms\.)/,
+        }
+      : 0,
     testTimeout: 30_000,
     projects: [
       {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ const forkTestConfig = {
   ...(process.env.CI
     ? {
         maxConcurrency: 1,
+        maxWorkers: 2,
         sequence: { concurrent: false, groupOrder: 1 },
       }
     : {}),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from "vitest/config";
 
-// Queue fork tests before their timeout starts while keeping pure tests unconstrained.
+// Bound fork RPC demand in CI while leaving local concurrency unrestricted.
 const forkTestConfig = {
   ...(process.env.CI
     ? {
         maxConcurrency: 1,
-        sequence: { groupOrder: 1 }, // Separate from unconstrained unit projects.
+        sequence: { concurrent: false, groupOrder: 1 },
       }
     : {}),
   testTimeout: 120_000,


### PR DESCRIPTION
## Summary

- use the lowest observed-failure CI setting: maxConcurrency 1 with no explicit worker cap
- keep local Vitest worker and concurrency defaults unrestricted
- cap package shards at two and serialize Test workflow calls through a retained GitHub queue
- stop retrying timed-out Vitest contexts while retaining retries for Anvil and RPC failures
- disable redundant retries and POST caching on the localhost Anvil transport
- save Foundry caches only after successful tests

## Validation

- CI-mode @morpho-org/test suite passed: 64 passed, 1 intentional timeout case
- package build passed on the complete stack

## Stack

1. #940 — chain time
2. #944 — Anvil lifecycle
3. #942 — test layout
4. #941 — fork workload limits
5. #943 — failure reports