### PR TITLE
feat(morpho-sdk): deprecate Vault V1 shared-liquidity reallocations (prerequisite minor)

### DIFF
--- a/.changeset/deprecate-v1-blue-reallocations.md
+++ b/.changeset/deprecate-v1-blue-reallocations.md
@@ -1,0 +1,9 @@
+---
+"@morpho-org/morpho-sdk": minor
+"@morpho-org/wdk-protocol-lending-morpho-evm": minor
+---
+
+Publish the pinned BlueBundlesV1 ABI and deprecate all Vault V1 shared-liquidity algorithm and
+Bundler3 composition surfaces in Morpho SDK, plus the WDK Vault V1 borrow input. Use Vault V2
+BluePublicAllocator reallocations for new integrations; all deprecated Vault V1 surfaces will be
+removed in the next major.

--- a/.changeset/permit2-signature-transfer-uint256.md
+++ b/.changeset/permit2-signature-transfer-uint256.md
@@ -1,0 +1,7 @@
+---
+"@morpho-org/blue-sdk-viem": patch
+"@morpho-org/morpho-sdk": patch
+---
+
+Clamp Permit2 SignatureTransfer allowances to the full uint256 range instead of the uint160
+AllowanceTransfer limit.

--- a/docs/tibs/TIB-2026-08-28-retire-vault-v1-shared-liquidity.md
+++ b/docs/tibs/TIB-2026-08-28-retire-vault-v1-shared-liquidity.md
@@ -1,0 +1,95 @@
+# TIB-2026-08-28: Retire Vault V1 shared liquidity
+
+| Field          | Value                                                            |
+| -------------- | ---------------------------------------------------------------- |
+| **Status**     | Proposed                                                         |
+| **Date**       | 2026-08-28                                                       |
+| **Author**     | @Rubilmax                                                        |
+| **Scope**      | Packages: `morpho-sdk`, `wdk-protocol-lending-morpho-evm`       |
+| **Supersedes** | TIB-2026-08-25 Vault V1 planning and composition retention only |
+
+---
+
+## Context
+
+[`TIB-2026-08-25`](./TIB-2026-08-25-blue-bundles-v1-sdk-actions.md) keeps Vault V1
+shared-liquidity planning data and low-level Bundler3 composition after high-level Blue writes move
+to BlueBundlesV1. That retention leaves two allocator models in the public SDK even though Vault V2
+BluePublicAllocator is the supported successor.
+
+The next `morpho-sdk` major should remove the obsolete Vault V1 algorithm rather than preserve a
+second planning and composition path indefinitely. The removal needs a published deprecation minor
+first under the repository's package lifecycle rules.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Give every consumer of the Vault V1 shared-liquidity algorithm a deprecation warning before the
+  next major.
+- Make Vault V2 BluePublicAllocator the only shared-liquidity model in the next major.
+- Keep the previous `morpho-sdk` major available for integrations that still require PublicAllocator
+  V1.
+
+**Non-Goals**
+
+- Remove Vault V1 deposits, withdrawals, redemptions, migrations, or in-kind exits.
+- Remove raw Vault V1 protocol ABI, address, fetch, or config exports from their protocol packages.
+- Remove unrelated Bundler3 primitives.
+
+## Current Solution
+
+`morpho-sdk` exposes Vault V1 reallocations through high-level Blue inputs, state and planner
+classes, free helpers, validators, V1-only types and errors, and
+`BundlerAction.publicAllocatorReallocateTo`. The WDK adapter also accepts Vault V1 reallocations in
+its legacy borrow options. `liquidity-sdk-viem` consumes the same V1 planner through its
+`morpho-sdk` 5 peer range.
+
+## Proposed Solution
+
+Publish one prerequisite minor that deprecates every public `morpho-sdk` symbol whose sole purpose
+is Vault V1 shared-liquidity planning or PublicAllocator composition, including:
+
+- the Vault V1 branch accepted by high-level Blue reallocation inputs;
+- `VaultV1ReallocationData`, its input shape, planner methods, metrics, and compatibility aliases;
+- V1 planner options, intermediate and action-ready reallocation types, free helpers, validators,
+  and V1-only errors;
+- `InputReallocation`, `ActionArgs.reallocateTo`, and
+  `BundlerAction.publicAllocatorReallocateTo`;
+- the WDK Vault V1 borrow-reallocation input.
+
+Keep these symbols functional for the deprecation minor. Remove them in the next `morpho-sdk` and
+WDK majors, and make high-level Blue reallocation inputs accept Vault V2 only. Raw protocol
+surfaces remain available because this decision retires the SDK algorithm, not the deployed
+contract.
+
+Do not widen `liquidity-sdk-viem`'s peer range to the next `morpho-sdk` major while it depends on the
+removed V1 planner. Its existing release remains available with `morpho-sdk` 5 unless a separate
+decision migrates it to Vault V2.
+
+## Considered Alternatives
+
+### Deprecate only high-level Blue inputs
+
+Keep V1 planning and manual Bundler3 composition as advanced APIs.
+
+**Why rejected:** Those APIs preserve the unsupported algorithm and imply an ongoing compatibility
+commitment after Vault V2 becomes the only high-level route.
+
+### Remove the V1 surface immediately
+
+Delete the algorithm in the BlueBundlesV1 major without a prior minor.
+
+**Why rejected:** Vault V1 reallocations are outside the narrow route-migration exception and must
+follow the repository's published deprecation lifecycle.
+
+## Assumptions & Constraints
+
+- The deprecation minor must publish before the BlueBundlesV1 major.
+- Vault V2 BluePublicAllocator remains the supported shared-liquidity successor.
+- Previous package majors remain installable for integrations that require Vault V1 reallocations.
+
+## References
+
+- [TIB-2026-08-25: Route Blue actions through BlueBundlesV1](./TIB-2026-08-25-blue-bundles-v1-sdk-actions.md)
+- [TIB-2026-08-18: Vault V2 Blue reallocation API](./TIB-2026-08-18-vault-v2-blue-reallocation-api.md)

