### PR TITLE
docs(evm-simulation): document gas/balance simulation-fidelity limit (Cantina 1631)

### DIFF
--- a/.changeset/evm-simulation-gas-fidelity-limit.md
+++ b/.changeset/evm-simulation-gas-fidelity-limit.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/evm-simulation": patch
+---
+
+Document the gas-cost and sender-balance fidelity limit of `simulate()` and its bundler-retention guard (Cantina finding 1631). Simulation overrides the sender's native balance to `maxUint256 / 2` and models no gas price, so a step that reverts on-chain only because of the caller's real post-gas native balance still succeeds in simulation; if that step is `skipRevert: true`, `BlacklistViolationError` does not fire even though earlier funds are stranded on-chain. JSDoc, README, and package conventions now state the invariant integrators must uphold — keep native/value-carrying steps `skipRevert: false`. No behavior change.

--- a/packages/evm-simulation/AGENTS.md
+++ b/packages/evm-simulation/AGENTS.md
@@ -5,7 +5,7 @@
 - Let `SimulationRevertedError` propagate; a revert belongs to the bundle, not the backend.
 - Keep backend outputs normalized to `RawSimulationResult`; add new backends under `src/simulate/backends/` with colocated parity tests.
 - Encode signature authorizations as `approve(spender, amount ?? maxUint256)` and prepend them to the simulated bundle.
-- Enforce bundler retention by net `(bundler3 address, token)` balance with `DUST_THRESHOLD = 100n`; skip only unknown blue-sdk chains.
+- Enforce bundler retention by net `(bundler3 address, token)` balance with `DUST_THRESHOLD = 100n`; skip only unknown blue-sdk chains. This runs on the *simulated* bundle, which overrides sender balance to `maxUint256 / 2` and models no gas price, so it cannot catch a `skipRevert: true` step that reverts on-chain only because of real post-gas native balance (Cantina 1631) — builders keep every native/value-carrying step `skipRevert: false` so the bundle reverts atomically instead.
 - Keep all thrown domain errors under `SimulationPackageError`; only `ExternalServiceError` is bypassable by callers.
 - Add chains through caller `SimulationConfig.chains`; the per-chain `ChainSimulationConfig` is a discriminated union enforcing at least one of `tenderlyRpc` or `simulateV1Url`. Confirm blue-sdk bundler addresses intentionally.
 - Keep unit tests colocated as `{module}.test.ts`; put shared unit fixtures in `src/test-helpers/`, which must stay out of published builds. Keep fork tests under `test/` as `*.integration.test.ts`.

