### PR TITLE
fix(morpho-ts): correct malformed explorer URLs in chain metadata

### DIFF
--- a/.changeset/fix-arc-explorer-url.md
+++ b/.changeset/fix-arc-explorer-url.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/morpho-ts": patch
+---
+
+Fix malformed `explorerUrl` values in `ChainUtils.CHAIN_METADATA`. Arc mainnet (5042) pointed at `http://explorer.arc.io/`, the only non-HTTPS explorer of the 43 registered chains, so every link built from it was an insecure navigation out of an HTTPS app. It is now `https://explorer.arc.io`. The trailing slash is also dropped from Tac, Celo, Abstract and Soneium so all 43 entries match the bare-origin convention and consumers concatenating `/tx/<hash>` or `/address/<addr>` no longer produce a double slash.

--- a/packages/blue-sdk/src/chain.test.ts
+++ b/packages/blue-sdk/src/chain.test.ts
@@ -103,7 +103,7 @@ describe("ChainUtils explorer URL helpers", () => {
       5_042,
       {
         name: "Arc",
-        explorerUrl: "http://explorer.arc.io/",
+        explorerUrl: "https://explorer.arc.io",
         identifier: "arc",
         nativeCurrency: { name: "USDC", symbol: "USDC", decimals: 18 },
       },

--- a/packages/morpho-ts/src/chain.test.ts
+++ b/packages/morpho-ts/src/chain.test.ts
@@ -103,7 +103,7 @@ describe("ChainUtils explorer URL helpers", () => {
       5_042,
       {
         name: "Arc",
-        explorerUrl: "http://explorer.arc.io/",
+        explorerUrl: "https://explorer.arc.io",
         identifier: "arc",
         nativeCurrency: { name: "USDC", symbol: "USDC", decimals: 18 },
       },

--- a/packages/morpho-ts/src/chain.ts
+++ b/packages/morpho-ts/src/chain.ts
@@ -284,7 +284,7 @@ export namespace ChainUtils {
       name: "TAC",
       id: ChainId.TacMainnet,
       nativeCurrency: { name: "TAC", symbol: "TAC", decimals: 18 },
-      explorerUrl: "https://explorer.tac.build/",
+      explorerUrl: "https://explorer.tac.build",
       identifier: "tac",
     },
     [ChainId.LiskMainnet]: {
@@ -347,14 +347,14 @@ export namespace ChainUtils {
       name: "Celo",
       id: ChainId.CeloMainnet,
       nativeCurrency: { name: "Celo", symbol: "CELO", decimals: 18 },
-      explorerUrl: "https://celoscan.io/",
+      explorerUrl: "https://celoscan.io",
       identifier: "celo",
     },
     [ChainId.AbstractMainnet]: {
       name: "Abstract",
       id: ChainId.AbstractMainnet,
       nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-      explorerUrl: "https://abscan.org/",
+      explorerUrl: "https://abscan.org",
       identifier: "abstract",
     },
     [ChainId.BitlayerMainnet]: {
@@ -375,7 +375,7 @@ export namespace ChainUtils {
       name: "Soneium",
       id: ChainId.SoneiumMainnet,
       nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-      explorerUrl: "https://soneium.blockscout.com/",
+      explorerUrl: "https://soneium.blockscout.com",
       identifier: "soneium",
     },
     [ChainId.TempoMainnet]: {
@@ -432,7 +432,7 @@ export namespace ChainUtils {
       name: "Arc",
       id: ChainId.ArcMainnet,
       nativeCurrency: { name: "USDC", symbol: "USDC", decimals: 18 },
-      explorerUrl: "http://explorer.arc.io/",
+      explorerUrl: "https://explorer.arc.io",
       identifier: "arc",
     },
     [ChainId.MorphMainnet]: {


### PR DESCRIPTION
## Motivation

`ChainUtils.CHAIN_METADATA` is the source of truth consumers use to build explorer links, via `ChainUtils.getExplorerTransactionUrl` / `getExplorerAddressUrl` (`<explorerUrl>/tx/<hash>`, `<explorerUrl>/address/<addr>`). Five of the 43 registered entries are malformed, so consumers cannot fix them app-side.

Arc mainnet (5042) is the real bug: `http://explorer.arc.io/` is the only non-HTTPS explorer in the registry, which makes every Arc explorer link an insecure navigation out of an HTTPS app. Verified in a Morpho consumer app, where the rendered href is literally `http://explorer.arc.io//address/0x8E357432CC12ff425c36432F312968aEb16112AF`.

The four trailing slashes are cosmetic — Blockscout and Etherscan tolerate the resulting `//tx/...` — but they are inconsistent with the 38 entries that already store a bare origin.

## Solution

- `ArcMainnet`: `http://explorer.arc.io/` → `https://explorer.arc.io`. The host is unchanged and confirmed correct; `explorer.arc.io` is behind a login until the Arc mainnet launch, then public.
- Drop the trailing slash on `TacMainnet`, `CeloMainnet`, `AbstractMainnet` and `SoneiumMainnet`, aligning all 43 entries on the bare-origin convention (`RobinhoodMainnet: "https://robinhoodchain.blockscout.com"` is the closest structural sibling).
- Update the two metadata assertions that pinned the old Arc value (`packages/morpho-ts/src/chain.test.ts`, `packages/blue-sdk/src/chain.test.ts`). A repo-wide grep confirms those are the only assertions on any of the five changed values.

Patch changeset on `@morpho-org/morpho-ts` only: `@morpho-org/blue-sdk` re-exports `ChainUtils` from it, and every direct dependent already declares a `workspace:^` dependency or a peer range (`^2.7.0` / `^2.8.0` / `^2.10.0`) that admits a patch bump, so no dependent bump or peer-range edit is required.

## Verification

- `pnpm lint` — clean (Biome 701 files, JSDoc self-check 41/41, checksum-address lint).
- `pnpm build` — all packages build.
- `npx vitest run packages/morpho-ts/src/chain.test.ts packages/blue-sdk/src/chain.test.ts` — 31/31 pass.
- Broader `packages/morpho-ts packages/blue-sdk` run: 71 files pass, 2 `blue-sdk-viem` fork integration files fail on public-RPC `429 over rate limit`. Environmental, unrelated to this diff (no code path touched).

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
