### PR TITLE
feat(morpho-sdk): stage vault bundles argument deprecations

### DIFF
--- a/.changeset/stage-vault-bundle-arguments.md
+++ b/.changeset/stage-vault-bundle-arguments.md
@@ -1,0 +1,8 @@
+---
+"@morpho-org/morpho-sdk": minor
+---
+
+Add bundles-compatible `userAddress` inputs to the Vault V1 and Vault V2 deposit, withdraw, and
+redeem action builders, and to the Vault V1-to-Vault V2 migration builder. Keep the existing
+`recipient`, `onBehalf`, and `minSharePriceVaultV1` inputs working but mark them deprecated for one
+published minor before their planned removal in morpho-sdk v6.

--- a/packages/morpho-sdk/src/actions/vaultV1/deposit.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/deposit.test.ts
@@ -72,7 +72,7 @@ describe("depositVaultV1 unit tests", () => {
       args: {
         amount: assets,
         maxSharePrice,
-        recipient: client.account.address,
+        userAddress: client.account.address,
         requirementSignature,
       },
     });

--- a/packages/morpho-sdk/src/actions/vaultV1/deposit.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/deposit.ts
@@ -18,17 +18,27 @@ import { getTokenRequirementActions } from "../signatures/getTokenRequirementAct
 
 /** Parameters for {@link vaultV1Deposit}. */
 export interface VaultV1DepositParams {
-  vault: {
-    chainId: number;
-    address: Address;
-    asset: Address;
+  readonly vault: {
+    readonly chainId: number;
+    readonly address: Address;
+    readonly asset: Address;
   };
-  args: DepositAmountArgs & {
-    maxSharePrice: bigint;
-    recipient: Address;
-    requirementSignature?: PermitRequirementSignature;
-  };
-  metadata?: Metadata;
+  readonly args: DepositAmountArgs & {
+    readonly maxSharePrice: bigint;
+    readonly requirementSignature?: PermitRequirementSignature;
+  } & (
+      | {
+          /** Account that receives the minted shares and submits the successor bundles route. */
+          readonly userAddress: Address;
+          readonly recipient?: never;
+        }
+      | {
+          /** @deprecated Use `userAddress`; `recipient` is removed in morpho-sdk v6. */
+          readonly recipient: Address;
+          readonly userAddress?: never;
+        }
+    );
+  readonly metadata?: Metadata;
 }
 
 /**
@@ -49,7 +59,9 @@ export interface VaultV1DepositParams {
  *   `nativeAmount` must be positive. Defaults to `0n`.
  * @param params.args.maxSharePrice - Maximum acceptable share price (in RAY, slippage
  *   protection enforced on-chain by `GeneralAdapter1`).
- * @param params.args.recipient - Address that receives the minted vault shares.
+ * @param params.args.userAddress - Account that receives the minted vault shares. This
+ *   bundles-compatible successor replaces `recipient` before morpho-sdk v6.
+ * @param params.args.recipient - Deprecated address that receives the minted vault shares.
  * @param params.args.requirementSignature - Optional pre-signed permit/permit2 approval.
  * @param params.args.nativeAmount - Optional amount of native token to wrap into wNative for the
  *   deposit. Requires the vault asset to be the chain's wNative.
@@ -79,7 +91,7 @@ export interface VaultV1DepositParams {
  *   args: {
  *     amount: 1_000_000n,
  *     maxSharePrice: 1_010_000_000_000_000_000_000_000_000n, // RAY-scaled, 1.01x
- *     recipient: depositor,
+ *     userAddress: depositor,
  *   },
  * });
  * // tx satisfies Readonly<Transaction<VaultV1DepositAction>>
@@ -87,15 +99,16 @@ export interface VaultV1DepositParams {
  */
 export const vaultV1Deposit = ({
   vault: { chainId, address: vaultAddress, asset },
-  args: {
-    amount = 0n,
-    maxSharePrice,
-    recipient,
-    requirementSignature,
-    nativeAmount,
-  },
+  args,
   metadata,
 }: VaultV1DepositParams): Readonly<Transaction<VaultV1DepositAction>> => {
+  const {
+    amount = 0n,
+    maxSharePrice,
+    requirementSignature,
+    nativeAmount,
+  } = args;
+  const recipient = args.userAddress ?? args.recipient;
   if (amount < 0n) {
     throw new NegativeInputError("amount", amount);
   }

--- a/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.test.ts
@@ -30,7 +30,6 @@ describe("vaultV1MigrateToV2 unit tests", () => {
     client,
   }) => {
     const shares = 1000000000000000000n;
-    const minSharePriceVaultV1 = 1000000000000000000000000000n;
     const maxSharePriceVaultV2 = 1000000000000000000000000000n;
 
     const tx = vaultV1MigrateToV2({
@@ -43,9 +42,8 @@ describe("vaultV1MigrateToV2 unit tests", () => {
         targetVault: KeyrockUsdcVaultV2.address,
         targetAsset: KeyrockUsdcVaultV2.asset,
         shares,
-        minSharePriceVaultV1,
         maxSharePriceVaultV2,
-        recipient: client.account.address,
+        userAddress: client.account.address,
       },
     });
 
@@ -53,7 +51,7 @@ describe("vaultV1MigrateToV2 unit tests", () => {
     expect(tx.action.type).toBe("vaultV1MigrateToV2");
     expect(tx.action.args.sourceVault).toBe(SteakhouseUsdcVaultV1.address);
     expect(tx.action.args.targetVault).toBe(KeyrockUsdcVaultV2.address);
-    expect(tx.action.args.minSharePriceVaultV1).toBe(minSharePriceVaultV1);
+    expect(tx.action.args.minSharePriceVaultV1).toBe(0n);
     expect(tx.action.args.maxSharePriceVaultV2).toBe(maxSharePriceVaultV2);
     expect(tx.action.args.recipient).toBe(client.account.address);
     expect(tx.to).toBeDefined();

--- a/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/migrateToV2.ts
@@ -16,28 +16,41 @@ import { getTokenRequirementActions } from "../signatures/getTokenRequirementAct
 
 /** Parameters for {@link vaultV1MigrateToV2}. */
 export interface VaultV1MigrateToV2Params {
-  vault: {
-    chainId: number;
-    address: Address;
+  readonly vault: {
+    readonly chainId: number;
+    readonly address: Address;
     /** Underlying asset of the source V1 vault. */
-    asset: Address;
+    readonly asset: Address;
   };
-  args: {
-    targetVault: Address;
+  readonly args: {
+    readonly targetVault: Address;
     /** Underlying asset of the target V2 vault. */
-    targetAsset: Address;
+    readonly targetAsset: Address;
     /** Number of V1 shares to migrate. */
-    shares: bigint;
-    /** Minimum acceptable share price for V1 redeem (slippage protection, in RAY). */
-    minSharePriceVaultV1: bigint;
+    readonly shares: bigint;
     /** Maximum acceptable share price for V2 deposit (inflation protection, in RAY). */
-    maxSharePriceVaultV2: bigint;
-    /** Receives the V2 vault shares. */
-    recipient: Address;
+    readonly maxSharePriceVaultV2: bigint;
     /** Pre-signed permit/permit2 approval for V1 share transfer. */
-    requirementSignature?: PermitRequirementSignature;
-  };
-  metadata?: Metadata;
+    readonly requirementSignature?: PermitRequirementSignature;
+  } & (
+    | {
+        /** Account that receives V2 shares and submits the successor bundles route. */
+        readonly userAddress: Address;
+        readonly minSharePriceVaultV1?: never;
+        readonly recipient?: never;
+      }
+    | {
+        /**
+         * @deprecated Omit this field and use `userAddress`; the V1 bound is removed in
+         * morpho-sdk v6 because VaultBundlesV1 cannot enforce it.
+         */
+        readonly minSharePriceVaultV1: bigint;
+        /** @deprecated Use `userAddress`; `recipient` is removed in morpho-sdk v6. */
+        readonly recipient: Address;
+        readonly userAddress?: never;
+      }
+  );
+  readonly metadata?: Metadata;
 }
 
 /**
@@ -60,11 +73,13 @@ export interface VaultV1MigrateToV2Params {
  * @param params.args.targetAsset - The underlying asset of the target V2 vault. Must equal
  *   `vault.asset`.
  * @param params.args.shares - Number of V1 shares to migrate.
- * @param params.args.minSharePriceVaultV1 - Minimum V1 share price in RAY (slippage protection
- *   for the redeem leg).
  * @param params.args.maxSharePriceVaultV2 - Maximum V2 share price in RAY (inflation protection
  *   for the deposit leg).
- * @param params.args.recipient - Address that receives the V2 vault shares.
+ * @param params.args.userAddress - Account that receives the V2 vault shares. This
+ *   bundles-compatible successor replaces `recipient` before morpho-sdk v6.
+ * @param params.args.minSharePriceVaultV1 - Deprecated V1 redeem share-price floor. The successor
+ *   omits it because VaultBundlesV1 cannot enforce it.
+ * @param params.args.recipient - Deprecated address that receives the V2 vault shares.
  * @param params.args.requirementSignature - Optional pre-signed permit/permit2 for the V1 share
  *   transfer.
  * @param params.metadata - Optional analytics metadata attached to the bundle.
@@ -89,9 +104,8 @@ export interface VaultV1MigrateToV2Params {
  *     targetVault,
  *     targetAsset: USDC,
  *     shares: 1_000_000n,
- *     minSharePriceVaultV1: 0n, // disables redeem-leg slippage protection — production code should compute from source vault state + slippage tolerance
  *     maxSharePriceVaultV2: 1_010_000_000_000_000_000_000_000_000n, // RAY-scaled, 1.01x
- *     recipient,
+ *     userAddress,
  *   },
  * });
  * // tx satisfies Readonly<Transaction<VaultV1MigrateToV2Action>>
@@ -99,19 +113,20 @@ export interface VaultV1MigrateToV2Params {
  */
 export const vaultV1MigrateToV2 = ({
   vault: { chainId, address: sourceVault, asset: sourceAsset },
-  args: {
-    targetVault,
-    targetAsset,
-    shares,
-    minSharePriceVaultV1,
-    maxSharePriceVaultV2,
-    recipient,
-    requirementSignature,
-  },
+  args,
   metadata,
 }: VaultV1MigrateToV2Params): Readonly<
   Transaction<VaultV1MigrateToV2Action>
 > => {
+  const {
+    targetVault,
+    targetAsset,
+    shares,
+    maxSharePriceVaultV2,
+    requirementSignature,
+  } = args;
+  const minSharePriceVaultV1 = args.minSharePriceVaultV1 ?? 0n;
+  const recipient = args.userAddress ?? args.recipient;
   // Both bundle legs use maxUint256: an asset mismatch leaves the redeemed
   // source asset stranded on GA1 while the user receives only dust shares.
   if (!isAddressEqual(sourceAsset, targetAsset)) {

--- a/packages/morpho-sdk/src/actions/vaultV1/redeem.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/redeem.test.ts
@@ -20,8 +20,7 @@ describe("redeemVaultV1 unit tests", () => {
       },
       args: {
         shares,
-        recipient: client.account.address,
-        onBehalf: client.account.address,
+        userAddress: client.account.address,
       },
     });
 

--- a/packages/morpho-sdk/src/actions/vaultV1/redeem.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/redeem.ts
@@ -11,15 +11,27 @@ import {
 
 /** Parameters for {@link vaultV1Redeem}. */
 export interface VaultV1RedeemParams {
-  vault: {
-    address: Address;
+  readonly vault: {
+    readonly address: Address;
   };
-  args: {
-    shares: bigint;
-    recipient: Address;
-    onBehalf: Address;
-  };
-  metadata?: Metadata;
+  readonly args: {
+    readonly shares: bigint;
+  } & (
+    | {
+        /** Account that receives assets, owns the burned shares, and submits the successor route. */
+        readonly userAddress: Address;
+        readonly recipient?: never;
+        readonly onBehalf?: never;
+      }
+    | {
+        /** @deprecated Use `userAddress`; `recipient` is removed in morpho-sdk v6. */
+        readonly recipient: Address;
+        /** @deprecated Use `userAddress`; `onBehalf` is removed in morpho-sdk v6. */
+        readonly onBehalf: Address;
+        readonly userAddress?: never;
+      }
+  );
+  readonly metadata?: Metadata;
 }
 
 /**
@@ -29,8 +41,10 @@ export interface VaultV1RedeemParams {
  *
  * @param params.vault.address - The VaultV1 (MetaMorpho) address.
  * @param params.args.shares - Amount of vault shares to redeem.
- * @param params.args.recipient - Address that receives the redeemed assets.
- * @param params.args.onBehalf - Address whose shares are burned.
+ * @param params.args.userAddress - Account that receives the redeemed assets and owns the burned
+ *   shares. This bundles-compatible successor replaces `recipient` and `onBehalf` before v6.
+ * @param params.args.recipient - Deprecated address that receives the redeemed assets.
+ * @param params.args.onBehalf - Deprecated address whose shares are burned.
  * @param params.metadata - Optional analytics metadata attached to the transaction.
  * @returns A deep-frozen `Transaction<VaultV1RedeemAction>` with `to`, `value`, `data`, and the
  *   typed `action` discriminator the simulation layer consumes.
@@ -41,16 +55,19 @@ export interface VaultV1RedeemParams {
  *
  * const tx = vaultV1Redeem({
  *   vault: { address: vaultAddress },
- *   args: { shares: 1_000_000n, recipient, onBehalf },
+ *   args: { shares: 1_000_000n, userAddress },
  * });
  * // tx satisfies Readonly<Transaction<VaultV1RedeemAction>>
  * ```
  */
 export const vaultV1Redeem = ({
   vault: { address: vaultAddress },
-  args: { shares, recipient, onBehalf },
+  args,
   metadata,
 }: VaultV1RedeemParams): Readonly<Transaction<VaultV1RedeemAction>> => {
+  const { shares } = args;
+  const recipient = args.userAddress ?? args.recipient;
+  const onBehalf = args.userAddress ?? args.onBehalf;
   if (shares <= 0n) {
     throw new NonPositiveInputError("shares", shares);
   }

--- a/packages/morpho-sdk/src/actions/vaultV1/withdraw.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/withdraw.test.ts
@@ -20,8 +20,7 @@ describe("withdrawVaultV1 unit tests", () => {
       },
       args: {
         amount,
-        recipient: client.account.address,
-        onBehalf: client.account.address,
+        userAddress: client.account.address,
       },
     });
 

--- a/packages/morpho-sdk/src/actions/vaultV1/withdraw.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/withdraw.ts
@@ -11,15 +11,27 @@ import {
 
 /** Parameters for {@link vaultV1Withdraw}. */
 export interface VaultV1WithdrawParams {
-  vault: {
-    address: Address;
+  readonly vault: {
+    readonly address: Address;
   };
-  args: {
-    amount: bigint;
-    recipient: Address;
-    onBehalf: Address;
-  };
-  metadata?: Metadata;
+  readonly args: {
+    readonly amount: bigint;
+  } & (
+    | {
+        /** Account that receives assets, owns the burned shares, and submits the successor route. */
+        readonly userAddress: Address;
+        readonly recipient?: never;
+        readonly onBehalf?: never;
+      }
+    | {
+        /** @deprecated Use `userAddress`; `recipient` is removed in morpho-sdk v6. */
+        readonly recipient: Address;
+        /** @deprecated Use `userAddress`; `onBehalf` is removed in morpho-sdk v6. */
+        readonly onBehalf: Address;
+        readonly userAddress?: never;
+      }
+  );
+  readonly metadata?: Metadata;
 }
 
 /**
@@ -29,8 +41,10 @@ export interface VaultV1WithdrawParams {
  *
  * @param params.vault.address - The VaultV1 (MetaMorpho) address.
  * @param params.args.amount - Amount of underlying assets to withdraw.
- * @param params.args.recipient - Address that receives the withdrawn assets.
- * @param params.args.onBehalf - Address whose shares are burned.
+ * @param params.args.userAddress - Account that receives the withdrawn assets and owns the burned
+ *   shares. This bundles-compatible successor replaces `recipient` and `onBehalf` before v6.
+ * @param params.args.recipient - Deprecated address that receives the withdrawn assets.
+ * @param params.args.onBehalf - Deprecated address whose shares are burned.
  * @param params.metadata - Optional analytics metadata attached to the transaction.
  * @returns A deep-frozen `Transaction<VaultV1WithdrawAction>` with `to`, `value`, `data`, and the
  *   typed `action` discriminator the simulation layer consumes.
@@ -41,16 +55,19 @@ export interface VaultV1WithdrawParams {
  *
  * const tx = vaultV1Withdraw({
  *   vault: { address: vaultAddress },
- *   args: { amount: 500_000n, recipient, onBehalf },
+ *   args: { amount: 500_000n, userAddress },
  * });
  * // tx satisfies Readonly<Transaction<VaultV1WithdrawAction>>
  * ```
  */
 export const vaultV1Withdraw = ({
   vault: { address: vaultAddress },
-  args: { amount, recipient, onBehalf },
+  args,
   metadata,
 }: VaultV1WithdrawParams): Readonly<Transaction<VaultV1WithdrawAction>> => {
+  const { amount } = args;
+  const recipient = args.userAddress ?? args.recipient;
+  const onBehalf = args.userAddress ?? args.onBehalf;
   if (amount <= 0n) {
     throw new NonPositiveInputError("amount", amount);
   }

--- a/packages/morpho-sdk/src/actions/vaultV2/deposit.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/deposit.test.ts
@@ -75,7 +75,7 @@ describe("depositVaultV2 unit tests", () => {
       args: {
         amount: assets,
         maxSharePrice,
-        recipient: client.account.address,
+        userAddress: client.account.address,
         requirementSignature,
       },
     });

--- a/packages/morpho-sdk/src/actions/vaultV2/deposit.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/deposit.ts
@@ -18,17 +18,27 @@ import { getTokenRequirementActions } from "../signatures/getTokenRequirementAct
 
 /** Parameters for {@link vaultV2Deposit}. */
 export interface VaultV2DepositParams {
-  vault: {
-    chainId: number;
-    address: Address;
-    asset: Address;
+  readonly vault: {
+    readonly chainId: number;
+    readonly address: Address;
+    readonly asset: Address;
   };
-  args: DepositAmountArgs & {
-    maxSharePrice: bigint;
-    recipient: Address;
-    requirementSignature?: PermitRequirementSignature;
-  };
-  metadata?: Metadata;
+  readonly args: DepositAmountArgs & {
+    readonly maxSharePrice: bigint;
+    readonly requirementSignature?: PermitRequirementSignature;
+  } & (
+      | {
+          /** Account that receives the minted shares and submits the successor bundles route. */
+          readonly userAddress: Address;
+          readonly recipient?: never;
+        }
+      | {
+          /** @deprecated Use `userAddress`; `recipient` is removed in morpho-sdk v6. */
+          readonly recipient: Address;
+          readonly userAddress?: never;
+        }
+    );
+  readonly metadata?: Metadata;
 }
 
 /**
@@ -49,7 +59,9 @@ export interface VaultV2DepositParams {
  *   `nativeAmount` must be positive. Defaults to `0n`.
  * @param params.args.maxSharePrice - Maximum acceptable share price (in RAY, slippage
  *   protection enforced on-chain by `GeneralAdapter1`).
- * @param params.args.recipient - Address that receives the minted vault shares.
+ * @param params.args.userAddress - Account that receives the minted vault shares. This
+ *   bundles-compatible successor replaces `recipient` before morpho-sdk v6.
+ * @param params.args.recipient - Deprecated address that receives the minted vault shares.
  * @param params.args.requirementSignature - Optional pre-signed permit/permit2 approval.
  * @param params.args.nativeAmount - Optional amount of native token to wrap into wNative for the
  *   deposit. Requires the vault asset to be the chain's wNative.
@@ -79,7 +91,7 @@ export interface VaultV2DepositParams {
  *   args: {
  *     amount: 1_000_000n,
  *     maxSharePrice: 1_010_000_000_000_000_000_000_000_000n, // RAY-scaled, 1.01x
- *     recipient: depositor,
+ *     userAddress: depositor,
  *   },
  * });
  * // tx satisfies Readonly<Transaction<VaultV2DepositAction>>
@@ -87,15 +99,16 @@ export interface VaultV2DepositParams {
  */
 export const vaultV2Deposit = ({
   vault: { chainId, address: vaultAddress, asset },
-  args: {
-    amount = 0n,
-    maxSharePrice,
-    recipient,
-    requirementSignature,
-    nativeAmount,
-  },
+  args,
   metadata,
 }: VaultV2DepositParams): Readonly<Transaction<VaultV2DepositAction>> => {
+  const {
+    amount = 0n,
+    maxSharePrice,
+    requirementSignature,
+    nativeAmount,
+  } = args;
+  const recipient = args.userAddress ?? args.recipient;
   if (amount < 0n) {
     throw new NegativeInputError("amount", amount);
   }

--- a/packages/morpho-sdk/src/actions/vaultV2/redeem.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/redeem.test.ts
@@ -20,8 +20,7 @@ describe("redeemVaultV2 unit tests", () => {
       },
       args: {
         shares,
-        recipient: client.account.address,
-        onBehalf: client.account.address,
+        userAddress: client.account.address,
       },
     });
 

--- a/packages/morpho-sdk/src/actions/vaultV2/redeem.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/redeem.ts
@@ -11,15 +11,27 @@ import {
 
 /** Parameters for {@link vaultV2Redeem}. */
 export interface VaultV2RedeemParams {
-  vault: {
-    address: Address;
+  readonly vault: {
+    readonly address: Address;
   };
-  args: {
-    shares: bigint;
-    recipient: Address;
-    onBehalf: Address;
-  };
-  metadata?: Metadata;
+  readonly args: {
+    readonly shares: bigint;
+  } & (
+    | {
+        /** Account that receives assets, owns the burned shares, and submits the successor route. */
+        readonly userAddress: Address;
+        readonly recipient?: never;
+        readonly onBehalf?: never;
+      }
+    | {
+        /** @deprecated Use `userAddress`; `recipient` is removed in morpho-sdk v6. */
+        readonly recipient: Address;
+        /** @deprecated Use `userAddress`; `onBehalf` is removed in morpho-sdk v6. */
+        readonly onBehalf: Address;
+        readonly userAddress?: never;
+      }
+  );
+  readonly metadata?: Metadata;
 }
 
 /**
@@ -30,8 +42,10 @@ export interface VaultV2RedeemParams {
  *
  * @param params.vault.address - The VaultV2 address.
  * @param params.args.shares - Amount of vault shares to redeem.
- * @param params.args.recipient - Address that receives the redeemed assets.
- * @param params.args.onBehalf - Address whose shares are burned.
+ * @param params.args.userAddress - Account that receives the redeemed assets and owns the burned
+ *   shares. This bundles-compatible successor replaces `recipient` and `onBehalf` before v6.
+ * @param params.args.recipient - Deprecated address that receives the redeemed assets.
+ * @param params.args.onBehalf - Deprecated address whose shares are burned.
  * @param params.metadata - Optional analytics metadata attached to the transaction.
  * @returns A deep-frozen `Transaction<VaultV2RedeemAction>` with `to`, `value`, `data`, and the
  *   typed `action` discriminator the simulation layer consumes.
@@ -42,16 +56,19 @@ export interface VaultV2RedeemParams {
  *
  * const tx = vaultV2Redeem({
  *   vault: { address: vaultAddress },
- *   args: { shares: 1_000_000n, recipient, onBehalf },
+ *   args: { shares: 1_000_000n, userAddress },
  * });
  * // tx satisfies Readonly<Transaction<VaultV2RedeemAction>>
  * ```
  */
 export const vaultV2Redeem = ({
   vault: { address: vaultAddress },
-  args: { shares, recipient, onBehalf },
+  args,
   metadata,
 }: VaultV2RedeemParams): Readonly<Transaction<VaultV2RedeemAction>> => {
+  const { shares } = args;
+  const recipient = args.userAddress ?? args.recipient;
+  const onBehalf = args.userAddress ?? args.onBehalf;
   if (shares <= 0n) {
     throw new NonPositiveInputError("shares", shares);
   }

--- a/packages/morpho-sdk/src/actions/vaultV2/withdraw.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/withdraw.test.ts
@@ -20,8 +20,7 @@ describe("withdrawVaultV2 unit tests", () => {
       },
       args: {
         amount,
-        recipient: client.account.address,
-        onBehalf: client.account.address,
+        userAddress: client.account.address,
       },
     });
 

--- a/packages/morpho-sdk/src/actions/vaultV2/withdraw.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/withdraw.ts
@@ -11,15 +11,27 @@ import {
 
 /** Parameters for {@link vaultV2Withdraw}. */
 export interface VaultV2WithdrawParams {
-  vault: {
-    address: Address;
+  readonly vault: {
+    readonly address: Address;
   };
-  args: {
-    amount: bigint;
-    recipient: Address;
-    onBehalf: Address;
-  };
-  metadata?: Metadata;
+  readonly args: {
+    readonly amount: bigint;
+  } & (
+    | {
+        /** Account that receives assets, owns the burned shares, and submits the successor route. */
+        readonly userAddress: Address;
+        readonly recipient?: never;
+        readonly onBehalf?: never;
+      }
+    | {
+        /** @deprecated Use `userAddress`; `recipient` is removed in morpho-sdk v6. */
+        readonly recipient: Address;
+        /** @deprecated Use `userAddress`; `onBehalf` is removed in morpho-sdk v6. */
+        readonly onBehalf: Address;
+        readonly userAddress?: never;
+      }
+  );
+  readonly metadata?: Metadata;
 }
 
 /**
@@ -30,8 +42,10 @@ export interface VaultV2WithdrawParams {
  *
  * @param params.vault.address - The VaultV2 address.
  * @param params.args.amount - Amount of underlying assets to withdraw.
- * @param params.args.recipient - Address that receives the withdrawn assets.
- * @param params.args.onBehalf - Address whose shares are burned.
+ * @param params.args.userAddress - Account that receives the withdrawn assets and owns the burned
+ *   shares. This bundles-compatible successor replaces `recipient` and `onBehalf` before v6.
+ * @param params.args.recipient - Deprecated address that receives the withdrawn assets.
+ * @param params.args.onBehalf - Deprecated address whose shares are burned.
  * @param params.metadata - Optional analytics metadata attached to the transaction.
  * @returns A deep-frozen `Transaction<VaultV2WithdrawAction>` with `to`, `value`, `data`, and the
  *   typed `action` discriminator the simulation layer consumes.
@@ -42,16 +56,19 @@ export interface VaultV2WithdrawParams {
  *
  * const tx = vaultV2Withdraw({
  *   vault: { address: vaultAddress },
- *   args: { amount: 500_000n, recipient, onBehalf },
+ *   args: { amount: 500_000n, userAddress },
  * });
  * // tx satisfies Readonly<Transaction<VaultV2WithdrawAction>>
  * ```
  */
 export const vaultV2Withdraw = ({
   vault: { address: vaultAddress },
-  args: { amount, recipient, onBehalf },
+  args,
   metadata,
 }: VaultV2WithdrawParams): Readonly<Transaction<VaultV2WithdrawAction>> => {
+  const { amount } = args;
+  const recipient = args.userAddress ?? args.recipient;
+  const onBehalf = args.userAddress ?? args.onBehalf;
   if (amount <= 0n) {
     throw new NonPositiveInputError("amount", amount);
   }


### PR DESCRIPTION
## Summary

- add bundles-compatible `userAddress` branches to Vault V1/V2 deposit, withdraw, and redeem action inputs and Vault V1-to-Vault V2 migration
- retain the published `recipient`, `onBehalf`, and `minSharePriceVaultV1` branches with `@deprecated` guidance through one minor
- exercise both successor and legacy-compatible paths and add the required morpho-sdk minor changeset

## Release ordering

This is the predecessor minor required by #951 and #981. It must merge and publish before the VaultBundlesV1 major removes the deprecated branches.

## Validation

- `pnpm exec tsc --noEmit` in `packages/morpho-sdk`
- `pnpm exec vitest --project morpho-sdk --run`
- targeted Biome checks and commit-hook address lint
- `git diff --check`

## Dependent audit

`wdk-protocol-lending-morpho-evm` and `liquidity-sdk-viem` do not consume the added action-input branch, so neither needs its own release to resolve this additive surface.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->