--- a/packages/blue-sdk-viem/src/signatures/permit2.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit2.ts
@@ -145,7 +145,7 @@ export const getPermit2TransferFromTypedData = (
     message: {
       permitted: {
         token: args.erc20,
-        amount: MathLib.min(args.allowance, MathLib.MAX_UINT_160),
+        amount: MathLib.min(args.allowance, MathLib.MAX_UINT_256),
       },
       spender: args.spender,
       nonce: args.nonce,

--- a/packages/blue-sdk-viem/src/signatures/signatures.test.ts
+++ b/packages/blue-sdk-viem/src/signatures/signatures.test.ts
@@ -176,11 +176,11 @@ describe("getPermit2PermitTypedData", () => {
 });
 
 describe("getPermit2TransferFromTypedData", () => {
-  test("clamps transfer allowance to MAX_UINT_160", () => {
+  test("clamps transfer allowance to MAX_UINT_256", () => {
     const typedData = getPermit2TransferFromTypedData(
       {
         erc20: TOKEN,
-        allowance: MathLib.MAX_UINT_160 + 1n,
+        allowance: MathLib.MAX_UINT_256 + 1n,
         nonce: 14n,
         deadline: 15n,
         spender: SPENDER,
@@ -189,7 +189,7 @@ describe("getPermit2TransferFromTypedData", () => {
     );
 
     expect(typedData.message).toEqual({
-      permitted: { token: TOKEN, amount: MathLib.MAX_UINT_160 },
+      permitted: { token: TOKEN, amount: MathLib.MAX_UINT_256 },
       spender: SPENDER,
       nonce: 14n,
       deadline: 15n,

--- a/packages/morpho-sdk/AGENTS.md
+++ b/packages/morpho-sdk/AGENTS.md
@@ -10,6 +10,9 @@ Transaction builders for VaultV1, VaultV2, Blue, and Midnight, plus shared requi
 
 - **VaultV1 / VaultV2 deposits** route through bundler3 via GeneralAdapter1 (which enforces `maxSharePrice`, protecting against inflation attacks). VaultV1/V2 `withdraw` and `redeem` are direct vault calls. VaultV2 `forceWithdraw` / `forceRedeem` use `multicall` with `forceDeallocate` calls before the final withdraw/redeem. VaultV1/V2 `inKindRedeem` handles validate their supplied snapshots eagerly and call the standalone VaultExitBundlesV1 periphery directly. Their optional RPC-backed pre-flight checks run only when the caller awaits `getRequirements()`; the pure actions and `buildTx()` remain synchronous and can encode without those reads.
 - **Blue bundled paths** (`supply`, `supplyCollateral`, `borrow`, `supplyCollateralBorrow`, `repay`, `repayWithdrawCollateral`, `withdraw`) route through bundler3 via GeneralAdapter1. `repay` and `withdraw` each accept assets or shares (mutually exclusive); `repayWithdrawCollateral` repays first then withdraws. Loan-asset `supply`, `repay`, and `repayWithdrawCollateral` support native wrapping when `loanToken === wNative` (repay assets mode is additive like supply; repay shares mode carves native out of the transfer); loan-asset `withdraw` supports optional PublicAllocator reallocations to top up market liquidity (same mechanism as `borrow`).
+- **Blue reallocation migration** — all SDK surfaces for the Vault V1 shared-liquidity algorithm
+  and its PublicAllocator Bundler3 composition are deprecated and will be removed in the next
+  major. Use Vault V2 BluePublicAllocator reallocations.
 - **Midnight paths** expose lazy action outputs under `client.morpho.midnight(chainId)`. Fixed-rate market taker flows route through Midnight Bundles, direct collateral supply/cancel/redeem route through Midnight, and maker flows return ratify-root requirements plus the mempool payload transaction. Requirement helpers under `src/actions/requirements/midnight` resolve Midnight authorization, Setter ratify-root, and token-pull requirements.
 - **Bundle composition, native wrapping, and reallocation rules** are canonical in [`src/actions/AGENTS.md`](./src/actions/AGENTS.md).
 
@@ -31,7 +34,12 @@ Protocol terms used across this package's docs and JSDoc:
 - **PublicAllocator V1** — MetaMorpho allocator that moves liquidity from one or more sorted source markets into a target via `reallocateTo(...)`; each call pays one `fee`.
 - **BluePublicAllocator** — the single canonical Vault V2 allocator registered per chain, which moves one source market or vault idle liquidity into the enclosing Blue action's target market via `reallocate(...)` or `allocateFromIdle(...)`. The caller supplies adapter addresses; the SDK resolves the allocator from the chain registry. Each call passes the vault's configured WAD-scaled `uint64 penalty`; the allocator pulls `ceil(assets × penalty / WAD)` of the target loan token from Bundler3 and donates it directly to the vault. Its canonical ABI export is `vaultV2BluePublicAllocatorAbi`.
 - **VaultExitBundlesV1** — standalone periphery for exiting an illiquid VaultV1 or single-adapter VaultV2 into idle underlying assets and/or Morpho Blue supply positions.
-- **Shared-liquidity naming** — `VaultV1ReallocationData`, `InputVaultV1ReallocationData`, and `VaultV1Reallocation` are canonical for PublicAllocator V1; `ReallocationData`, `InputReallocationData`, and `VaultReallocation` remain their deprecated aliases. The free helper `computeVaultV1Reallocations` replaces deprecated `computeReallocations`. The instance method `VaultV1ReallocationData.computeVaultV1Reallocations` replaces deprecated `getMarketPublicReallocations`. `MorphoBlue.getVaultV1ReallocationData` is the canonical V1 fetcher; unversioned `getReallocationData` is its deprecated alias. `MorphoBlue.getVaultV2BlueReallocationData` fetches the Blue-specific V2 snapshot. `VaultV2BlueReallocationData.computeVaultV2BlueReallocations` discovers every friendly call by default or accepts an optional operation to produce an amount-aware plan; both modes return flat, action-ready `VaultV2BlueReallocation` calls and their simulated state.
+- **Shared-liquidity migration** — every PublicAllocator V1 planning, data, input, validation, and
+  Bundler3-composition symbol is deprecated and will be removed in the next major. The successor is
+  `MorphoBlue.getVaultV2BlueReallocationData` plus
+  `VaultV2BlueReallocationData.computeVaultV2BlueReallocations`, which return flat, action-ready
+  `VaultV2BlueReallocation` calls and their simulated state. Raw protocol ABI, address, fetch, and
+  config exports are not part of this SDK-algorithm deprecation.
 
 ### Bundler actions
 
@@ -43,7 +51,8 @@ The action verbs an integrator sees in the bundle (`BundlerAction.encode...`):
 - **`erc20TransferFrom`** — pulls user-approved tokens into the bundler.
 - **`nativeTransfer` + `wrapNative`** — pair that converts an attached native amount (`tx.value`) into the chain's wNative for a deposit/supply path.
 - **`forceDeallocate`** — VaultV2 multicall entry that pulls liquidity out of a specific adapter before withdraw/redeem.
-- **`reallocateTo`** — PublicAllocator V1 call that shifts liquidity from sorted source markets into the target market.
+- **`reallocateTo`** — deprecated PublicAllocator V1 call that shifts liquidity from sorted source
+  markets into the target market; removed from the SDK in the next major.
 - **`vaultV2BluePublicAllocatorReallocate` / `vaultV2BluePublicAllocatorAllocateFromIdle`** — BluePublicAllocator calls that move one market source or vault idle liquidity into the enclosing Blue action's target market. Both target the chain's registered allocator, approve the exact loan-token penalty from Bundler3, and carry the configured penalty rate in calldata.
 
 ### Constants and conventions

--- a/packages/morpho-sdk/BUNDLER3.md
+++ b/packages/morpho-sdk/BUNDLER3.md
@@ -20,6 +20,9 @@ Instead of exposing the user directly to target contracts (ERC-4626 vault, Morph
 Bundler3 also calls allocator contracts directly for shared liquidity: `reallocateTo` on Public
 Allocator V1 and `reallocate` or `allocateFromIdle` on Blue Public Allocator.
 
+PublicAllocator V1 composition is deprecated and will be removed from the SDK in the next major.
+Use Vault V2 BluePublicAllocator actions for new integrations.
+
 The spender of every **user-supplied** approval / permit / permit2 is `generalAdapter1`, never the vault or Morpho directly. Blue Public Allocator penalties add a separate internal allowance: Bundler3 approves the allocator for each exact penalty amount immediately before the non-skippable allocator call. See [`getGeneralAdapterRequirements`](src/actions/requirements/generalAdapter/getGeneralAdapterRequirements.ts) and the "Requirements System" section of [ARCHITECTURE.md](ARCHITECTURE.md#requirements-system).
 
 ## Composability & modularity

--- a/packages/morpho-sdk/README.md
+++ b/packages/morpho-sdk/README.md
@@ -159,6 +159,10 @@ const tx = buildTx(signatures);
 
 The LLTV buffer guards against instant liquidation.
 
+> All SDK surfaces for the Vault V1 shared-liquidity algorithm and its PublicAllocator Bundler3
+> composition are deprecated and will be removed in the next major. Use Vault V2
+> BluePublicAllocator reallocations.
+
 ### Midnight: take a fixed-rate offer
 
 Protocol-specific names are qualified in shared facades, for example `fetchBluePosition` and `fetchMidnightPosition` from `@morpho-org/morpho-sdk/fetch`. Raw upstream names remain available under `/blue/{abis,addresses,constants,entities,errors,fetch,types,utils}` and `/midnight/{abis,constants,entities,errors,fetch,types,utils}`.

--- a/packages/morpho-sdk/src/abis.test.ts
+++ b/packages/morpho-sdk/src/abis.test.ts
@@ -1,0 +1,24 @@
+import { toFunctionSelector, toFunctionSignature } from "viem";
+import { describe, expect, test } from "vitest";
+import { blueBundlesV1Abi } from "./abis.js";
+
+describe("blueBundlesV1Abi", () => {
+  test("matches the selectors deployed at registered BlueBundlesV1 addresses", () => {
+    const selectors = Object.fromEntries(
+      blueBundlesV1Abi
+        .filter((item) => item.type === "function")
+        .map((item) => [
+          item.name,
+          toFunctionSelector(toFunctionSignature(item)),
+        ]),
+    );
+
+    expect(selectors).toMatchObject({
+      blueBundlesV1Supply: "0xa4d5ece4",
+      blueBundlesV1SupplyCollateralAndBorrow: "0xb1268765",
+      blueBundlesV1RepayAndWithdrawCollateral: "0x827d6bd8",
+      blueBundlesV1Withdraw: "0xc0229fe8",
+      blueBundlesV1MigrateBorrowPosition: "0x9834e387",
+    });
+  });
+});

--- a/packages/morpho-sdk/src/abis.ts
+++ b/packages/morpho-sdk/src/abis.ts
@@ -2148,3 +2148,741 @@ export const compoundV3MigrationAdapterAbi = [
     stateMutability: "nonpayable",
   },
 ] as const satisfies Abi;
+
+/**
+ * Pinned ABI JSON for the five BlueBundlesV1 entrypoints used by high-level Morpho Blue writes.
+ *
+ * Source: `morpho-org/bundles` commit `dceb05da1c730424e6b36caf445dff808a2d5007`,
+ * `src/blue/interfaces/IBlueBundlesV1.sol`, with `Signature` pinned by that commit's
+ * `morpho-blue` submodule at `1478e9cfe1b4d514f80682b3b60e4e12ff3ee45a` (`v` is `uint8`).
+ *
+ * @see https://github.com/morpho-org/bundles/blob/dceb05da1c730424e6b36caf445dff808a2d5007/src/blue/interfaces/IBlueBundlesV1.sol
+ * @example
+ * ```ts
+ * import { blueBundlesV1Abi } from "@morpho-org/morpho-sdk/abis";
+ *
+ * console.log(blueBundlesV1Abi.length);
+ * ```
+ */
+export const blueBundlesV1Abi = [
+  {
+    type: "function",
+    name: "blueBundlesV1SupplyCollateralAndBorrow",
+    stateMutability: "payable",
+    inputs: [
+      {
+        name: "marketParams",
+        type: "tuple",
+        components: [
+          {
+            name: "loanToken",
+            type: "address",
+          },
+          {
+            name: "collateralToken",
+            type: "address",
+          },
+          {
+            name: "oracle",
+            type: "address",
+          },
+          {
+            name: "irm",
+            type: "address",
+          },
+          {
+            name: "lltv",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "collateralAssets",
+        type: "uint256",
+      },
+      {
+        name: "borrowAssets",
+        type: "uint256",
+      },
+      {
+        name: "maxLtv",
+        type: "uint256",
+      },
+      {
+        name: "collateralPermit",
+        type: "tuple",
+        components: [
+          {
+            name: "kind",
+            type: "uint8",
+          },
+          {
+            name: "data",
+            type: "bytes",
+          },
+        ],
+      },
+      {
+        name: "signedAuthorization",
+        type: "tuple",
+        components: [
+          {
+            name: "signature",
+            type: "tuple",
+            components: [
+              {
+                name: "v",
+                type: "uint8",
+              },
+              {
+                name: "r",
+                type: "bytes32",
+              },
+              {
+                name: "s",
+                type: "bytes32",
+              },
+            ],
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+          },
+          {
+            name: "deadline",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "reallocations",
+        type: "tuple[]",
+        components: [
+          {
+            name: "vault",
+            type: "address",
+          },
+          {
+            name: "adapter",
+            type: "address",
+          },
+          {
+            name: "marketParams",
+            type: "tuple",
+            components: [
+              {
+                name: "loanToken",
+                type: "address",
+              },
+              {
+                name: "collateralToken",
+                type: "address",
+              },
+              {
+                name: "oracle",
+                type: "address",
+              },
+              {
+                name: "irm",
+                type: "address",
+              },
+              {
+                name: "lltv",
+                type: "uint256",
+              },
+            ],
+          },
+          {
+            name: "fromIdle",
+            type: "bool",
+          },
+          {
+            name: "sourceAdapter",
+            type: "address",
+          },
+          {
+            name: "sourceMarketParams",
+            type: "tuple",
+            components: [
+              {
+                name: "loanToken",
+                type: "address",
+              },
+              {
+                name: "collateralToken",
+                type: "address",
+              },
+              {
+                name: "oracle",
+                type: "address",
+              },
+              {
+                name: "irm",
+                type: "address",
+              },
+              {
+                name: "lltv",
+                type: "uint256",
+              },
+            ],
+          },
+          {
+            name: "assets",
+            type: "uint128",
+          },
+          {
+            name: "penalty",
+            type: "uint64",
+          },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+      },
+      {
+        name: "deadline",
+        type: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "blueBundlesV1RepayAndWithdrawCollateral",
+    stateMutability: "payable",
+    inputs: [
+      {
+        name: "marketParams",
+        type: "tuple",
+        components: [
+          {
+            name: "loanToken",
+            type: "address",
+          },
+          {
+            name: "collateralToken",
+            type: "address",
+          },
+          {
+            name: "oracle",
+            type: "address",
+          },
+          {
+            name: "irm",
+            type: "address",
+          },
+          {
+            name: "lltv",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "repayAssets",
+        type: "uint256",
+      },
+      {
+        name: "repayShares",
+        type: "uint256",
+      },
+      {
+        name: "maxRepayAssets",
+        type: "uint256",
+      },
+      {
+        name: "collateralAssets",
+        type: "uint256",
+      },
+      {
+        name: "maxLtv",
+        type: "uint256",
+      },
+      {
+        name: "loanTokenPermit",
+        type: "tuple",
+        components: [
+          {
+            name: "kind",
+            type: "uint8",
+          },
+          {
+            name: "data",
+            type: "bytes",
+          },
+        ],
+      },
+      {
+        name: "signedAuthorization",
+        type: "tuple",
+        components: [
+          {
+            name: "signature",
+            type: "tuple",
+            components: [
+              {
+                name: "v",
+                type: "uint8",
+              },
+              {
+                name: "r",
+                type: "bytes32",
+              },
+              {
+                name: "s",
+                type: "bytes32",
+              },
+            ],
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+          },
+          {
+            name: "deadline",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+      },
+      {
+        name: "deadline",
+        type: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "blueBundlesV1Supply",
+    stateMutability: "payable",
+    inputs: [
+      {
+        name: "marketParams",
+        type: "tuple",
+        components: [
+          {
+            name: "loanToken",
+            type: "address",
+          },
+          {
+            name: "collateralToken",
+            type: "address",
+          },
+          {
+            name: "oracle",
+            type: "address",
+          },
+          {
+            name: "irm",
+            type: "address",
+          },
+          {
+            name: "lltv",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "assets",
+        type: "uint256",
+      },
+      {
+        name: "loanTokenPermit",
+        type: "tuple",
+        components: [
+          {
+            name: "kind",
+            type: "uint8",
+          },
+          {
+            name: "data",
+            type: "bytes",
+          },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+      },
+      {
+        name: "deadline",
+        type: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "blueBundlesV1Withdraw",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "marketParams",
+        type: "tuple",
+        components: [
+          {
+            name: "loanToken",
+            type: "address",
+          },
+          {
+            name: "collateralToken",
+            type: "address",
+          },
+          {
+            name: "oracle",
+            type: "address",
+          },
+          {
+            name: "irm",
+            type: "address",
+          },
+          {
+            name: "lltv",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "withdrawAssets",
+        type: "uint256",
+      },
+      {
+        name: "withdrawShares",
+        type: "uint256",
+      },
+      {
+        name: "signedAuthorization",
+        type: "tuple",
+        components: [
+          {
+            name: "signature",
+            type: "tuple",
+            components: [
+              {
+                name: "v",
+                type: "uint8",
+              },
+              {
+                name: "r",
+                type: "bytes32",
+              },
+              {
+                name: "s",
+                type: "bytes32",
+              },
+            ],
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+          },
+          {
+            name: "deadline",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "reallocations",
+        type: "tuple[]",
+        components: [
+          {
+            name: "vault",
+            type: "address",
+          },
+          {
+            name: "adapter",
+            type: "address",
+          },
+          {
+            name: "marketParams",
+            type: "tuple",
+            components: [
+              {
+                name: "loanToken",
+                type: "address",
+              },
+              {
+                name: "collateralToken",
+                type: "address",
+              },
+              {
+                name: "oracle",
+                type: "address",
+              },
+              {
+                name: "irm",
+                type: "address",
+              },
+              {
+                name: "lltv",
+                type: "uint256",
+              },
+            ],
+          },
+          {
+            name: "fromIdle",
+            type: "bool",
+          },
+          {
+            name: "sourceAdapter",
+            type: "address",
+          },
+          {
+            name: "sourceMarketParams",
+            type: "tuple",
+            components: [
+              {
+                name: "loanToken",
+                type: "address",
+              },
+              {
+                name: "collateralToken",
+                type: "address",
+              },
+              {
+                name: "oracle",
+                type: "address",
+              },
+              {
+                name: "irm",
+                type: "address",
+              },
+              {
+                name: "lltv",
+                type: "uint256",
+              },
+            ],
+          },
+          {
+            name: "assets",
+            type: "uint128",
+          },
+          {
+            name: "penalty",
+            type: "uint64",
+          },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+      },
+      {
+        name: "deadline",
+        type: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "blueBundlesV1MigrateBorrowPosition",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "sourceMarketParams",
+        type: "tuple",
+        components: [
+          {
+            name: "loanToken",
+            type: "address",
+          },
+          {
+            name: "collateralToken",
+            type: "address",
+          },
+          {
+            name: "oracle",
+            type: "address",
+          },
+          {
+            name: "irm",
+            type: "address",
+          },
+          {
+            name: "lltv",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "destMarketParams",
+        type: "tuple",
+        components: [
+          {
+            name: "loanToken",
+            type: "address",
+          },
+          {
+            name: "collateralToken",
+            type: "address",
+          },
+          {
+            name: "oracle",
+            type: "address",
+          },
+          {
+            name: "irm",
+            type: "address",
+          },
+          {
+            name: "lltv",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "maxLtv",
+        type: "uint256",
+      },
+      {
+        name: "signedAuthorization",
+        type: "tuple",
+        components: [
+          {
+            name: "signature",
+            type: "tuple",
+            components: [
+              {
+                name: "v",
+                type: "uint8",
+              },
+              {
+                name: "r",
+                type: "bytes32",
+              },
+              {
+                name: "s",
+                type: "bytes32",
+              },
+            ],
+          },
+          {
+            name: "nonce",
+            type: "uint256",
+          },
+          {
+            name: "deadline",
+            type: "uint256",
+          },
+        ],
+      },
+      {
+        name: "reallocations",
+        type: "tuple[]",
+        components: [
+          {
+            name: "vault",
+            type: "address",
+          },
+          {
+            name: "adapter",
+            type: "address",
+          },
+          {
+            name: "marketParams",
+            type: "tuple",
+            components: [
+              {
+                name: "loanToken",
+                type: "address",
+              },
+              {
+                name: "collateralToken",
+                type: "address",
+              },
+              {
+                name: "oracle",
+                type: "address",
+              },
+              {
+                name: "irm",
+                type: "address",
+              },
+              {
+                name: "lltv",
+                type: "uint256",
+              },
+            ],
+          },
+          {
+            name: "fromIdle",
+            type: "bool",
+          },
+          {
+            name: "sourceAdapter",
+            type: "address",
+          },
+          {
+            name: "sourceMarketParams",
+            type: "tuple",
+            components: [
+              {
+                name: "loanToken",
+                type: "address",
+              },
+              {
+                name: "collateralToken",
+                type: "address",
+              },
+              {
+                name: "oracle",
+                type: "address",
+              },
+              {
+                name: "irm",
+                type: "address",
+              },
+              {
+                name: "lltv",
+                type: "uint256",
+              },
+            ],
+          },
+          {
+            name: "assets",
+            type: "uint128",
+          },
+          {
+            name: "penalty",
+            type: "uint64",
+          },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+      },
+      {
+        name: "deadline",
+        type: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+] as const satisfies Abi;

--- a/packages/morpho-sdk/src/actions/AGENTS.md
+++ b/packages/morpho-sdk/src/actions/AGENTS.md
@@ -26,6 +26,9 @@ Only valid for assets/collateral configured as wNative. When `nativeAmount > 0`:
 
 `blueBorrow`, `blueSupplyCollateralBorrow`, loan-asset `blueWithdraw`, and refinance target flows accept an optional homogeneous `BlueReallocationPlan` (refinance names the field `targetReallocations`). `VaultV1Reallocation` entries become `reallocateTo(vault, fee, sortedWithdrawals, targetMarket)` before the primary Blue action; `VaultReallocation` remains a deprecated alias. `VaultV2BlueReallocation` entries map 1:1 to `reallocate(...)` for a market source or `allocateFromIdle(...)` for idle liquidity; the enclosing action supplies the target market, the input supplies adapters, the chain registry supplies the allocator, and each call passes the vault's configured WAD-scaled `penalty`. Mixing allocator versions throws `MixedReallocationVersionsError`. BluePublicAllocator sources are not sorted and idle uses no synthetic zero-address market. High-level builders pull the aggregate V2 penalty in the target loan token through GeneralAdapter1, then each low-level allocator action approves and spends its independently rounded `ceil(assets × penalty / WAD)` amount from Bundler3. Only V1 fees contribute to `tx.value`; all high-level allocator calls use `skipRevert: false`. Normalization dispatches to the separate V1 and V2 validators and action builders.
 
+All Vault V1 shared-liquidity inputs and low-level Bundler3 composition are deprecated and will be
+removed in the next major. New integrations use `VaultV2BlueReallocation`.
+
 ## Discriminated unions
 
 All action interfaces extend `BaseAction<TType, TArgs>` and discriminate on `type`. To add a new operation, see [`types/AGENTS.md`](../types/AGENTS.md#adding-a-new-operation).

--- a/packages/morpho-sdk/src/actions/blue/borrow.ts
+++ b/packages/morpho-sdk/src/actions/blue/borrow.ts
@@ -28,7 +28,10 @@ export interface BlueBorrowParams {
     receiver: Address;
     /** Minimum borrow share price (in ray). Protects against share price manipulation. */
     minSharePrice: bigint;
-    /** Homogeneous Vault V1 or Vault V2 reallocations to execute before borrowing. */
+    /**
+     * Homogeneous Vault V1 or Vault V2 reallocations to execute before borrowing.
+     * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2 for new integrations.
+     */
     reallocations?: BlueReallocationPlan;
     /**
      * Optional signed Morpho authorization. When provided, a `setAuthorizationWithSig` call is
@@ -58,7 +61,7 @@ export interface BlueBorrowParams {
  * @param params.args.receiver - Address that receives the borrowed assets.
  * @param params.args.minSharePrice - Minimum borrow share price (in ray). Slippage protection.
  * @param params.args.reallocations - Optional homogeneous Vault V1 or Vault V2 reallocations to
- *   execute before borrowing.
+ *   execute before borrowing. Vault V1 inputs are deprecated; use Vault V2 for new integrations.
  * @param params.args.authorizationSignature - Optional signed Morpho authorization; when present,
  *   a `setAuthorizationWithSig` call is prepended to the bundle.
  * @param params.metadata - Optional analytics metadata attached to the bundle.

--- a/packages/morpho-sdk/src/actions/blue/refinance.ts
+++ b/packages/morpho-sdk/src/actions/blue/refinance.ts
@@ -44,7 +44,10 @@ export interface BlueRefinanceParams {
     minBorrowSharePrice: bigint;
     /** Maximum repay share price on the source market (in ray); must be > 0 when a repay leg exists. */
     maxRepaySharePrice: bigint;
-    /** Homogeneous Vault V1 or Vault V2 reallocations into the target market. */
+    /**
+     * Homogeneous Vault V1 or Vault V2 reallocations into the target market.
+     * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2 for new integrations.
+     */
     targetReallocations?: BlueReallocationPlan;
     /**
      * Optional signed Morpho authorization. When provided, a `setAuthorizationWithSig` call is
@@ -103,7 +106,9 @@ export interface BlueRefinanceParams {
  * @param params.args.minBorrowSharePrice - Minimum borrow share price (ray) on the target.
  * @param params.args.maxRepaySharePrice - Maximum repay share price (ray) on the source.
  * @param params.args.targetReallocations - Homogeneous Vault V1 or Vault V2 reallocations into the
- *   target, run before the supply leg. V1 fees add to `tx.value`; V2 penalties are paid in the target loan token.
+ *   target, run before the supply leg. Vault V1 inputs are deprecated for high-level Blue writes;
+ *   use Vault V2 for new integrations. V1 fees add to `tx.value`; V2 penalties are paid in the
+ *   target loan token.
  * @param params.args.authorizationSignature - Optional signed Morpho authorization; when present,
  *   a `setAuthorizationWithSig` call is prepended to the bundle.
  * @param params.metadata - Optional analytics metadata appended to `tx.data`.

--- a/packages/morpho-sdk/src/actions/blue/supplyCollateralBorrow.ts
+++ b/packages/morpho-sdk/src/actions/blue/supplyCollateralBorrow.ts
@@ -35,7 +35,10 @@ export interface BlueSupplyCollateralBorrowParams {
     minSharePrice: bigint;
     /** Optional pre-signed permit/permit2 approval for the collateral transfer. */
     requirementSignature?: PermitRequirementSignature;
-    /** Homogeneous Vault V1 or Vault V2 reallocations to execute before borrowing. */
+    /**
+     * Homogeneous Vault V1 or Vault V2 reallocations to execute before borrowing.
+     * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2 for new integrations.
+     */
     reallocations?: BlueReallocationPlan;
     /**
      * Optional signed Morpho authorization. When provided, a `setAuthorizationWithSig` call is
@@ -77,7 +80,8 @@ export interface BlueSupplyCollateralBorrowParams {
  * @param params.args.nativeAmount - Optional amount of native token to wrap into wNative for the
  *   collateral supply. Requires the collateral token to be the chain's wNative.
  * @param params.args.reallocations - Optional homogeneous Vault V1 or Vault V2 reallocations to
- *   execute between the supply and borrow legs.
+ *   execute between the supply and borrow legs. Vault V1 inputs are deprecated; use Vault V2 for
+ *   new integrations.
  * @param params.args.authorizationSignature - Optional signed Morpho authorization; when present,
  *   a `setAuthorizationWithSig` call is prepended to the bundle.
  * @param params.metadata - Optional analytics metadata attached to the bundle.

--- a/packages/morpho-sdk/src/actions/blue/withdraw.ts
+++ b/packages/morpho-sdk/src/actions/blue/withdraw.ts
@@ -35,6 +35,7 @@ export interface BlueWithdrawParams {
      * Homogeneous Vault V1 or Vault V2 reallocations to execute before withdrawing. V1 entries can be
      * computed via `MorphoBlue.getVaultV1Reallocations({ operation: "withdraw", amount })` or directly
      * via `computeVaultV1Reallocations({ operation: "withdraw", amount, ... })`.
+     * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2 for new integrations.
      */
     reallocations?: BlueReallocationPlan;
     /**
@@ -75,7 +76,7 @@ export interface BlueWithdrawParams {
  * @param params.args.minSharePrice - Minimum acceptable withdraw share price (in ray). Slippage
  *   protection.
  * @param params.args.reallocations - Optional homogeneous Vault V1 or Vault V2 reallocations to
- *   execute before withdrawing.
+ *   execute before withdrawing. Vault V1 inputs are deprecated; use Vault V2 for new integrations.
  * @param params.args.authorizationSignature - Optional signed Morpho authorization; when present,
  *   a `setAuthorizationWithSig` call is prepended to the bundle.
  * @param params.metadata - Optional analytics metadata attached to the bundle.

--- a/packages/morpho-sdk/src/bundler/actions.ts
+++ b/packages/morpho-sdk/src/bundler/actions.ts
@@ -1400,6 +1400,8 @@ export namespace BundlerAction {
    * @param skipRevert - Whether Bundler3 should tolerate a revert.
    * @returns Encoded Bundler3 calls.
    * @throws {BundlerErrors.UnexpectedAction} when the PublicAllocator is unavailable on the chain.
+   * @deprecated Vault V1 PublicAllocator composition will be removed in the next major. Use
+   * `vaultV2BluePublicAllocatorReallocate` or `vaultV2BluePublicAllocatorAllocateFromIdle`.
    *
    * @example
    * ```ts

--- a/packages/morpho-sdk/src/bundler/types.ts
+++ b/packages/morpho-sdk/src/bundler/types.ts
@@ -24,6 +24,9 @@ export interface Authorization {
 
 /**
  * Public allocator withdrawal input used by a `reallocateTo` Bundler3 action.
+ *
+ * @deprecated Vault V1 PublicAllocator composition will be removed in the next major. Use Vault V2
+ * BluePublicAllocator actions.
  */
 export interface InputReallocation {
   /** Market to withdraw liquidity from. */
@@ -201,7 +204,13 @@ export interface ActionArgs {
     skipRevert?: boolean,
   ];
 
-  /** PublicAllocator reallocation to `supplyMarket` from `vault` withdrawals while paying `fee`; `skipRevert` controls Bundler3 revert handling. */
+  /**
+   * PublicAllocator reallocation to `supplyMarket` from `vault` withdrawals while paying `fee`;
+   * `skipRevert` controls Bundler3 revert handling.
+   *
+   * @deprecated Vault V1 PublicAllocator composition will be removed in the next major. Use Vault V2
+   * BluePublicAllocator actions.
+   */
   readonly reallocateTo: [
     vault: Address,
     fee: bigint,

--- a/packages/morpho-sdk/src/entities/AGENTS.md
+++ b/packages/morpho-sdk/src/entities/AGENTS.md
@@ -15,6 +15,9 @@ See [`packages/morpho-sdk/AGENTS.md`](../../AGENTS.md) routing summary.
 
 ## Shared liquidity
 
-`MorphoBlue.borrow()`, `supplyCollateralBorrow()`, `withdraw()`, and `refinance()` accept optional homogeneous V1-or-V2 reallocation plans; mixing versions is rejected. Consumer-supplied reallocation plans and vault allowlists accept any iterable and are normalized once before lazy or repeated use; ordered outputs remain readonly arrays. The entity validates their state-independent shape before returning requirements, and the pure action repeats the same validation before encoding. `getVaultV1ReallocationData` and `getVaultV2BlueReallocationData` fetch the versioned inputs needed to compute reallocations; deprecated `getReallocationData` delegates to the V1 fetcher. Action encoding stays outside every entity fetch path.
+`MorphoBlue.borrow()`, `supplyCollateralBorrow()`, `withdraw()`, and `refinance()` accept optional homogeneous V1-or-V2 reallocation plans; mixing versions is rejected. All Vault V1 shared-liquidity inputs, data, and planning methods are deprecated and will be removed in the next major; new integrations use Vault V2. Consumer-supplied reallocation plans and vault allowlists accept any iterable and are normalized once before lazy or repeated use; ordered outputs remain readonly arrays. The entity validates their state-independent shape before returning requirements, and the pure action repeats the same validation before encoding. Action encoding stays outside every entity fetch path.
 
-`VaultV1ReallocationData` is the entity-level state container for PublicAllocator V1 simulations; `ReallocationData` remains its deprecated compatibility alias. `VaultV2BlueReallocationData` owns the separate BluePublicAllocator state model. Their public maps are readable snapshots for inspection; state transitions stay on their methods and return cloned instances of the same versioned class.
+`VaultV1ReallocationData` and its compatibility alias `ReallocationData` are deprecated with the
+rest of the PublicAllocator V1 algorithm. `VaultV2BlueReallocationData` owns the successor
+BluePublicAllocator state model. Public maps are readable snapshots for inspection; state
+transitions stay on methods and return cloned instances of the same versioned class.

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -224,6 +224,8 @@ export interface BlueActions {
    * When `reallocations` is provided, its homogeneous V1 or V2 actions are
    * prepended to move liquidity before withdrawing. V1 fees add
    * to the transaction value; V2 penalties are paid in the loan token.
+   * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2
+   * reallocations for new integrations.
    *
    * `getRequirements` returns the loan-token approval needed for V2 penalties
    * and `morpho.setAuthorization(generalAdapter1, true)` when GA1 is not yet
@@ -247,6 +249,7 @@ export interface BlueActions {
       receiver?: Address;
       positionData: AccrualPosition;
       slippageTolerance?: bigint;
+      /** Vault V1 inputs are deprecated for high-level Blue writes; prefer Vault V2. */
       reallocations?: BlueReallocationPlan;
     } & AssetsOrSharesArgs,
   ) => {
@@ -272,6 +275,8 @@ export interface BlueActions {
    * When `reallocations` is provided, its homogeneous V1 or V2 actions are
    * prepended before borrowing. V1 fees add to the transaction
    * value; V2 penalties are paid in the loan token.
+   * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2
+   * reallocations for new integrations.
    *
    * `getRequirements` returns the loan-token approval needed for V2 penalties
    * and Morpho authorization for GeneralAdapter1 when needed.
@@ -293,6 +298,7 @@ export interface BlueActions {
     amount: bigint;
     positionData: AccrualPosition;
     slippageTolerance?: bigint;
+    /** Vault V1 inputs are deprecated for high-level Blue writes; prefer Vault V2. */
     reallocations?: BlueReallocationPlan;
   }) => {
     buildTx: (
@@ -425,6 +431,8 @@ export interface BlueActions {
    * When `reallocations` is provided, its homogeneous V1 or V2 actions run
    * between the collateral supply and `morphoBorrow`. V1 fees add
    * to the transaction value; V2 penalties are paid in the loan token.
+   * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2
+   * reallocations for new integrations.
    *
    * `getRequirements` returns in parallel:
    * - ERC20 approval or permit for collateral token (to GeneralAdapter1).
@@ -449,6 +457,7 @@ export interface BlueActions {
       positionData: AccrualPosition;
       borrowAmount: bigint;
       slippageTolerance?: bigint;
+      /** Vault V1 inputs are deprecated for high-level Blue writes; prefer Vault V2. */
       reallocations?: BlueReallocationPlan;
     } & DepositAmountArgs,
   ) => {
@@ -482,6 +491,8 @@ export interface BlueActions {
    * A homogeneous V1 or V2 target reallocation plan runs first; V1 fees add
    * to the transaction value and V2 penalties are paid
    * in the loan token.
+   * Vault V1 inputs are deprecated for high-level Blue writes; use Vault V2
+   * reallocations for new integrations.
    *
    * `getRequirements` returns the loan-token approval needed for V2 penalties
    * and Morpho authorization for GeneralAdapter1 when needed.
@@ -494,7 +505,8 @@ export interface BlueActions {
    * @param params.borrowAssets - Loan assets to repay on source; exclusive with `borrowShares`.
    * @param params.borrowShares - Borrow shares to repay on source; exclusive with `borrowAssets`.
    * @param params.slippageTolerance - WAD slippage tolerance. Defaults to `DEFAULT_SLIPPAGE_TOLERANCE`.
-   * @param params.targetReallocations - Homogeneous Vault V1 or Vault V2 reallocations into the target market.
+   * @param params.targetReallocations - Homogeneous Vault V1 or Vault V2 reallocations into the
+   *   target market. Vault V1 inputs are deprecated; prefer Vault V2.
    * @returns Object with `buildTx` and `getRequirements`.
    * @throws {BundlerErrors.UnexpectedAction} when a V2 plan is unsupported on the chain.
    * @throws {InputExceedsMaxError} when a V2 reallocation asset amount exceeds `uint128` or its penalty exceeds WAD.
@@ -515,6 +527,7 @@ export interface BlueActions {
     borrowAssets?: bigint;
     borrowShares?: bigint;
     slippageTolerance?: bigint;
+    /** Vault V1 inputs are deprecated for high-level Blue writes; prefer Vault V2. */
     targetReallocations?: BlueReallocationPlan;
   }) => {
     buildTx: (
@@ -549,6 +562,8 @@ export interface BlueActions {
    * @param params.block - The block to fetch data at (number and timestamp).
    * @returns A VaultV1ReallocationData instance populated with all required data.
    * @throws {ChainIdMismatchError} when the client chain does not match this market.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocationData}.
    */
   getVaultV1ReallocationData: (params: {
     vaultAddresses: readonly Address[];
@@ -566,7 +581,8 @@ export interface BlueActions {
    * @param params.block.timestamp - Timestamp corresponding to the fetched block.
    * @returns A `VaultV1ReallocationData` snapshot populated from one block.
    * @throws {ChainIdMismatchError} when the client chain does not match this market.
-   * @deprecated Use {@link getVaultV1ReallocationData} instead.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocationData}.
    */
   getReallocationData: (params: {
     vaultAddresses: readonly Address[];
@@ -627,6 +643,8 @@ export interface BlueActions {
    * @throws {ReallocationWithdrawExceedsMarketSupplyError} when a withdrawal exceeds the target market supply.
    * @throws {MissingPublicAllocatorConfigError} when a selected vault is missing its public allocator config.
    * @throws {UnknownReallocationMarketError} when the target market is absent from the reallocation data.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocations}.
    * @example
    * ```ts
    * const reallocations = market.getVaultV1Reallocations({
@@ -654,7 +672,8 @@ export interface BlueActions {
    * @throws {ReallocationWithdrawExceedsMarketSupplyError} when a withdrawal exceeds market supply.
    * @throws {MissingPublicAllocatorConfigError} when a selected vault lacks allocator state.
    * @throws {UnknownReallocationMarketError} when the target market is absent.
-   * @deprecated Use {@link getVaultV1Reallocations} instead.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocations}.
    * @example
    * ```ts
    * const reallocations = market.getReallocations({
@@ -1914,6 +1933,8 @@ export class MorphoBlue implements BlueActions {
    * @param params.block.timestamp - Timestamp corresponding to the fetched block.
    * @returns Reallocation data ready for {@link getVaultV1Reallocations}.
    * @throws {ChainIdMismatchError} when the client chain does not match this market.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocationData}.
    * @example
    * ```ts
    * import { markets, vaults } from "@morpho-org/morpho-test";
@@ -2051,7 +2072,8 @@ export class MorphoBlue implements BlueActions {
    * @param params.block.timestamp - Timestamp corresponding to the fetched block.
    * @returns A `VaultV1ReallocationData` snapshot populated from one block.
    * @throws {ChainIdMismatchError} when the client chain does not match this market.
-   * @deprecated Use {@link getVaultV1ReallocationData} instead.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocationData}.
    * @example
    * ```ts
    * const data = await market.getReallocationData({ vaultAddresses, block });
@@ -2192,6 +2214,8 @@ export class MorphoBlue implements BlueActions {
    * @throws {ReallocationWithdrawExceedsMarketSupplyError} when `operation === "withdraw"` and `amount` exceeds the target market's `totalSupplyAssets`.
    * @throws {MissingPublicAllocatorConfigError} when a selected vault is missing its public allocator config.
    * @throws {UnknownReallocationMarketError} when the target market is absent from the reallocation data.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocations}.
    * @example
    * ```ts
    * const reallocations = market.getVaultV1Reallocations({
@@ -2242,7 +2266,8 @@ export class MorphoBlue implements BlueActions {
    * @throws {ReallocationWithdrawExceedsMarketSupplyError} when a withdrawal exceeds market supply.
    * @throws {MissingPublicAllocatorConfigError} when a selected vault lacks allocator state.
    * @throws {UnknownReallocationMarketError} when the target market is absent.
-   * @deprecated Use {@link getVaultV1Reallocations} instead.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * {@link getVaultV2BlueReallocations}.
    * @example
    * ```ts
    * const reallocations = market.getReallocations({

--- a/packages/morpho-sdk/src/entities/vaultV1ReallocationData.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1ReallocationData.ts
@@ -33,6 +33,9 @@ import {
 
 /**
  * Input state required to construct {@link VaultV1ReallocationData}.
+ *
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * `InputVaultV2BlueReallocationData`.
  */
 export interface InputVaultV1ReallocationData {
   /** Chain id associated with the fetched state. */
@@ -58,7 +61,8 @@ export interface InputVaultV1ReallocationData {
 /**
  * Deprecated input name for Vault V1 reallocation data.
  *
- * @deprecated Use {@link InputVaultV1ReallocationData} instead.
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * `InputVaultV2BlueReallocationData`.
  */
 export type InputReallocationData = InputVaultV1ReallocationData;
 
@@ -124,6 +128,9 @@ const cloneVaultMarketConfig = (config: VaultMarketConfig) =>
  * `markets`, `vaults`, `positions`, and `vaultMarketConfigs` as a read
  * contract keyed by market id or address; use the getters for typed absence
  * errors and use simulation methods to produce updated state.
+ *
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * `VaultV2BlueReallocationData`.
  */
 export class VaultV1ReallocationData implements InputVaultV1ReallocationData {
   /** Chain id associated with the fetched reallocation data. */
@@ -341,6 +348,8 @@ export class VaultV1ReallocationData implements InputVaultV1ReallocationData {
    * @param options - Optional allocator discovery options.
    * @returns Computed source-market withdrawals and the post-reallocation state.
    * @throws {@link UnknownReallocationMarketError} when the target market is absent.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * `VaultV2BlueReallocationData.computeVaultV2BlueReallocations`.
    * @example
    * ```ts
    * import { createPublicClient, http } from "viem";
@@ -481,7 +490,8 @@ export class VaultV1ReallocationData implements InputVaultV1ReallocationData {
    * @param options - Optional allocator discovery options.
    * @returns Computed source-market withdrawals and the post-reallocation state.
    * @throws {@link UnknownReallocationMarketError} when the target market is absent.
-   * @deprecated Use {@link computeVaultV1Reallocations} instead.
+   * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+   * `VaultV2BlueReallocationData.computeVaultV2BlueReallocations`.
    */
   public getMarketPublicReallocations(
     marketId: MarketId,
@@ -503,6 +513,8 @@ export class VaultV1ReallocationData implements InputVaultV1ReallocationData {
    * @param options - Optional allocator discovery options.
    * @returns Total reallocatable assets in loan-token units; `0n` when none is available.
    * @throws {@link UnknownReallocationMarketError} when the target market is absent.
+   * @deprecated Vault V1 shared-liquidity metrics will be removed in the next major. Use
+   * `VaultV2BlueReallocationData.getPublicReallocationLiquidity`.
    * @example
    * ```ts
    * import { createPublicClient, http } from "viem";
@@ -562,6 +574,8 @@ export class VaultV1ReallocationData implements InputVaultV1ReallocationData {
    * @param options - Optional reallocation options (supply target utilization trigger, timestamp, withdrawal caps).
    * @returns Available liquidity to the given utilization in loan-token units; `0n` when none is available.
    * @throws {@link UnknownReallocationMarketError} when the target market is absent.
+   * @deprecated Vault V1 shared-liquidity metrics will be removed in the next major. Use
+   * `VaultV2BlueReallocationData.getAvailableLiquidityToUtilization`.
    * @example
    * ```ts
    * import { createPublicClient, http, parseEther } from "viem";
@@ -816,6 +830,7 @@ export class VaultV1ReallocationData implements InputVaultV1ReallocationData {
 /**
  * Deprecated class name for Vault V1 reallocation data.
  *
- * @deprecated Use {@link VaultV1ReallocationData} instead.
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * `VaultV2BlueReallocationData`.
  */
 export { VaultV1ReallocationData as ReallocationData };

--- a/packages/morpho-sdk/src/helpers/AGENTS.md
+++ b/packages/morpho-sdk/src/helpers/AGENTS.md
@@ -9,7 +9,11 @@ Per-function contracts (arguments, return shapes, behavior) live as JSDoc on eac
 - **Encoders** (ABI encoding plus input validation, no I/O) — e.g. `encodeForceDeallocateCall(deallocation, onBehalf)`. ABI-encodes a single `VaultV2.forceDeallocate` calldata entry and throws `NonPositiveInputError` on a non-positive `amount`. The `data` field carries ABI-encoded `MarketParams` for the Morpho Market V1 adapter, or empty bytes otherwise. Internal sub-helpers (e.g. `encodeDeallocateData`) are not exported.
 - **Validators** (pure, throw typed errors) — `validateReallocations(...)`, `validateSlippageTolerance(...)`, `validatePositionHealth(...)`. Each enforces a public-API invariant: see the `error.ts` exports for the full list of error classes a caller may pattern-match on.
 - **Math / share-price helpers** — `computeMaxRepaySharePrice`, `computeMinBorrowSharePrice`, etc. Use `MAX_SLIPPAGE_TOLERANCE` and cap at `MAX_ABSOLUTE_SHARE_PRICE`.
-- **Shared-liquidity** — `computeVaultV1Reallocations` builds PublicAllocator V1 reallocations for a borrow/withdraw; `computeReallocations` remains its deprecated compatibility alias. Vault V2 planning and state transitions live on `VaultV2BlueReallocationData`. `getSupplyTargetUtilization(marketId, options)` resolves the per-market → default → `DEFAULT_SUPPLY_TARGET_UTILIZATION` supply target for V1. Read-only liquidity metrics live on the corresponding versioned reallocation-data entity, not in this layer.
+- **Shared-liquidity** — `computeVaultV1Reallocations`, its compatibility alias
+  `computeReallocations`, and the PublicAllocator V1 validator are deprecated and will be removed in
+  the next major. Vault V2 planning and state transitions live on `VaultV2BlueReallocationData`.
+  Read-only liquidity metrics live on the corresponding versioned reallocation-data entity, not in
+  this layer.
 - **Metadata** — `addTransactionMetadata(tx, metadata)` appends hex-encoded analytics bytes to `tx.data`: an optional 4-byte unix timestamp followed by a 4-byte origin (timestamp is omitted when `metadata.timestamp` is falsy). Callers gate on `metadata` being provided; the helper itself is a no-op when `tx.data` is empty.
 
 ## Constants

--- a/packages/morpho-sdk/src/helpers/computeVaultV1Reallocations.ts
+++ b/packages/morpho-sdk/src/helpers/computeVaultV1Reallocations.ts
@@ -107,6 +107,8 @@ const capVaultWithdrawals = (
  * @throws {InsufficientSharedLiquidityError} when shared liquidity cannot cover the operation's absolute shortfall on the target market — preventing fee-bearing reallocations from being attached to a call that would still revert onchain.
  * @throws {ReallocationWithdrawExceedsMarketSupplyError} when `operation === "withdraw"` and `amount` exceeds the target market's `totalSupplyAssets` — the on-chain call would revert regardless of reallocations.
  * @throws {MissingPublicAllocatorConfigError} when a selected vault is missing its public allocator config.
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * `VaultV2BlueReallocationData.computeVaultV2BlueReallocations`.
  * @example
  * ```ts
  * import { createPublicClient, http, parseUnits } from "viem";
@@ -318,6 +320,7 @@ export const computeVaultV1Reallocations = ({
 /**
  * Deprecated name for the Vault V1 amount-aware reallocation planner.
  *
- * @deprecated Use {@link computeVaultV1Reallocations} instead.
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * `VaultV2BlueReallocationData.computeVaultV2BlueReallocations`.
  */
 export const computeReallocations = computeVaultV1Reallocations;

--- a/packages/morpho-sdk/src/helpers/validate.ts
+++ b/packages/morpho-sdk/src/helpers/validate.ts
@@ -347,6 +347,8 @@ export const validateRepayShares = (params: {
  * @throws {NonPositiveInputError} when a withdrawal amount is non-positive.
  * @throws {ReallocationWithdrawalOnTargetMarketError} when a withdrawal references the target market.
  * @throws {UnsortedReallocationWithdrawalsError} when withdrawals are not strictly market-id sorted.
+ * @deprecated Vault V1 PublicAllocator validation will be removed in the next major. Use Vault V2
+ * reallocations for new integrations.
  * @example
  * ```ts
  * import type { BlueMarketId } from "@morpho-org/morpho-sdk/types";

--- a/packages/morpho-sdk/src/types/AGENTS.md
+++ b/packages/morpho-sdk/src/types/AGENTS.md
@@ -18,10 +18,12 @@ Centralized type definitions and error classes. Barrel-exported via `index.ts`. 
 
 ## Shared liquidity (`sharedLiquidity.ts`)
 
-- `VaultV1Reallocation` — vault address + fee + sorted withdrawals; maps to `reallocateTo()`. `VaultReallocation` is its deprecated compatibility alias.
+- All Vault V1 shared-liquidity types are deprecated and will be removed in the next major, including
+  `PublicAllocatorOptions`, `PublicReallocation`, `ReallocationWithdrawal`,
+  `VaultV1Reallocation`, `VaultReallocation`, and `ReallocationComputeOptions`.
 - `VaultV2BlueReallocation` — BluePublicAllocator vault/source/target-adapter/assets/WAD-scaled-penalty input; maps 1:1 to `reallocate()` or `allocateFromIdle()` while deriving target market params from the enclosing Blue action.
 - `VaultV2BluePublicAllocatorOptions` — canonical Vault V2 discovery and planner options for timestamp, enablement, vault allowlisting, friendly source-market utilization, and the maximum proportional penalty.
-- `BlueReallocationPlan` — homogeneous iterable accepted by Blue action and entity pass-through surfaces; a plan contains only V1 or only V2 reallocations.
+- `BlueReallocationPlan` — homogeneous iterable accepted by Blue action and entity pass-through surfaces; a plan contains only V1 or only V2 reallocations. Its V1 branch is deprecated and will be removed in the next major; use V2 for new integrations.
 
 ## Errors (`error.ts`)
 

--- a/packages/morpho-sdk/src/types/error.ts
+++ b/packages/morpho-sdk/src/types/error.ts
@@ -807,7 +807,11 @@ export class AccrualPositionUserMismatchError extends Error {
   }
 }
 
-/** Thrown when a reallocation has no withdrawals. */
+/**
+ * Thrown when a reallocation has no withdrawals.
+ *
+ * @deprecated Vault V1 PublicAllocator support will be removed in the next major.
+ */
 export class EmptyReallocationWithdrawalsError extends Error {
   constructor(vault: string) {
     super(`Reallocation withdrawals list cannot be empty for vault: ${vault}`);
@@ -827,6 +831,8 @@ export class ReallocationWithdrawalOnTargetMarketError extends Error {
  * Thrown when a Public Allocator reallocation does not match exactly one V1 or
  * V2 input shape.
  *
+ * @deprecated Vault V1/V2 reallocation-shape dispatch will be removed in the next major. Use Vault
+ * V2 reallocations.
  * @example
  * ```ts
  * import { InvalidReallocationShapeError } from "@morpho-org/morpho-sdk";
@@ -846,6 +852,8 @@ export class InvalidReallocationShapeError extends Error {
 /**
  * Thrown when one reallocation plan contains both Vault V1 and Vault V2 entries.
  *
+ * @deprecated Vault V1/V2 mixed-plan support will be removed in the next major. Use Vault V2
+ * reallocations.
  * @example
  * ```ts
  * import { MixedReallocationVersionsError } from "@morpho-org/morpho-sdk";
@@ -966,7 +974,11 @@ export class InconsistentReallocationPenaltyError extends Error {
   }
 }
 
-/** Thrown when reallocation withdrawals within a vault are not strictly sorted by market id. */
+/**
+ * Thrown when reallocation withdrawals within a vault are not strictly sorted by market id.
+ *
+ * @deprecated Vault V1 PublicAllocator support will be removed in the next major.
+ */
 export class UnsortedReallocationWithdrawalsError extends Error {
   constructor(vault: string, marketId: string) {
     super(
@@ -1065,7 +1077,11 @@ export class RepaySharesExceedDebtError extends Error {
   }
 }
 
-/** Thrown when a vault selected for reallocation has no configured `PublicAllocator`. */
+/**
+ * Thrown when a vault selected for reallocation has no configured `PublicAllocator`.
+ *
+ * @deprecated Vault V1 PublicAllocator support will be removed in the next major.
+ */
 export class MissingPublicAllocatorConfigError extends Error {
   constructor(vault: string) {
     super(
@@ -1074,7 +1090,11 @@ export class MissingPublicAllocatorConfigError extends Error {
   }
 }
 
-/** Thrown when a reallocation attempts to use a disabled vault market. */
+/**
+ * Thrown when a reallocation attempts to use a disabled vault market.
+ *
+ * @deprecated Vault V1 PublicAllocator support will be removed in the next major.
+ */
 export class DisabledReallocationMarketError extends Error {
   constructor(
     public readonly vault: Address,
@@ -1127,7 +1147,11 @@ export class UnknownReallocationVaultError extends UnknownDataError {
   }
 }
 
-/** Thrown when reallocation state does not contain a requested vault-market config. */
+/**
+ * Thrown when reallocation state does not contain a requested vault-market config.
+ *
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major.
+ */
 export class UnknownReallocationVaultMarketConfigError extends UnknownDataError {
   /**
    * @param vault - Vault address for the missing config.
@@ -1143,7 +1167,11 @@ export class UnknownReallocationVaultMarketConfigError extends UnknownDataError 
   }
 }
 
-/** Thrown when reallocation state does not contain a requested market position. */
+/**
+ * Thrown when reallocation state does not contain a requested market position.
+ *
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major.
+ */
 export class UnknownReallocationPositionError extends UnknownDataError {
   /**
    * @param user - Position owner address.

--- a/packages/morpho-sdk/src/types/sharedLiquidity.ts
+++ b/packages/morpho-sdk/src/types/sharedLiquidity.ts
@@ -3,6 +3,9 @@ import type { Address } from "viem";
 
 /**
  * Options controlling public allocator withdrawal discovery.
+ *
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * {@link VaultV2BluePublicAllocatorOptions}.
  */
 export interface PublicAllocatorOptions {
   /** Whether public allocator reallocation discovery is enabled. */
@@ -76,6 +79,9 @@ export interface VaultV2BluePublicAllocatorOptions {
 
 /**
  * A computed source-market withdrawal before it is grouped by vault.
+ *
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * {@link VaultV2BlueReallocation}.
  */
 export interface PublicReallocation {
   /** Source market id to withdraw from. */
@@ -88,7 +94,12 @@ export interface PublicReallocation {
   readonly assets: bigint;
 }
 
-/** A single withdrawal from a source market within a vault reallocation. */
+/**
+ * A single withdrawal from a source market within a vault reallocation.
+ *
+ * @deprecated Vault V1 shared-liquidity support will be removed in the next major. Use
+ * {@link VaultV2BlueReallocation}.
+ */
 export interface ReallocationWithdrawal {
   /** Source market parameters to pass to the public allocator. */
   readonly marketParams: MarketParams;
@@ -102,6 +113,9 @@ export interface ReallocationWithdrawal {
  *
  * Maps 1:1 to a `PublicAllocator.reallocateTo()` call.
  * Withdraws from source markets and supplies to the target market.
+ *
+ * @deprecated Vault V1 shared-liquidity support will be removed in the next major. Use
+ * {@link VaultV2BlueReallocation}.
  */
 export interface VaultV1Reallocation {
   readonly vault: Address;
@@ -144,7 +158,12 @@ export interface VaultV2BlueReallocation {
   readonly penalty: bigint;
 }
 
-/** A homogeneous Blue action plan containing only Vault V1 or only Vault V2 reallocations. */
+/**
+ * A homogeneous Blue action plan containing only Vault V1 or only Vault V2 reallocations.
+ *
+ * Vault V1 members are deprecated for high-level Blue writes and will stop being accepted in the
+ * next major. Use Vault V2 members for new high-level integrations.
+ */
 export type BlueReallocationPlan =
   | Iterable<VaultV1Reallocation>
   | Iterable<VaultV2BlueReallocation>;
@@ -152,7 +171,8 @@ export type BlueReallocationPlan =
 /**
  * Deprecated name for a Vault V1 reallocation.
  *
- * @deprecated Use {@link VaultV1Reallocation} instead.
+ * @deprecated Vault V1 shared-liquidity support will be removed in the next major. Use
+ * {@link VaultV2BlueReallocation}.
  */
 export type VaultReallocation = VaultV1Reallocation;
 
@@ -161,6 +181,9 @@ export type VaultReallocation = VaultV1Reallocation;
  *
  * Extends {@link PublicAllocatorOptions} with supply-side utilization targets
  * that determine when reallocation is triggered.
+ *
+ * @deprecated Vault V1 shared-liquidity planning will be removed in the next major. Use
+ * {@link VaultV2BluePublicAllocatorOptions}.
  */
 export interface ReallocationComputeOptions extends PublicAllocatorOptions {
   /**

--- a/packages/wdk-protocol-lending-morpho-evm/README.md
+++ b/packages/wdk-protocol-lending-morpho-evm/README.md
@@ -139,9 +139,8 @@ Requirement entries are one of:
 
 Morpho SDK enforces a builder/executor invariant for bundled actions. For that reason, `onBehalfOf` and vault/collateral withdrawal `to` must equal the connected wallet address in this WDK adapter.
 
-Existing `MorphoBorrowOptions` callers keep the Vault V1 reallocation input and
-an authorization-only `getBorrowRequirements` result type. To include Vault V2
-BluePublicAllocator calls, type the options as
+The Vault V1 `MorphoBorrowOptions.reallocations` flow remains compatible but is deprecated and
+will be removed in the next major. For new integrations, type the options as
 `MorphoBorrowWithVaultV2ReallocationsOptions`; this explicitly widens the
 result to include the loan-token approval used for proportional penalty donations:
 

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
@@ -157,7 +157,13 @@ export interface MorphoBorrowOptions {
   amount: number | bigint;
   /** The address on behalf of which the borrow operation should be performed. Must match the wallet account address when set. */
   onBehalfOf?: string;
-  /** Optional Vault V1 PublicAllocator reallocations to include in the borrow action. */
+  /**
+   * Optional Vault V1 PublicAllocator reallocations to include in the borrow action.
+   *
+   * @deprecated Use {@link MorphoBorrowWithVaultV2ReallocationsOptions} for Vault V2
+   * BluePublicAllocator reallocations. Vault V1 reallocations will no longer be accepted by
+   * high-level Blue writes in the next major.
+   */
   reallocations?: readonly VaultReallocation[];
   /** Signature returned by a Morpho SDK authorization requirement, folded into the bundle as `setAuthorizationWithSig`. */
   requirementSignature?: RequirementSignature;


### PR DESCRIPTION
## Why

This is the **prerequisite deprecation minor** for the BlueBundlesV1 major migration (#984 / #971).

Every review of #984 raised the same **blocking** release-sequencing defect: `#984` carries both the Vault V1 deprecation changeset (`deprecate-v1-blue-reallocations.md`, minor) **and** the V2-only major changeset (`blue-v2-only-reallocations.md`, major) targeting the **same packages** (`morpho-sdk`, `wdk-protocol-lending-morpho-evm`). Changesets collapses same-package bumps to the highest level, so the deprecation minor would **never publish** — violating the §7 rule ("deprecate in a published minor before the major") and the retire-V1 TIB's constraint that "the deprecation minor must publish before the BlueBundlesV1 major".

This PR extracts that minor so it can ship on its own first (`morpho-sdk` 5.9.0 / `wdk-protocol-lending-morpho-evm` 1.2.0). The companion change on #984 removes the deprecation changeset from the major and deletes the now-deprecated V1 surfaces entirely.

## What

Content is exactly the migration prerequisites (originally #962), rebased onto `main`:

- **Publish the pinned `BlueBundlesV1` ABI** in `morpho-sdk`.
- **Deprecate** (via `@deprecated` JSDoc, kept fully functional) every public `morpho-sdk` symbol whose sole purpose is Vault V1 shared-liquidity planning or PublicAllocator composition: `VaultV1ReallocationData` (+ `ReallocationData` alias, planner methods, metrics), `computeVaultV1Reallocations` (+ `computeReallocations`), the V1 branches of the shared-liquidity types (`PublicAllocatorOptions`, `PublicReallocation`, `ReallocationWithdrawal`, `VaultV1Reallocation`/`VaultReallocation`, `ReallocationComputeOptions`), `InputReallocation`, `ActionArgs.reallocateTo`, and `BundlerAction.publicAllocatorReallocateTo`.
- **Deprecate the WDK Vault V1 borrow-reallocation input** (`MorphoBorrowOptions.reallocations`).
- Add **TIB-2026-08-28** (retire Vault V1 shared liquidity).
- Clamp Permit2 SignatureTransfer allowances to the full `uint256` range (`blue-sdk-viem` + `morpho-sdk` patch).

New integrations should use Vault V2 `BluePublicAllocator` reallocations. All deprecated Vault V1 surfaces are removed in the next major.

## Changesets

- `deprecate-v1-blue-reallocations.md` — `morpho-sdk` minor, `wdk-protocol-lending-morpho-evm` minor
- `permit2-signature-transfer-uint256.md` — `blue-sdk-viem` patch, `morpho-sdk` patch

## Verification

- `tsc --noEmit` on `morpho-sdk` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->