--- a/packages/evm-simulation/README.md
+++ b/packages/evm-simulation/README.md
@@ -52,6 +52,14 @@ try {
 
 Each chain entry must declare at least one backend — `tenderlyRpc` (primary), `simulateV1Url` (fallback), or both. The type system enforces this.
 
+### Simulation fidelity: gas cost & sender balance
+
+Every backend runs the bundle with the sender's native balance overridden to `maxUint256 / 2` and **no gas price** (`SimulationTransaction` cannot express one). This is deliberate — it suppresses false "insufficient funds for gas" reverts for wallets low on the native token — but it has a consequence:
+
+> A bundle step that reverts on-chain **only because** the caller's real, post-gas native balance is too low still **succeeds in simulation**. If that step is encoded with `skipRevert: true`, Bundler3 continues past it on-chain and any funds routed to `bundler3` by earlier steps are stranded — and `BlacklistViolationError` will **not** have fired, because the simulated run retained nothing (Cantina finding 1631).
+
+The Morpho builders (`@morpho-org/morpho-sdk`) avoid this by keeping every native/value-carrying step `skipRevert: false`, so any such bundle reverts atomically rather than silently skipping a step. **Integrators composing raw bundles must uphold the same invariant**, and may additionally keep an on-chain native reserve for gas. `simulate()` is a preview and a retention safety-net, not a guarantee of on-chain success.
+
 ### API surface
 
 All symbols below are re-exported from the package root.

--- a/packages/evm-simulation/src/errors.ts
+++ b/packages/evm-simulation/src/errors.ts
@@ -30,7 +30,18 @@ interface RetainedAsset {
   netRetained: string;
 }
 
-/** Funds would flow to bundler3 contract addresses. Never bypassable. */
+/**
+ * Funds would flow to bundler3 contract addresses. Never bypassable.
+ *
+ * @remarks
+ * The guard proves this for the *simulated* run only. Simulation overrides the
+ * sender's native balance to `maxUint256 / 2` and models no gas price, so it
+ * cannot detect a step that reverts on-chain *only because* the caller's real,
+ * post-gas native balance is too low; when that step carries `skipRevert: true`
+ * the on-chain revert is swallowed and earlier funds are stranded without this
+ * error firing (Cantina finding 1631). Keep native/value-carrying steps
+ * `skipRevert: false` so such a bundle reverts atomically instead.
+ */
 export class BlacklistViolationError extends SimulationPackageError {
   readonly code = "BLACKLIST_ERROR";
 

--- a/packages/evm-simulation/src/simulate/pipeline/bundler-retention.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/bundler-retention.ts
@@ -95,6 +95,16 @@ interface AssertNoBundlerRetentionParams {
  * native move exists both as a synthetic `ethAddress` transfer log *and* in the
  * `assetChanges` derived from it — native transfer logs are only used as a
  * fallback for bundler addresses that carry no native `assetChanges` entry.
+ *
+ * **Known limitation (Cantina finding 1631).** This check runs on the simulated
+ * bundle, which executes with the sender's native balance overridden to
+ * `maxUint256 / 2` and no gas price. A step that succeeds here but reverts
+ * on-chain *only because* the caller's real, post-gas native balance is too low
+ * therefore evades this guard: if that step is `skipRevert: true`, Bundler3
+ * skips it on-chain and earlier funds are stranded while this simulation
+ * reports none retained. The Morpho builders keep native/value-carrying steps
+ * `skipRevert: false` so no such divergence exists; raw-bundle callers must do
+ * the same.
  */
 export function assertNoBundlerRetention(
   params: AssertNoBundlerRetentionParams,

--- a/packages/evm-simulation/src/simulate/simulate.ts
+++ b/packages/evm-simulation/src/simulate/simulate.ts
@@ -31,6 +31,22 @@ import {
  * - `transfers[k].txIdx` → index into `simulationTxs` of the tx that emitted the
  *   underlying log; consumers map back via `simulationTxs[transfer.txIdx]`.
  *
+ * @remarks
+ * **Simulation fidelity — gas cost & sender balance.** Every backend runs the
+ * bundle with the sender's native balance overridden to `maxUint256 / 2` and
+ * with no gas price (`SimulationTransaction` cannot express one). This
+ * deliberately suppresses false "insufficient funds for gas" reverts, but it
+ * also means the simulation cannot observe a step that reverts on-chain *only
+ * because* the caller's real, post-gas native balance is too low. If such a
+ * step is encoded with `skipRevert: true`, Bundler3 continues past it on-chain
+ * and any funds routed to a `bundler3` address by earlier steps are stranded —
+ * a case the retention guard behind `BlacklistViolationError` cannot
+ * flag, because the step succeeds in simulation (Cantina finding 1631). The
+ * Morpho builders avoid this by keeping every native/value-carrying step
+ * `skipRevert: false` so the bundle reverts atomically; integrators composing
+ * raw bundles must uphold the same invariant, and may additionally reserve
+ * on-chain native value for gas.
+ *
  * @param config - Backend configuration: per-chain Tenderly RPC and/or `eth_simulateV1`
  *   URL, optional logger, and the overall timeout budget.
  * @param params - Per-call simulation input.


### PR DESCRIPTION
## What & why

Response to **Cantina finding #1631** (severity: *low*):

> The SDK ignores the gas-price fee when simulating. If it simulates a step with `skipRevert = true`, gas price is 0 and everything works in simulation, but on-chain the gas price is > 0 and *because of that* the step reverts. Since `skipRevert` is true, any tokens previously sent to the bundler are left there (where anyone can take them). This is only a new issue if the revert is caused by the gas price being nonzero.

**The premise is accurate about the simulator.** Both backends run the bundle with the sender's native balance overridden to `maxUint256 / 2` and **no gas price** (`SimulationTransaction` can't express one):

- `src/simulate/backends/eth-simulate-v1.ts` → `simulateCalls({ …, stateOverrides: [{ address: sender, balance: maxUint256 / 2n }] })`, calls are `{to,data,value}` only.
- `src/simulate/backends/tenderly-rpc.ts` → `buildStateOverrides` sets `balance: maxUint256/2`, `buildCall` emits no gas fields.

So a step that reverts on-chain **only because** the caller's real, post-gas native balance is too low still succeeds in simulation. If that step is `skipRevert: true`, Bundler3 skips it on-chain and earlier-routed funds are stranded — and `assertNoBundlerRetention` / `BlacklistViolationError` (the fix for sibling finding #1440) **can't** flag it, because it runs on the simulated result where the step succeeded.

## Why this is *documentation*, not a behavior change

- **Not exploitable through the SDK's shipped high-level flows today.** `@morpho-org/morpho-sdk` keeps every native/value-carrying step (`nativeTransfer`, `wrapNative`, vault deposits) `skipRevert: false`, so such a bundle reverts atomically. The only `skipRevert: true` steps are `permit` / `approve2` / `setAuthorizationWithSig` (all `value: 0n`) and the refinance shares-mode sweep-repay (depends on an ERC-20 residual, not native/gas). None can be flipped by gas price.
- **A real behavioral "fix" would regress deliberate design.** The `maxUint256/2` balance override exists specifically to suppress false "insufficient funds for gas" reverts (added in #803). Modeling gas realistically means *not* inflating the balance, which reintroduces exactly those false reverts — a net-negative trade for a low-severity, largely-inherent limitation. The simulator also can't inspect `skipRevert`: it sees only the top-level tx to bundler3; the per-step flags are opaque bytes inside the multicall calldata.

The correct, proportionate response is therefore to **make the limitation and the invariant explicit**, so integrators composing raw bundles don't over-trust the retention safety-net.

## Changes (docs only)

- `simulate()` JSDoc — `@remarks` describing the gas/balance fidelity limit.
- `BlacklistViolationError` JSDoc — qualifies "Never bypassable" with the simulated-run boundary.
- `assertNoBundlerRetention` JSDoc — known-limitation note (companions the existing #1440 note).
- `README.md` — new "Simulation fidelity: gas cost & sender balance" section.
- `AGENTS.md` — caveat on the retention convention bullet.
- Patch changeset (JSDoc/docs on published API surface; drop if you'd rather not cut a release for docs).

Typecheck + Biome clean. No source behavior changes, no test changes.

## Suggested follow-up (separate PR)

Per root `AGENTS.md` §5 ("security invariants are tests"), pin the property that keeps this non-exploitable — a `morpho-sdk` test asserting no first-party bundle emits a `value > 0` inner call with `skipRevert: true`. Kept out of this PR to respect one-concern-per-PR; happy to open it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)