### PR TITLE
fix(test): drop Osaka hardfork pin from Midnight fork test

### DIFF
--- a/packages/morpho-sdk/test/actions/midnight/requirements.integration.test.ts
+++ b/packages/morpho-sdk/test/actions/midnight/requirements.integration.test.ts
@@ -36,7 +36,6 @@ import {
 const test = createViemTest(base, {
   forkUrl: process.env.BASE_RPC_URL,
   forkBlockNumber: 48_287_000n,
-  hardfork: "Osaka",
   stepsTracing: false,
 });
 


### PR DESCRIPTION
## Problem

`test / vitest` fails because the whole Midnight requirements suite (`packages/morpho-sdk/test/actions/midnight/requirements.integration.test.ts`) errors at Anvil startup:

```
AnvilStartupError: Anvil exited before listening on port "auto" (code 1).
Error: hardfork `Osaka` conflicts with network config `optimism`
```

The test forks **Base** (OP-stack), so Anvil applies the `optimism` network config — and the test also pinned `hardfork: "Osaka"`, which Anvil rejects on that config. Anvil never binds, so `client` is `undefined` and every test in the file throws cascading `Cannot read properties of undefined`.

## Fix

Drop the `hardfork: "Osaka"` pin (added in #942 — the only one in the repo) so Anvil picks the fork's native OP-stack hardfork, matching every other Base fork test, including `midnight-sdk/test/e2e/setup.ts` (same chain, same block `48_287_000n`, no pin).

Verified with Anvil 1.5.0: `anvil --optimism --hardfork Osaka` errors; `anvil --optimism` binds cleanly.

## Effect on CI (measured)

The file went from **crashing entirely** to running: **248 pass, 2 fail**.

⚠️ The 2 remaining failures are **NOT fixed by this PR and are unrelated to it**: `executes supply-collateral and take-borrow outputs` and `executes supply-collateral-take-borrow and repay outputs` revert on-chain with `custom error 0x5e71e7fb` = **`OutOfOffers()`** from `MidnightBundlesV1` (the take-borrow `buildTx` call to `midnightBundles`). That is a genuine Midnight take-borrow test/SDK correctness issue shipped **untested** by #942 (the Osaka crash had always masked it) — it needs the Midnight owner, not a hardfork change.

So this PR is a strict improvement (turns a hard crash that hides everything into a clean run surfacing one real, actionable revert) but does **not** by itself make the job green. See the `OutOfOffers()` follow-up.

## Scope

Tests-only — no runtime source, no changeset (root §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)