### PR TITLE
refactor(morpho-sdk)!: share VaultBundlesV1 prerequisites

### DIFF
--- a/.changeset/vault-bundles-prerequisites.md
+++ b/.changeset/vault-bundles-prerequisites.md
@@ -1,0 +1,7 @@
+---
+"@morpho-org/morpho-sdk": major
+---
+
+Generalize the fixed-bundles token requirement surface shared by BlueBundlesV1 and VaultBundlesV1,
+including the distinct Permit2 SignatureTransfer discriminator, explicit unordered nonces, canonical
+Permit2 approvals, referral-fee math, vault bounds, and registered-spender validation.

--- a/.changeset/vault-bundles-prerequisites.md
+++ b/.changeset/vault-bundles-prerequisites.md
@@ -7,5 +7,9 @@ Generalize the fixed-bundles token requirement surface shared by BlueBundlesV1 a
 including the distinct Permit2 SignatureTransfer discriminator, explicit unordered nonces, canonical
 Permit2 approvals, referral-fee math, vault bounds, and registered-spender validation.
 
+Reject out-of-range uint256 pull amounts in the standalone requirement resolver. Share the
+canonical `BundleSharesPermit` tuple through the `BundlesSharesPermit` and
+`VaultExitBundlesV1PermitStruct` compatibility aliases.
+
 Update the WDK's public token requirement signatures to `BundlesTokenRequirementSignature` from
 the new morpho-sdk major.

--- a/.changeset/vault-bundles-prerequisites.md
+++ b/.changeset/vault-bundles-prerequisites.md
@@ -1,7 +1,11 @@
 ---
 "@morpho-org/morpho-sdk": major
+"@morpho-org/wdk-protocol-lending-morpho-evm": major
 ---
 
 Generalize the fixed-bundles token requirement surface shared by BlueBundlesV1 and VaultBundlesV1,
 including the distinct Permit2 SignatureTransfer discriminator, explicit unordered nonces, canonical
 Permit2 approvals, referral-fee math, vault bounds, and registered-spender validation.
+
+Update the WDK's public token requirement signatures to `BundlesTokenRequirementSignature` from
+the new morpho-sdk major.

--- a/packages/morpho-sdk/MIGRATION-v5-to-v6.md
+++ b/packages/morpho-sdk/MIGRATION-v5-to-v6.md
@@ -199,3 +199,24 @@ The `BlueReallocationPlan` union is removed. High-level Blue write inputs accept
 - Update transaction decoding, simulation fixtures, and action metadata fields; discriminator
   names remain stable.
 - Test native funding, full repay, and full-position migration paths used by the application.
+
+## Fixed-bundles token requirement APIs
+
+The Blue-only fixed-bundles requirement surface is generalized into a shared surface used by both
+BlueBundlesV1 and the upcoming VaultBundlesV1.
+
+| v5 symbol | v6 replacement |
+| --- | --- |
+| `getBlueBundlesV1TokenRequirements` (action-layer) | `getBundlesTokenRequirements` (entity-layer; reads state, so it now lives under `entities/requirements` instead of `actions/requirements/blue`). Takes the same funding parameters plus a `spender` naming the registered fixed bundles deployment (BlueBundlesV1 or VaultBundlesV1). |
+| `BlueBundlesV1TokenSignatureRequirement` / `BlueBundlesV1TokenRequirementSignature` | `BundlesTokenSignatureRequirement` / `BundlesTokenRequirementSignature` |
+| `encodeErc20Permit2TransferFrom` | `encodeErc20Permit2SignatureTransfer` |
+| Action discriminator `"permit2TransferFrom"` | `"permit2SignatureTransfer"` |
+| `Permit2TransferFromAction` / `Permit2TransferFromRequirementSignature` | `Permit2SignatureTransferAction` / `Permit2SignatureTransferRequirementSignature` |
+| `isPermit2TransferFromSignature` | `isPermit2SignatureTransferSignature` |
+| `selectRequirementSignatures` option and result field `permit2TransferFrom` | `permit2SignatureTransfer` |
+| `MissingPermit2TransferFromNonceError` | `MissingPermit2SignatureTransferNonceError` (old name kept as a `@deprecated` alias) |
+| `Permit2TransferFromNonceAlreadyUsedError` | `Permit2SignatureTransferNonceAlreadyUsedError` (old name kept as a `@deprecated` alias) |
+
+Update call sites and `switch`/discriminated-union checks on `action.type` to the new
+`"permit2SignatureTransfer"` tag; the signed payload shape (`nonce`, `deadline`, `signature`) is
+unchanged.

--- a/packages/morpho-sdk/src/abis.test.ts
+++ b/packages/morpho-sdk/src/abis.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import {
   blueBundlesV1Abi,
   publicAllocatorAbi,
+  vaultBundlesV1Abi,
   vaultV1PublicAllocatorAbi,
   vaultV2BluePublicAllocatorAbi,
 } from "./abis.js";
@@ -25,6 +26,26 @@ describe("blueBundlesV1Abi", () => {
       blueBundlesV1RepayAndWithdrawCollateral: "0x827d6bd8",
       blueBundlesV1Withdraw: "0xc0229fe8",
       blueBundlesV1MigrateBorrowPosition: "0x9834e387",
+    });
+  });
+});
+
+describe("vaultBundlesV1Abi", () => {
+  test("behavior: matches the pinned VaultBundlesV1 selectors", () => {
+    const selectors = Object.fromEntries(
+      vaultBundlesV1Abi
+        .filter((item) => item.type === "function")
+        .map((item) => [
+          item.name,
+          toFunctionSelector(toFunctionSignature(item)),
+        ]),
+    );
+
+    expect(selectors).toEqual({
+      initiator: "0x5c39fcc1",
+      vaultBundlesV1Deposit: "0x6bbba4e0",
+      vaultBundlesV1Withdraw: "0x932084a8",
+      vaultBundlesV1Migrate: "0x8355f776",
     });
   });
 });

--- a/packages/morpho-sdk/src/abis.ts
+++ b/packages/morpho-sdk/src/abis.ts
@@ -1250,7 +1250,7 @@ export const generalAdapter1Abi = [
   },
   {
     type: "function",
-    name: "permit2SignatureTransfer",
+    name: "permit2TransferFrom",
     inputs: [
       {
         name: "token",

--- a/packages/morpho-sdk/src/abis.ts
+++ b/packages/morpho-sdk/src/abis.ts
@@ -218,6 +218,147 @@ export const vaultExitBundlesV1Abi = [
   },
 ] as const satisfies Abi;
 
+/**
+ * Pinned ABI for the VaultBundlesV1 entrypoints used by Vault V1 and Vault V2 actions.
+ *
+ * Sourced from `morpho-org/bundles` commit
+ * `f27e7bcf744310303e24faa522b71d702e696686`.
+ */
+export const vaultBundlesV1Abi = [
+  { type: "error", name: "AlreadyInitiated", inputs: [] },
+  { type: "error", name: "DeadlinePassed", inputs: [] },
+  { type: "error", name: "InconsistentAssets", inputs: [] },
+  { type: "error", name: "NotExactlyOneZero", inputs: [] },
+  { type: "error", name: "PctExceeded", inputs: [] },
+  { type: "error", name: "SlippageExceeded", inputs: [] },
+  {
+    type: "function",
+    name: "initiator",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "vaultBundlesV1Deposit",
+    inputs: [
+      { name: "vault", type: "address", internalType: "address" },
+      { name: "assets", type: "uint256", internalType: "uint256" },
+      {
+        name: "maxSharePriceE27",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "assetPermit",
+        type: "tuple",
+        internalType: "struct TokenPermit",
+        components: [
+          { name: "kind", type: "uint8", internalType: "enum PermitKind" },
+          { name: "data", type: "bytes", internalType: "bytes" },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+        internalType: "address",
+      },
+      { name: "deadline", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "vaultBundlesV1Withdraw",
+    inputs: [
+      { name: "vault", type: "address", internalType: "address" },
+      { name: "assets", type: "uint256", internalType: "uint256" },
+      { name: "shares", type: "uint256", internalType: "uint256" },
+      {
+        name: "sharesPermit",
+        type: "tuple",
+        internalType: "struct Permit",
+        components: [
+          { name: "value", type: "uint256", internalType: "uint256" },
+          { name: "nonce", type: "uint256", internalType: "uint256" },
+          { name: "deadline", type: "uint256", internalType: "uint256" },
+          { name: "v", type: "uint8", internalType: "uint8" },
+          { name: "r", type: "bytes32", internalType: "bytes32" },
+          { name: "s", type: "bytes32", internalType: "bytes32" },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+        internalType: "address",
+      },
+      { name: "deadline", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "vaultBundlesV1Migrate",
+    inputs: [
+      { name: "sourceVault", type: "address", internalType: "address" },
+      { name: "destVault", type: "address", internalType: "address" },
+      {
+        name: "assetsWithdrawn",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "sharesRedeemed",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "destMaxSharePriceE27",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "sharesPermit",
+        type: "tuple",
+        internalType: "struct Permit",
+        components: [
+          { name: "value", type: "uint256", internalType: "uint256" },
+          { name: "nonce", type: "uint256", internalType: "uint256" },
+          { name: "deadline", type: "uint256", internalType: "uint256" },
+          { name: "v", type: "uint8", internalType: "uint8" },
+          { name: "r", type: "bytes32", internalType: "bytes32" },
+          { name: "s", type: "bytes32", internalType: "bytes32" },
+        ],
+      },
+      {
+        name: "referralFeePct",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "referralFeeRecipient",
+        type: "address",
+        internalType: "address",
+      },
+      { name: "deadline", type: "uint256", internalType: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+] as const satisfies Abi;
+
 /** ABI for the Bundler3 multicall contract. */
 export const bundler3Abi = [
   {
@@ -1109,7 +1250,7 @@ export const generalAdapter1Abi = [
   },
   {
     type: "function",
-    name: "permit2TransferFrom",
+    name: "permit2SignatureTransfer",
     inputs: [
       {
         name: "token",

--- a/packages/morpho-sdk/src/actions/blue/borrow.ts
+++ b/packages/morpho-sdk/src/actions/blue/borrow.ts
@@ -70,7 +70,7 @@ export interface BlueBorrowParams {
  * @throws {ReallocationWithdrawalOnTargetMarketError} when a source is the target market.
  * @throws {ReallocationLoanTokenMismatchError} when a source market uses another loan token.
  * @throws {DepositOwnerMismatchError} when the signed authorization owner differs from `userAddress`.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when authorization cannot be bound safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when authorization cannot be bound safely.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.
  * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
  * @example

--- a/packages/morpho-sdk/src/actions/blue/common.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/common.test.ts
@@ -57,7 +57,7 @@ const permit2SignatureTransfer = {
   },
   action: {
     type: "permit2SignatureTransfer",
-    args: { spender, amount: 5n, deadline: 123n },
+    args: { spender, amount: 5n, nonce: 2n, deadline: 123n },
   },
 } satisfies BundlesTokenRequirementSignature;
 
@@ -150,6 +150,7 @@ const permit2SignatureTransferPermit = (
   action: {
     type: "permit2SignatureTransfer",
     args: {
+      nonce: argsOverrides.nonce ?? 9n,
       spender: blueBundlesV1,
       amount: permitAmount,
       deadline: permitDeadline,
@@ -363,7 +364,7 @@ describe("getBlueBundlesV1TokenPermit", () => {
         userAddress: owner,
         token: asset,
         amount: permitAmount,
-        requirementSignature: permit2Allowance,
+        requirementSignature: permit2Allowance as unknown as BundlesTokenRequirementSignature,
       });
     } catch (error) {
       thrown = error;

--- a/packages/morpho-sdk/src/actions/blue/common.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/common.test.ts
@@ -14,15 +14,15 @@ import { describe, expect, test } from "vitest";
 import {
   AmbiguousRequirementSignaturesError,
   type AuthorizationRequirementSignature,
-  BlueBundlesV1RequirementSignatureMismatchError,
-  type BlueBundlesV1TokenRequirementSignature,
+  BundlesRequirementSignatureMismatchError,
+  type BundlesTokenRequirementSignature,
   DepositAmountMismatchError,
   DepositAssetMismatchError,
   DepositOwnerMismatchError,
   DepositSpenderMismatchError,
   type Erc2612RequirementSignature,
   type Permit2AllowanceRequirementSignature,
-  type Permit2TransferFromRequirementSignature,
+  type Permit2SignatureTransferRequirementSignature,
 } from "../../types/index.js";
 import {
   getBlueBundlesV1SignedAuthorization,
@@ -44,9 +44,9 @@ const permit = {
     deadline: 123n,
   },
   action: { type: "permit", args: { spender, amount: 5n, deadline: 123n } },
-} satisfies BlueBundlesV1TokenRequirementSignature;
+} satisfies BundlesTokenRequirementSignature;
 
-const permit2TransferFrom = {
+const permit2SignatureTransfer = {
   args: {
     owner,
     nonce: 2n,
@@ -56,10 +56,10 @@ const permit2TransferFrom = {
     deadline: 123n,
   },
   action: {
-    type: "permit2TransferFrom",
+    type: "permit2SignatureTransfer",
     args: { spender, amount: 5n, deadline: 123n },
   },
-} satisfies BlueBundlesV1TokenRequirementSignature;
+} satisfies BundlesTokenRequirementSignature;
 
 describe("selectBlueBundlesV1RequirementSignatures", () => {
   test("default: returns the single accepted token signature", () => {
@@ -69,11 +69,11 @@ describe("selectBlueBundlesV1RequirementSignatures", () => {
     expect(selected.token).toBe(permit);
   });
 
-  test("error: AmbiguousRequirementSignaturesError when both a permit and a permit2TransferFrom target the single token slot", () => {
+  test("error: AmbiguousRequirementSignaturesError when both a permit and a permit2SignatureTransfer target the single token slot", () => {
     // The single BlueBundlesV1 permit slot can carry one token signature; two competing ones would
     // otherwise silently drop one and mis-fund the bundle, so the selector must reject them.
     expect(() =>
-      selectBlueBundlesV1RequirementSignatures([permit, permit2TransferFrom], {
+      selectBlueBundlesV1RequirementSignatures([permit, permit2SignatureTransfer], {
         token: true,
       }),
     ).toThrow(AmbiguousRequirementSignaturesError);
@@ -132,12 +132,12 @@ const erc2612Permit = (
   },
 });
 
-const permit2TransferFromPermit = (
-  argsOverrides: Partial<Permit2TransferFromRequirementSignature["args"]> = {},
+const permit2SignatureTransferPermit = (
+  argsOverrides: Partial<Permit2SignatureTransferRequirementSignature["args"]> = {},
   actionArgsOverrides: Partial<
-    Permit2TransferFromRequirementSignature["action"]["args"]
+    Permit2SignatureTransferRequirementSignature["action"]["args"]
   > = {},
-): Permit2TransferFromRequirementSignature => ({
+): Permit2SignatureTransferRequirementSignature => ({
   args: {
     owner,
     nonce: 9n,
@@ -148,7 +148,7 @@ const permit2TransferFromPermit = (
     ...argsOverrides,
   },
   action: {
-    type: "permit2TransferFrom",
+    type: "permit2SignatureTransfer",
     args: {
       spender: blueBundlesV1,
       amount: permitAmount,
@@ -236,7 +236,7 @@ describe("getBlueBundlesV1TokenPermit", () => {
       userAddress: owner,
       token: asset,
       amount: permitAmount,
-      requirementSignature: permit2TransferFromPermit({ nonce: 42n }),
+      requirementSignature: permit2SignatureTransferPermit({ nonce: 42n }),
     });
 
     expect(tokenPermit.kind).toBe(2);
@@ -311,7 +311,7 @@ describe("getBlueBundlesV1TokenPermit", () => {
     ).toThrow(DepositSpenderMismatchError);
   });
 
-  test("error: BlueBundlesV1RequirementSignatureMismatchError on inconsistent permit deadlines", () => {
+  test("error: BundlesRequirementSignatureMismatchError on inconsistent permit deadlines", () => {
     let thrown: unknown;
     try {
       getBlueBundlesV1TokenPermit({
@@ -329,12 +329,12 @@ describe("getBlueBundlesV1TokenPermit", () => {
     }
 
     expect(thrown).toBeInstanceOf(
-      BlueBundlesV1RequirementSignatureMismatchError,
+      BundlesRequirementSignatureMismatchError,
     );
     expect(thrown).toMatchObject({ field: "deadline" });
   });
 
-  test("error: BlueBundlesV1RequirementSignatureMismatchError rejects a Permit2 AllowanceTransfer signature", () => {
+  test("error: BundlesRequirementSignatureMismatchError rejects a Permit2 AllowanceTransfer signature", () => {
     const permit2Allowance: Permit2AllowanceRequirementSignature = {
       args: {
         owner,
@@ -370,12 +370,12 @@ describe("getBlueBundlesV1TokenPermit", () => {
     }
 
     expect(thrown).toBeInstanceOf(
-      BlueBundlesV1RequirementSignatureMismatchError,
+      BundlesRequirementSignatureMismatchError,
     );
     expect(thrown).toMatchObject({ field: "type" });
   });
 
-  test("error: BlueBundlesV1RequirementSignatureMismatchError preserves the parser cause for a malformed signature", () => {
+  test("error: BundlesRequirementSignatureMismatchError preserves the parser cause for a malformed signature", () => {
     let thrown: unknown;
     try {
       getBlueBundlesV1TokenPermit({
@@ -390,9 +390,9 @@ describe("getBlueBundlesV1TokenPermit", () => {
     }
 
     expect(thrown).toBeInstanceOf(
-      BlueBundlesV1RequirementSignatureMismatchError,
+      BundlesRequirementSignatureMismatchError,
     );
-    if (!(thrown instanceof BlueBundlesV1RequirementSignatureMismatchError))
+    if (!(thrown instanceof BundlesRequirementSignatureMismatchError))
       throw thrown;
     expect(thrown.field).toBe("signature");
     expect(thrown.cause).toBeInstanceOf(Error);
@@ -412,7 +412,7 @@ describe("getBlueBundlesV1TokenPermit", () => {
             userAddress: owner,
             token: asset,
             amount,
-            requirementSignature: permit2TransferFromPermit(
+            requirementSignature: permit2SignatureTransferPermit(
               { amount, deadline, nonce },
               { amount, deadline },
             ),
@@ -502,7 +502,7 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
       }
 
       expect(thrown).toBeInstanceOf(
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       );
       expect(thrown).toMatchObject({ field: "authorized" });
     },
@@ -532,13 +532,13 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
       }
 
       expect(thrown).toBeInstanceOf(
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       );
       expect(thrown).toMatchObject({ field: "isAuthorized" });
     },
   );
 
-  test("error: BlueBundlesV1RequirementSignatureMismatchError on inconsistent authorization deadlines", () => {
+  test("error: BundlesRequirementSignatureMismatchError on inconsistent authorization deadlines", () => {
     let thrown: unknown;
     try {
       getBlueBundlesV1SignedAuthorization({
@@ -554,12 +554,12 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
     }
 
     expect(thrown).toBeInstanceOf(
-      BlueBundlesV1RequirementSignatureMismatchError,
+      BundlesRequirementSignatureMismatchError,
     );
     expect(thrown).toMatchObject({ field: "deadline" });
   });
 
-  test("error: BlueBundlesV1RequirementSignatureMismatchError preserves the parser cause for a malformed signature", () => {
+  test("error: BundlesRequirementSignatureMismatchError preserves the parser cause for a malformed signature", () => {
     let thrown: unknown;
     try {
       getBlueBundlesV1SignedAuthorization({
@@ -572,9 +572,9 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
     }
 
     expect(thrown).toBeInstanceOf(
-      BlueBundlesV1RequirementSignatureMismatchError,
+      BundlesRequirementSignatureMismatchError,
     );
-    if (!(thrown instanceof BlueBundlesV1RequirementSignatureMismatchError))
+    if (!(thrown instanceof BundlesRequirementSignatureMismatchError))
       throw thrown;
     expect(thrown.field).toBe("signature");
     expect(thrown.cause).toBeInstanceOf(Error);

--- a/packages/morpho-sdk/src/actions/blue/common.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/common.test.ts
@@ -23,6 +23,7 @@ import {
   type Erc2612RequirementSignature,
   type Permit2AllowanceRequirementSignature,
   type Permit2SignatureTransferRequirementSignature,
+  UnexpectedRequirementSignatureError,
 } from "../../types/index.js";
 import {
   getBlueBundlesV1SignedAuthorization,
@@ -73,9 +74,12 @@ describe("selectBlueBundlesV1RequirementSignatures", () => {
     // The single BlueBundlesV1 permit slot can carry one token signature; two competing ones would
     // otherwise silently drop one and mis-fund the bundle, so the selector must reject them.
     expect(() =>
-      selectBlueBundlesV1RequirementSignatures([permit, permit2SignatureTransfer], {
-        token: true,
-      }),
+      selectBlueBundlesV1RequirementSignatures(
+        [permit, permit2SignatureTransfer],
+        {
+          token: true,
+        },
+      ),
     ).toThrow(AmbiguousRequirementSignaturesError);
   });
 });
@@ -133,7 +137,9 @@ const erc2612Permit = (
 });
 
 const permit2SignatureTransferPermit = (
-  argsOverrides: Partial<Permit2SignatureTransferRequirementSignature["args"]> = {},
+  argsOverrides: Partial<
+    Permit2SignatureTransferRequirementSignature["args"]
+  > = {},
   actionArgsOverrides: Partial<
     Permit2SignatureTransferRequirementSignature["action"]["args"]
   > = {},
@@ -329,13 +335,11 @@ describe("getBlueBundlesV1TokenPermit", () => {
       thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(
-      BundlesRequirementSignatureMismatchError,
-    );
+    expect(thrown).toBeInstanceOf(BundlesRequirementSignatureMismatchError);
     expect(thrown).toMatchObject({ field: "deadline" });
   });
 
-  test("error: BundlesRequirementSignatureMismatchError rejects a Permit2 AllowanceTransfer signature", () => {
+  test("error: UnexpectedRequirementSignatureError rejects a Permit2 AllowanceTransfer signature", () => {
     const permit2Allowance: Permit2AllowanceRequirementSignature = {
       args: {
         owner,
@@ -364,16 +368,14 @@ describe("getBlueBundlesV1TokenPermit", () => {
         userAddress: owner,
         token: asset,
         amount: permitAmount,
-        requirementSignature: permit2Allowance as unknown as BundlesTokenRequirementSignature,
+        requirementSignature:
+          permit2Allowance as unknown as BundlesTokenRequirementSignature,
       });
     } catch (error) {
       thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(
-      BundlesRequirementSignatureMismatchError,
-    );
-    expect(thrown).toMatchObject({ field: "type" });
+    expect(thrown).toBeInstanceOf(UnexpectedRequirementSignatureError);
   });
 
   test("error: BundlesRequirementSignatureMismatchError preserves the parser cause for a malformed signature", () => {
@@ -390,9 +392,7 @@ describe("getBlueBundlesV1TokenPermit", () => {
       thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(
-      BundlesRequirementSignatureMismatchError,
-    );
+    expect(thrown).toBeInstanceOf(BundlesRequirementSignatureMismatchError);
     if (!(thrown instanceof BundlesRequirementSignatureMismatchError))
       throw thrown;
     expect(thrown.field).toBe("signature");
@@ -502,9 +502,7 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
         thrown = error;
       }
 
-      expect(thrown).toBeInstanceOf(
-        BundlesRequirementSignatureMismatchError,
-      );
+      expect(thrown).toBeInstanceOf(BundlesRequirementSignatureMismatchError);
       expect(thrown).toMatchObject({ field: "authorized" });
     },
   );
@@ -532,9 +530,7 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
         thrown = error;
       }
 
-      expect(thrown).toBeInstanceOf(
-        BundlesRequirementSignatureMismatchError,
-      );
+      expect(thrown).toBeInstanceOf(BundlesRequirementSignatureMismatchError);
       expect(thrown).toMatchObject({ field: "isAuthorized" });
     },
   );
@@ -554,9 +550,7 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
       thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(
-      BundlesRequirementSignatureMismatchError,
-    );
+    expect(thrown).toBeInstanceOf(BundlesRequirementSignatureMismatchError);
     expect(thrown).toMatchObject({ field: "deadline" });
   });
 
@@ -572,9 +566,7 @@ describe("getBlueBundlesV1SignedAuthorization", () => {
       thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(
-      BundlesRequirementSignatureMismatchError,
-    );
+    expect(thrown).toBeInstanceOf(BundlesRequirementSignatureMismatchError);
     if (!(thrown instanceof BundlesRequirementSignatureMismatchError))
       throw thrown;
     expect(thrown.field).toBe("signature");

--- a/packages/morpho-sdk/src/actions/blue/common.ts
+++ b/packages/morpho-sdk/src/actions/blue/common.ts
@@ -7,7 +7,6 @@ import { deepFreeze, getChainAddress } from "@morpho-org/morpho-ts";
 import {
   type Address,
   compactSignatureToSignature,
-  encodeAbiParameters,
   type Hex,
   isAddressEqual,
   maxUint256,
@@ -27,27 +26,25 @@ import {
   AmbiguousRequirementSignaturesError,
   type AuthorizationRequirementSignature,
   type BaseAction,
-  BlueBundlesV1RequirementSignatureMismatchError,
-  type BlueBundlesV1TokenRequirementSignature,
-  DepositAmountMismatchError,
-  DepositAssetMismatchError,
+  BundlesRequirementSignatureMismatchError,
+  type BundlesTokenRequirementSignature,
   DepositOwnerMismatchError,
-  DepositSpenderMismatchError,
   type Erc2612RequirementSignature,
-  InputExceedsMaxError,
   type Metadata,
-  MissingReferralFeeRecipientError,
   NativeFundingAmountMismatchError,
   NegativeInputError,
-  NonPositiveInputError,
   ReallocationLoanTokenMismatchError,
   type RequirementSignature,
   selectRequirementSignatures,
-  type TokenRequirementSignature,
   type Transaction,
   UnexpectedRequirementSignatureError,
   type VaultV2BlueReallocation,
 } from "../../types/index.js";
+import {
+  type BundlesTokenPermit,
+  getBundlesTokenPermit,
+  normalizeBundlesCommonParams,
+} from "../bundles/index.js";
 
 /** @internal */
 export interface BlueBundlesV1CommonParams {
@@ -65,33 +62,13 @@ export interface NormalizedBlueBundlesV1CommonParams {
   referralFeeRecipient: Address;
 }
 
-/**
- * BlueBundlesV1 token-permit discriminator carried in the encoded permit struct: `none` (0) skips
- * the pull, `erc2612` (1) is an ERC-2612 permit, `permit2TransferFrom` (2) is a Permit2
- * SignatureTransfer. Named so a transposed literal can't silently route a permit to the wrong branch.
- * @internal
- */
-const BLUE_BUNDLES_V1_TOKEN_PERMIT_KIND = {
-  none: 0,
-  erc2612: 1,
-  permit2TransferFrom: 2,
-} as const;
-
-interface BlueBundlesV1TokenPermit {
-  kind: (typeof BLUE_BUNDLES_V1_TOKEN_PERMIT_KIND)[keyof typeof BLUE_BUNDLES_V1_TOKEN_PERMIT_KIND];
-  data: Hex;
-}
+type BlueBundlesV1TokenPermit = BundlesTokenPermit;
 
 interface BlueBundlesV1SignedAuthorization {
   signature: { v: number; r: Hex; s: Hex };
   nonce: bigint;
   deadline: bigint;
 }
-
-const EMPTY_TOKEN_PERMIT: BlueBundlesV1TokenPermit = {
-  kind: BLUE_BUNDLES_V1_TOKEN_PERMIT_KIND.none,
-  data: "0x",
-};
 
 const EMPTY_SIGNED_AUTHORIZATION: BlueBundlesV1SignedAuthorization = {
   signature: { v: 0, r: zeroHash, s: zeroHash },
@@ -103,37 +80,10 @@ const EMPTY_SIGNED_AUTHORIZATION: BlueBundlesV1SignedAuthorization = {
 export const normalizeBlueBundlesV1CommonParams = (
   params: BlueBundlesV1CommonParams,
 ): NormalizedBlueBundlesV1CommonParams => {
-  if (params.deadline <= 0n) {
-    throw new NonPositiveInputError("deadline", params.deadline);
-  }
-  if (params.deadline > maxUint256) {
-    throw new InputExceedsMaxError({
-      field: "deadline",
-      value: params.deadline,
-      max: maxUint256,
-    });
-  }
-  const referralFeePct = params.referralFeePct ?? 0n;
-  if (referralFeePct < 0n) {
-    throw new NegativeInputError("referralFeePct", referralFeePct);
-  }
-  if (referralFeePct >= MathLib.WAD) {
-    throw new InputExceedsMaxError({
-      field: "referralFeePct",
-      value: referralFeePct,
-      max: MathLib.WAD - 1n,
-    });
-  }
-  if (
-    referralFeePct > 0n &&
-    (params.referralFeeRecipient == null ||
-      isAddressEqual(params.referralFeeRecipient, zeroAddress))
-  ) {
-    throw new MissingReferralFeeRecipientError();
-  }
+  const normalized = normalizeBundlesCommonParams(params);
   return {
-    referralFeePct,
-    referralFeeRecipient: params.referralFeeRecipient ?? zeroAddress,
+    referralFeePct: normalized.referralFeePct,
+    referralFeeRecipient: normalized.referralFeeRecipient,
   };
 };
 
@@ -143,7 +93,7 @@ export const validateBlueBundlesV1NativeFunding = (params: {
   token: Address;
   fundedAmount: bigint;
   nativeAmount?: bigint;
-  requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+  requirementSignature?: BundlesTokenRequirementSignature;
 }): bigint => {
   const nativeAmount = params.nativeAmount ?? 0n;
   if (nativeAmount < 0n) {
@@ -172,117 +122,15 @@ export const getBlueBundlesV1TokenPermit = (params: {
   userAddress: Address;
   token: Address;
   amount: bigint;
-  requirementSignature?: TokenRequirementSignature;
+  requirementSignature?: BundlesTokenRequirementSignature;
 }): BlueBundlesV1TokenPermit => {
-  const { requirementSignature } = params;
-  if (requirementSignature == null) return EMPTY_TOKEN_PERMIT;
-
-  const spender = getChainAddress(params.chainId, "bundles.blueBundlesV1");
-  if (!isAddressEqual(requirementSignature.args.owner, params.userAddress)) {
-    throw new DepositOwnerMismatchError(
-      params.userAddress,
-      requirementSignature.args.owner,
-    );
-  }
-  if (!isAddressEqual(requirementSignature.args.asset, params.token)) {
-    throw new DepositAssetMismatchError(
-      params.token,
-      requirementSignature.args.asset,
-    );
-  }
-  if (requirementSignature.args.amount !== params.amount) {
-    throw new DepositAmountMismatchError(
-      params.amount,
-      requirementSignature.args.amount,
-    );
-  }
-  if (!isAddressEqual(requirementSignature.action.args.spender, spender)) {
-    throw new DepositSpenderMismatchError(
-      spender,
-      requirementSignature.action.args.spender,
-    );
-  }
-  if (requirementSignature.action.args.amount !== params.amount) {
-    throw new DepositAmountMismatchError(
-      params.amount,
-      requirementSignature.action.args.amount,
-    );
-  }
-  if (
-    requirementSignature.action.args.deadline !==
-    requirementSignature.args.deadline
-  ) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
-      field: "deadline",
-      expected: String(requirementSignature.args.deadline),
-      actual: String(requirementSignature.action.args.deadline),
-    });
-  }
-
-  if (requirementSignature.action.type === "permit2TransferFrom") {
-    return {
-      kind: BLUE_BUNDLES_V1_TOKEN_PERMIT_KIND.permit2TransferFrom,
-      data: encodeAbiParameters(
-        [
-          { type: "uint256", name: "nonce" },
-          { type: "uint256", name: "deadline" },
-          { type: "bytes", name: "signature" },
-        ],
-        [
-          requirementSignature.args.nonce,
-          requirementSignature.args.deadline,
-          requirementSignature.args.signature,
-        ],
-      ),
-    };
-  }
-  if (requirementSignature.action.type !== "permit") {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
-      field: "type",
-      expected: "permit or permit2TransferFrom",
-      actual: requirementSignature.action.type,
-    });
-  }
-
-  const serializedSignature = requirementSignature.args.signature;
-  let parsed: Signature;
-  try {
-    parsed =
-      size(serializedSignature) === 64
-        ? compactSignatureToSignature(
-            parseCompactSignature(serializedSignature),
-          )
-        : parseSignature(serializedSignature);
-  } catch (cause) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
-      field: "signature",
-      expected: "a 64-byte compact or 65-byte serialized ECDSA signature",
-      actual: serializedSignature,
-      cause,
-    });
-  }
-  const v =
-    parsed.v ??
-    (parsed.yParity == null ? undefined : BigInt(parsed.yParity + 27));
-  if (v == null) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
-      field: "signature",
-      expected: "a signature containing v or yParity",
-      actual: serializedSignature,
-    });
-  }
-  return {
-    kind: BLUE_BUNDLES_V1_TOKEN_PERMIT_KIND.erc2612,
-    data: encodeAbiParameters(
-      [
-        { type: "uint256", name: "deadline" },
-        { type: "uint8", name: "v" },
-        { type: "bytes32", name: "r" },
-        { type: "bytes32", name: "s" },
-      ],
-      [requirementSignature.args.deadline, Number(v), parsed.r, parsed.s],
-    ),
-  };
+  return getBundlesTokenPermit({
+    userAddress: params.userAddress,
+    token: params.token,
+    spender: getChainAddress(params.chainId, "bundles.blueBundlesV1"),
+    amount: params.amount,
+    requirementSignature: params.requirementSignature,
+  });
 };
 
 /** @internal */
@@ -302,7 +150,7 @@ export const getBlueBundlesV1SignedAuthorization = (params: {
     );
   }
   if (!isAddressEqual(authorizationSignature.args.authorized, authorized)) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "authorized",
       expected: authorized,
       actual: authorizationSignature.args.authorized,
@@ -311,21 +159,21 @@ export const getBlueBundlesV1SignedAuthorization = (params: {
   if (
     !isAddressEqual(authorizationSignature.action.args.authorized, authorized)
   ) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "authorized",
       expected: authorized,
       actual: authorizationSignature.action.args.authorized,
     });
   }
   if (!authorizationSignature.args.isAuthorized) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "isAuthorized",
       expected: "true",
       actual: String(authorizationSignature.args.isAuthorized),
     });
   }
   if (!authorizationSignature.action.args.isAuthorized) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "isAuthorized",
       expected: "true",
       actual: String(authorizationSignature.action.args.isAuthorized),
@@ -335,7 +183,7 @@ export const getBlueBundlesV1SignedAuthorization = (params: {
     authorizationSignature.action.args.deadline !==
     authorizationSignature.args.deadline
   ) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "deadline",
       expected: String(authorizationSignature.args.deadline),
       actual: String(authorizationSignature.action.args.deadline),
@@ -352,7 +200,7 @@ export const getBlueBundlesV1SignedAuthorization = (params: {
           )
         : parseSignature(serializedSignature);
   } catch (cause) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "signature",
       expected: "a 64-byte compact or 65-byte serialized ECDSA signature",
       actual: serializedSignature,
@@ -363,7 +211,7 @@ export const getBlueBundlesV1SignedAuthorization = (params: {
     parsed.v ??
     (parsed.yParity == null ? undefined : BigInt(parsed.yParity + 27));
   if (v == null) {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "signature",
       expected: "a signature containing v or yParity",
       actual: serializedSignature,
@@ -448,29 +296,29 @@ export const selectBlueBundlesV1RequirementSignatures = (
   signatures: readonly RequirementSignature[] | undefined,
   accepts: { token?: boolean; authorization?: boolean },
 ): {
-  token?: BlueBundlesV1TokenRequirementSignature;
+  token?: BundlesTokenRequirementSignature;
   authorization?: AuthorizationRequirementSignature;
 } => {
-  const { permit, permit2TransferFrom, authorization } =
+  const { permit, permit2SignatureTransfer, authorization } =
     selectRequirementSignatures(signatures, {
       permit: accepts.token,
-      permit2TransferFrom: accepts.token,
+      permit2SignatureTransfer: accepts.token,
       authorization: accepts.authorization,
     });
   if (permit?.action.type === "permit2") {
-    throw new BlueBundlesV1RequirementSignatureMismatchError({
+    throw new BundlesRequirementSignatureMismatchError({
       field: "type",
-      expected: "permit or permit2TransferFrom",
+      expected: "permit or permit2SignatureTransfer",
       actual: permit.action.type,
     });
   }
-  if (permit != null && permit2TransferFrom != null) {
+  if (permit != null && permit2SignatureTransfer != null) {
     throw new AmbiguousRequirementSignaturesError("permit", 2);
   }
   return {
     token:
       (permit as Erc2612RequirementSignature | undefined) ??
-      permit2TransferFrom,
+      permit2SignatureTransfer,
     authorization,
   };
 };

--- a/packages/morpho-sdk/src/actions/blue/common.ts
+++ b/packages/morpho-sdk/src/actions/blue/common.ts
@@ -39,10 +39,10 @@ import {
   UnexpectedRequirementSignatureError,
   type VaultV2BlueReallocation,
 } from "../../types/index.js";
+import { normalizeBundlesCommonParams } from "../bundles/common.js";
 import {
   type BundlesTokenPermit,
   getBundlesTokenPermit,
-  normalizeBundlesCommonParams,
 } from "../bundles/index.js";
 
 /** @internal */

--- a/packages/morpho-sdk/src/actions/blue/common.ts
+++ b/packages/morpho-sdk/src/actions/blue/common.ts
@@ -9,7 +9,6 @@ import {
   compactSignatureToSignature,
   type Hex,
   isAddressEqual,
-  maxUint256,
   parseCompactSignature,
   parseSignature,
   type Signature,

--- a/packages/morpho-sdk/src/actions/blue/refinance.ts
+++ b/packages/morpho-sdk/src/actions/blue/refinance.ts
@@ -89,7 +89,7 @@ export interface BlueRefinanceParams {
  * @throws {ReallocationWithdrawalOnTargetMarketError} when a source is the destination market.
  * @throws {ReallocationLoanTokenMismatchError} when a source market uses another loan token.
  * @throws {DepositOwnerMismatchError} when the signed authorization owner differs from `userAddress`.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when authorization cannot be bound safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when authorization cannot be bound safely.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.
  * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
  * @example

--- a/packages/morpho-sdk/src/actions/blue/repay.ts
+++ b/packages/morpho-sdk/src/actions/blue/repay.ts
@@ -2,8 +2,8 @@ import type { MarketParams } from "@morpho-org/blue-sdk";
 import { deepFreeze } from "@morpho-org/morpho-ts";
 import { type Address, maxUint256 } from "viem";
 import type {
-  BlueBundlesV1TokenRequirementSignature,
   BlueRepayAction,
+  BundlesTokenRequirementSignature,
   Metadata,
   Transaction,
 } from "../../types/index.js";
@@ -35,7 +35,7 @@ export interface BlueRepayParams {
     /** Recipient required when `referralFeePct` is positive. */
     readonly referralFeeRecipient?: Address;
     /** Optional loan-token ERC-2612 or Permit2 SignatureTransfer result. */
-    readonly requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+    readonly requirementSignature?: BundlesTokenRequirementSignature;
   };
   /** Optional transaction metadata suffix. */
   readonly metadata?: Metadata;
@@ -74,7 +74,7 @@ export interface BlueRepayParams {
  * @throws {DepositAssetMismatchError} when the signed asset differs from the loan token.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `maxRepayAssets`.
  * @throws {DepositSpenderMismatchError} when the signed spender is not BlueBundlesV1.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when a signature cannot be encoded safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when a signature cannot be encoded safely.
  * @throws {InputExceedsMaxError} when the referral fee is at least WAD.
  * @throws {MissingReferralFeeRecipientError} when a positive fee has no recipient.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.

--- a/packages/morpho-sdk/src/actions/blue/repayWithdrawCollateral.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/repayWithdrawCollateral.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, test } from "vitest";
 import { blueBundlesV1Abi } from "../../abis.js";
 import {
   type AuthorizationRequirementSignature,
-  type BlueBundlesV1TokenRequirementSignature,
+  type BundlesTokenRequirementSignature,
   InputExceedsMaxError,
   MaxRepayAssetsBelowRepayAssetsError,
   MutuallyExclusiveRepayAmountsError,
@@ -403,10 +403,10 @@ describe("blueRepayWithdrawCollateral", () => {
         deadline,
       },
       action: {
-        type: "permit2TransferFrom",
-        args: { spender: blueBundlesV1, amount: 5n, deadline },
+        type: "permit2SignatureTransfer",
+        args: { spender: blueBundlesV1, amount: 5n, nonce: 1n, deadline },
       },
-    } satisfies BlueBundlesV1TokenRequirementSignature;
+    } satisfies BundlesTokenRequirementSignature;
     const authorizationSignature = {
       args: {
         owner: userAddress,

--- a/packages/morpho-sdk/src/actions/blue/repayWithdrawCollateral.ts
+++ b/packages/morpho-sdk/src/actions/blue/repayWithdrawCollateral.ts
@@ -4,9 +4,9 @@ import { blueBundlesV1Abi } from "../../abis.js";
 import { validateUint256Field } from "../../helpers/validate.js";
 import {
   type AuthorizationRequirementSignature,
-  type BlueBundlesV1TokenRequirementSignature,
   type BlueRepayWithdrawCollateralAction,
   InputExceedsMaxError,
+  type BundlesTokenRequirementSignature,
   MaxRepayAssetsBelowRepayAssetsError,
   type Metadata,
   MutuallyExclusiveRepayAmountsError,
@@ -54,7 +54,7 @@ export interface BlueRepayWithdrawCollateralParams {
     /** Recipient required when `referralFeePct` is positive. */
     readonly referralFeeRecipient?: Address;
     /** Optional loan-token ERC-2612 or Permit2 SignatureTransfer result. */
-    readonly requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+    readonly requirementSignature?: BundlesTokenRequirementSignature;
     /** Optional Morpho authorization signature for BlueBundlesV1. */
     readonly authorizationSignature?: AuthorizationRequirementSignature;
   };
@@ -101,7 +101,7 @@ export interface BlueRepayWithdrawCollateralParams {
  * @throws {DepositAssetMismatchError} when the signed asset differs from the loan token.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `maxRepayAssets`.
  * @throws {DepositSpenderMismatchError} when the signed spender is not BlueBundlesV1.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when a signature cannot be bound safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when a signature cannot be bound safely.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.
  * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
  * @example

--- a/packages/morpho-sdk/src/actions/blue/repayWithdrawCollateral.ts
+++ b/packages/morpho-sdk/src/actions/blue/repayWithdrawCollateral.ts
@@ -5,8 +5,8 @@ import { validateUint256Field } from "../../helpers/validate.js";
 import {
   type AuthorizationRequirementSignature,
   type BlueRepayWithdrawCollateralAction,
-  InputExceedsMaxError,
   type BundlesTokenRequirementSignature,
+  InputExceedsMaxError,
   MaxRepayAssetsBelowRepayAssetsError,
   type Metadata,
   MutuallyExclusiveRepayAmountsError,

--- a/packages/morpho-sdk/src/actions/blue/supply.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/supply.test.ts
@@ -17,8 +17,8 @@ import { mainnet } from "viem/chains";
 import { describe, expect, test } from "vitest";
 import { blueBundlesV1Abi } from "../../abis.js";
 import {
-  BlueBundlesV1RequirementSignatureMismatchError,
-  type BlueBundlesV1TokenRequirementSignature,
+  BundlesRequirementSignatureMismatchError,
+  type BundlesTokenRequirementSignature,
   DepositAmountMismatchError,
   DepositAssetMismatchError,
   DepositOwnerMismatchError,
@@ -197,7 +197,7 @@ describe("blueSupply", () => {
         type: "permit",
         args: { spender: blueBundlesV1, amount: 5n, deadline: 123n },
       },
-    } satisfies BlueBundlesV1TokenRequirementSignature;
+    } satisfies BundlesTokenRequirementSignature;
 
     const decoded = decodeFunctionData({
       abi: blueBundlesV1Abi,
@@ -249,7 +249,7 @@ describe("blueSupply", () => {
         type: "permit",
         args: { spender: blueBundlesV1, amount: 5n, deadline: 123n },
       },
-    } satisfies BlueBundlesV1TokenRequirementSignature;
+    } satisfies BundlesTokenRequirementSignature;
     const permit2 = {
       args: {
         owner: userAddress,
@@ -260,10 +260,10 @@ describe("blueSupply", () => {
         deadline: 789n,
       },
       action: {
-        type: "permit2TransferFrom",
-        args: { spender: blueBundlesV1, amount: 5n, deadline: 789n },
+        type: "permit2SignatureTransfer",
+        args: { spender: blueBundlesV1, amount: 5n, nonce: 9n, deadline: 789n },
       },
-    } satisfies BlueBundlesV1TokenRequirementSignature;
+    } satisfies BundlesTokenRequirementSignature;
 
     const erc2612Decoded = decodeFunctionData({
       abi: blueBundlesV1Abi,
@@ -332,7 +332,7 @@ describe("blueSupply", () => {
           },
         },
       }),
-    ).toThrow(BlueBundlesV1RequirementSignatureMismatchError);
+    ).toThrow(BundlesRequirementSignatureMismatchError);
     expect(() =>
       blueSupply({
         market,
@@ -352,10 +352,10 @@ describe("blueSupply", () => {
                 expiration: 999n,
               },
             },
-          } as unknown as BlueBundlesV1TokenRequirementSignature,
+          } as unknown as BundlesTokenRequirementSignature,
         },
       }),
-    ).toThrow(BlueBundlesV1RequirementSignatureMismatchError);
+    ).toThrow(UnexpectedRequirementSignatureError);
   });
 
   test("error: binds every token signature field", () => {
@@ -378,7 +378,7 @@ describe("blueSupply", () => {
         type: "permit",
         args: { spender: blueBundlesV1, amount: 5n, deadline },
       },
-    } satisfies BlueBundlesV1TokenRequirementSignature;
+    } satisfies BundlesTokenRequirementSignature;
     const otherAddress = getAddress(
       "0x00000000000000000000000000000000000000B1",
     );
@@ -423,7 +423,7 @@ describe("blueSupply", () => {
       [
         "serialized signature",
         { ...permit, args: { ...permit.args, signature: "0x12" as const } },
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       ],
     ] as const;
 
@@ -459,10 +459,10 @@ describe("blueSupply", () => {
         deadline,
       },
       action: {
-        type: "permit2TransferFrom",
-        args: { spender: blueBundlesV1, amount: 2n, deadline },
+        type: "permit2SignatureTransfer",
+        args: { spender: blueBundlesV1, amount: 2n, nonce: 1n, deadline },
       },
-    } satisfies BlueBundlesV1TokenRequirementSignature;
+    } satisfies BundlesTokenRequirementSignature;
 
     expect(
       blueSupply({

--- a/packages/morpho-sdk/src/actions/blue/supply.ts
+++ b/packages/morpho-sdk/src/actions/blue/supply.ts
@@ -2,8 +2,8 @@ import type { MarketParams } from "@morpho-org/blue-sdk";
 import { type Address, encodeFunctionData, maxUint256 } from "viem";
 import { blueBundlesV1Abi } from "../../abis.js";
 import type {
-  BlueBundlesV1TokenRequirementSignature,
   BlueSupplyAction,
+  BundlesTokenRequirementSignature,
   Metadata,
   Transaction,
 } from "../../types/index.js";
@@ -41,7 +41,7 @@ export interface BlueSupplyParams {
     /** Recipient required when `referralFeePct` is positive. */
     readonly referralFeeRecipient?: Address;
     /** Optional ERC-2612 or Permit2 SignatureTransfer requirement result. */
-    readonly requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+    readonly requirementSignature?: BundlesTokenRequirementSignature;
   };
   /** Optional transaction metadata suffix. */
   readonly metadata?: Metadata;
@@ -78,7 +78,7 @@ export interface BlueSupplyParams {
  * @throws {DepositAssetMismatchError} when the signed asset differs from the loan token.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `assets`.
  * @throws {DepositSpenderMismatchError} when the signed spender is not BlueBundlesV1.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when the signature kind or encoding is invalid.
+ * @throws {BundlesRequirementSignatureMismatchError} when the signature kind or encoding is invalid.
  * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
  * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
  * @example

--- a/packages/morpho-sdk/src/actions/blue/supplyCollateral.ts
+++ b/packages/morpho-sdk/src/actions/blue/supplyCollateral.ts
@@ -2,8 +2,8 @@ import type { MarketParams } from "@morpho-org/blue-sdk";
 import { deepFreeze } from "@morpho-org/morpho-ts";
 import { type Address, maxUint256 } from "viem";
 import type {
-  BlueBundlesV1TokenRequirementSignature,
   BlueSupplyCollateralAction,
+  BundlesTokenRequirementSignature,
   Metadata,
   Transaction,
 } from "../../types/index.js";
@@ -31,7 +31,7 @@ export interface BlueSupplyCollateralParams {
     /** Recipient required when `referralFeePct` is positive. */
     readonly referralFeeRecipient?: Address;
     /** Optional collateral ERC-2612 or Permit2 SignatureTransfer result. */
-    readonly requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+    readonly requirementSignature?: BundlesTokenRequirementSignature;
   };
   /** Optional transaction metadata suffix. */
   readonly metadata?: Metadata;
@@ -66,7 +66,7 @@ export interface BlueSupplyCollateralParams {
  * @throws {DepositAssetMismatchError} when the signed asset differs from the collateral token.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `collateralAssets`.
  * @throws {DepositSpenderMismatchError} when the signed spender is not BlueBundlesV1.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when a signature cannot be encoded safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when a signature cannot be encoded safely.
  * @throws {InputExceedsMaxError} when the referral fee is at least WAD.
  * @throws {MissingReferralFeeRecipientError} when a positive fee has no recipient.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.

--- a/packages/morpho-sdk/src/actions/blue/supplyCollateralBorrow.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/supplyCollateralBorrow.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, test } from "vitest";
 import { blueBundlesV1Abi } from "../../abis.js";
 import {
   type AuthorizationRequirementSignature,
-  type BlueBundlesV1TokenRequirementSignature,
+  type BundlesTokenRequirementSignature,
   InputExceedsMaxError,
   NativeFundingAmountMismatchError,
   NegativeInputError,
@@ -414,10 +414,10 @@ describe("blueSupplyCollateralBorrow", () => {
         deadline,
       },
       action: {
-        type: "permit2TransferFrom",
-        args: { spender: blueBundlesV1, amount: 5n, deadline },
+        type: "permit2SignatureTransfer",
+        args: { spender: blueBundlesV1, amount: 5n, nonce: 1n, deadline },
       },
-    } satisfies BlueBundlesV1TokenRequirementSignature;
+    } satisfies BundlesTokenRequirementSignature;
     const authorizationSignature = {
       args: {
         owner: userAddress,

--- a/packages/morpho-sdk/src/actions/blue/supplyCollateralBorrow.ts
+++ b/packages/morpho-sdk/src/actions/blue/supplyCollateralBorrow.ts
@@ -4,8 +4,8 @@ import { blueBundlesV1Abi } from "../../abis.js";
 import { validateUint256Field } from "../../helpers/validate.js";
 import {
   type AuthorizationRequirementSignature,
-  type BlueBundlesV1TokenRequirementSignature,
   type BlueSupplyCollateralBorrowAction,
+  type BundlesTokenRequirementSignature,
   InputExceedsMaxError,
   type Metadata,
   NonPositiveInputError,
@@ -53,7 +53,7 @@ export interface BlueSupplyCollateralBorrowParams {
     /** Recipient required when `referralFeePct` is positive. */
     readonly referralFeeRecipient?: Address;
     /** Optional collateral ERC-2612 or Permit2 SignatureTransfer result. */
-    readonly requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+    readonly requirementSignature?: BundlesTokenRequirementSignature;
     /** Optional Morpho authorization signature for BlueBundlesV1. */
     readonly authorizationSignature?: AuthorizationRequirementSignature;
   };
@@ -103,7 +103,7 @@ export interface BlueSupplyCollateralBorrowParams {
  * @throws {DepositAssetMismatchError} when the signed asset differs from the collateral token.
  * @throws {DepositAmountMismatchError} when the signed amount differs from `collateralAssets`.
  * @throws {DepositSpenderMismatchError} when the signed spender is not BlueBundlesV1.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when a signature cannot be bound safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when a signature cannot be bound safely.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.
  * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
  * @example

--- a/packages/morpho-sdk/src/actions/blue/withdraw.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/withdraw.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, test } from "vitest";
 import { blueBundlesV1Abi } from "../../abis.js";
 import {
   type AuthorizationRequirementSignature,
-  BlueBundlesV1RequirementSignatureMismatchError,
+  BundlesRequirementSignatureMismatchError,
   DepositOwnerMismatchError,
   InputExceedsMaxError,
   MutuallyExclusiveWithdrawAmountsError,
@@ -243,7 +243,7 @@ describe("blueWithdraw", () => {
           },
         },
       }),
-    ).toThrow(BlueBundlesV1RequirementSignatureMismatchError);
+    ).toThrow(BundlesRequirementSignatureMismatchError);
   });
 
   test("error: binds every authorization signature field", () => {
@@ -285,7 +285,7 @@ describe("blueWithdraw", () => {
           ...authorization,
           args: { ...authorization.args, authorized: otherAddress },
         },
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       ],
       [
         "action authorized",
@@ -296,7 +296,7 @@ describe("blueWithdraw", () => {
             args: { ...authorization.action.args, authorized: otherAddress },
           },
         },
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       ],
       [
         "signed isAuthorized",
@@ -304,7 +304,7 @@ describe("blueWithdraw", () => {
           ...authorization,
           args: { ...authorization.args, isAuthorized: false },
         },
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       ],
       [
         "action isAuthorized",
@@ -315,7 +315,7 @@ describe("blueWithdraw", () => {
             args: { ...authorization.action.args, isAuthorized: false },
           },
         },
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       ],
       [
         "serialized signature",
@@ -323,7 +323,7 @@ describe("blueWithdraw", () => {
           ...authorization,
           args: { ...authorization.args, signature: "0x12" as const },
         },
-        BlueBundlesV1RequirementSignatureMismatchError,
+        BundlesRequirementSignatureMismatchError,
       ],
     ] as const;
 

--- a/packages/morpho-sdk/src/actions/blue/withdraw.ts
+++ b/packages/morpho-sdk/src/actions/blue/withdraw.ts
@@ -85,7 +85,7 @@ export interface BlueWithdrawParams {
  * @throws {ReallocationWithdrawalOnTargetMarketError} when a source is the target market.
  * @throws {ReallocationLoanTokenMismatchError} when a source market uses another loan token.
  * @throws {DepositOwnerMismatchError} when the signed authorization owner differs from `userAddress`.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when authorization cannot be bound safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when authorization cannot be bound safely.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.
  * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
  * @example

--- a/packages/morpho-sdk/src/actions/blue/withdrawCollateral.ts
+++ b/packages/morpho-sdk/src/actions/blue/withdrawCollateral.ts
@@ -61,7 +61,7 @@ export interface BlueWithdrawCollateralParams {
  * @throws {InputExceedsMaxError} when the referral fee is at least WAD.
  * @throws {MissingReferralFeeRecipientError} when a positive fee has no recipient.
  * @throws {DepositOwnerMismatchError} when the signed authorization owner differs from `userAddress`.
- * @throws {BlueBundlesV1RequirementSignatureMismatchError} when authorization cannot be bound safely.
+ * @throws {BundlesRequirementSignatureMismatchError} when authorization cannot be bound safely.
  * @throws {UnsupportedChainIdError} when the chain is absent from the registry.
  * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
  * @example

--- a/packages/morpho-sdk/src/actions/bundles/common.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/common.test.ts
@@ -1,0 +1,197 @@
+import fc from "fast-check";
+import { maxUint256, serializeSignature, toHex, zeroHash } from "viem";
+import { describe, expect, test } from "vitest";
+import {
+  type BundlesFundingArgs,
+  BundlesPermitMismatchError,
+  MixedBundlesFundingError,
+  NegativeInputError,
+  NonPositiveInputError,
+  type PermitRequirementSignature,
+} from "../../types/index.js";
+import {
+  getBundlesSharesPermit,
+  resolveBundlesFunding,
+  selectBundlesSharesRequirementSignature,
+  selectBundlesTokenRequirementSignature,
+} from "./common.js";
+
+const owner = "0x0000000000000000000000000000000000000001" as const;
+const vault = "0x0000000000000000000000000000000000000002" as const;
+const spender = "0x0000000000000000000000000000000000000003" as const;
+const signature = serializeSignature({
+  r: toHex(1n, { size: 32 }),
+  s: toHex(2n, { size: 32 }),
+  yParity: 0,
+});
+
+describe("resolveBundlesFunding", () => {
+  test("behavior: preserves exclusive token and native amounts", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1n, max: maxUint256 }),
+        fc.boolean(),
+        (assets, native) => {
+          const funding: BundlesFundingArgs = native
+            ? { nativeAmount: assets }
+            : { amount: assets };
+          expect(resolveBundlesFunding(funding)).toEqual({
+            assets,
+            value: native ? assets : 0n,
+          });
+        },
+      ),
+      { numRuns: 100, seed: 20_260_909 },
+    );
+  });
+
+  test("error: typed runtime boundaries", () => {
+    expect(() =>
+      resolveBundlesFunding({
+        amount: 1n,
+        nativeAmount: 1n,
+      } as unknown as BundlesFundingArgs),
+    ).toThrow(MixedBundlesFundingError);
+    expect(() => resolveBundlesFunding({ amount: -1n })).toThrow(
+      NegativeInputError,
+    );
+    expect(() => resolveBundlesFunding({ nativeAmount: 0n })).toThrow(
+      NonPositiveInputError,
+    );
+  });
+});
+
+describe("getBundlesSharesPermit", () => {
+  const permit = {
+    args: {
+      owner,
+      asset: vault,
+      amount: 7n,
+      nonce: 9n,
+      deadline: 11n,
+      signature,
+    },
+    action: {
+      type: "permit",
+      args: { spender, amount: 7n, deadline: 11n, nonce: 9n },
+    },
+  } satisfies PermitRequirementSignature;
+
+  test("default", () => {
+    expect(getBundlesSharesPermit({ vault, deadline: 13n })).toEqual({
+      value: 0n,
+      nonce: 0n,
+      deadline: 13n,
+      v: 0,
+      r: zeroHash,
+      s: zeroHash,
+    });
+    expect(
+      getBundlesSharesPermit({
+        vault,
+        owner,
+        spender,
+        amount: 7n,
+        deadline: 13n,
+        requirementSignature: permit,
+      }),
+    ).toMatchObject({ value: 7n, nonce: 9n, deadline: 11n, v: 27 });
+  });
+
+  test("error: BundlesPermitMismatchError", () => {
+    expect(() =>
+      getBundlesSharesPermit({
+        vault,
+        owner,
+        spender,
+        amount: 8n,
+        deadline: 13n,
+        requirementSignature: permit,
+      }),
+    ).toThrow(BundlesPermitMismatchError);
+  });
+});
+
+describe("selectBundlesSharesRequirementSignature", () => {
+  const permit = {
+    args: {
+      owner,
+      asset: vault,
+      amount: 7n,
+      nonce: 9n,
+      deadline: 11n,
+      signature,
+    },
+    action: {
+      type: "permit",
+      args: { spender, amount: 7n, deadline: 11n, nonce: 9n },
+    },
+  } satisfies PermitRequirementSignature;
+
+  test("default", () => {
+    expect(
+      selectBundlesSharesRequirementSignature([permit], {
+        requiredShareAllowance: 7n,
+        expectedRequirement: permit.action,
+      }),
+    ).toEqual(permit);
+  });
+
+  test("error: BundlesPermitMismatchError", () => {
+    expect(() =>
+      selectBundlesSharesRequirementSignature([permit], {
+        requiredShareAllowance: undefined,
+      }),
+    ).toThrow(BundlesPermitMismatchError);
+    expect(() =>
+      selectBundlesSharesRequirementSignature([permit], {
+        requiredShareAllowance: 8n,
+        expectedRequirement: permit.action,
+      }),
+    ).toThrow(BundlesPermitMismatchError);
+    expect(() =>
+      selectBundlesSharesRequirementSignature([permit], {
+        requiredShareAllowance: 7n,
+        expectedRequirement: {
+          ...permit.action,
+          args: { ...permit.action.args, nonce: 10n },
+        },
+      }),
+    ).toThrow(BundlesPermitMismatchError);
+  });
+});
+
+describe("selectBundlesTokenRequirementSignature", () => {
+  const permit = {
+    args: {
+      owner,
+      asset: vault,
+      amount: 7n,
+      nonce: 9n,
+      deadline: 11n,
+      signature,
+    },
+    action: {
+      type: "permit",
+      args: { spender, amount: 7n, deadline: 11n, nonce: 9n },
+    },
+  } satisfies PermitRequirementSignature;
+
+  test("default", () => {
+    expect(
+      selectBundlesTokenRequirementSignature([permit], permit.action),
+    ).toEqual(permit);
+  });
+
+  test("error: rejects signatures outside the prepared requirement", () => {
+    expect(() => selectBundlesTokenRequirementSignature([permit])).toThrow(
+      BundlesPermitMismatchError,
+    );
+    expect(() =>
+      selectBundlesTokenRequirementSignature([permit], {
+        ...permit.action,
+        args: { ...permit.action.args, deadline: 12n },
+      }),
+    ).toThrow(BundlesPermitMismatchError);
+  });
+});

--- a/packages/morpho-sdk/src/actions/bundles/common.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/common.test.ts
@@ -1,16 +1,39 @@
 import fc from "fast-check";
-import { maxUint256, serializeSignature, toHex, zeroHash } from "viem";
-import { describe, expect, test } from "vitest";
+import {
+  decodeAbiParameters,
+  maxUint256,
+  serializeCompactSignature,
+  serializeSignature,
+  signatureToCompactSignature,
+  toHex,
+  zeroHash,
+} from "viem";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import type {
+  BundleSharesPermit,
+  BundlesSharesPermit,
+  VaultExitBundlesV1PermitStruct,
+} from "../../index.js";
 import {
   type BundlesFundingArgs,
   BundlesPermitMismatchError,
+  BundlesRequirementSignatureMismatchError,
+  DepositAmountMismatchError,
+  DepositAssetMismatchError,
+  DepositOwnerMismatchError,
+  DepositSpenderMismatchError,
+  type Erc2612RequirementSignature,
   MixedBundlesFundingError,
   NegativeInputError,
   NonPositiveInputError,
+  type Permit2AllowanceRequirementSignature,
+  type Permit2SignatureTransferRequirementSignature,
   type PermitRequirementSignature,
+  UnexpectedRequirementSignatureError,
 } from "../../types/index.js";
 import {
   getBundlesSharesPermit,
+  getBundlesTokenPermit,
   resolveBundlesFunding,
   selectBundlesSharesRequirementSignature,
   selectBundlesTokenRequirementSignature,
@@ -78,6 +101,11 @@ describe("getBundlesSharesPermit", () => {
   } satisfies PermitRequirementSignature;
 
   test("default", () => {
+    expectTypeOf<
+      ReturnType<typeof getBundlesSharesPermit>
+    >().toEqualTypeOf<BundleSharesPermit>();
+    expectTypeOf<VaultExitBundlesV1PermitStruct>().toEqualTypeOf<BundleSharesPermit>();
+    expectTypeOf<BundlesSharesPermit>().toEqualTypeOf<BundleSharesPermit>();
     expect(getBundlesSharesPermit({ vault, deadline: 13n })).toEqual({
       value: 0n,
       nonce: 0n,
@@ -109,6 +137,179 @@ describe("getBundlesSharesPermit", () => {
         requirementSignature: permit,
       }),
     ).toThrow(BundlesPermitMismatchError);
+  });
+});
+
+describe("getBundlesTokenPermit", () => {
+  const params = { userAddress: owner, token: vault, spender, amount: 7n };
+  const permit = {
+    args: {
+      owner,
+      asset: vault,
+      amount: 7n,
+      nonce: 9n,
+      deadline: 11n,
+      signature,
+    },
+    action: {
+      type: "permit",
+      args: { spender, amount: 7n, deadline: 11n, nonce: 9n },
+    },
+  } satisfies Erc2612RequirementSignature;
+  const permit2 = {
+    args: { ...permit.args, signature: "0x1234" },
+    action: {
+      type: "permit2SignatureTransfer",
+      args: { spender, amount: 7n, deadline: 11n, nonce: 9n },
+    },
+  } satisfies Permit2SignatureTransferRequirementSignature;
+
+  test("default: returns the empty permit for allowance funding", () => {
+    expect(getBundlesTokenPermit(params)).toEqual({ kind: 0, data: "0x" });
+  });
+
+  test.each([
+    { label: "serialized", signature },
+    {
+      label: "compact",
+      signature: serializeCompactSignature(
+        signatureToCompactSignature({
+          r: toHex(1n, { size: 32 }),
+          s: toHex(2n, { size: 32 }),
+          yParity: 0,
+        }),
+      ),
+    },
+  ])(
+    "behavior: encodes a $label ERC-2612 permit",
+    ({ signature: encodedSignature }) => {
+      const tokenPermit = getBundlesTokenPermit({
+        ...params,
+        requirementSignature: {
+          ...permit,
+          args: { ...permit.args, signature: encodedSignature },
+        },
+      });
+      expect(tokenPermit.kind).toBe(1);
+      expect(
+        decodeAbiParameters(
+          [
+            { type: "uint256" },
+            { type: "uint8" },
+            { type: "bytes32" },
+            { type: "bytes32" },
+          ],
+          tokenPermit.data,
+        ),
+      ).toEqual([11n, 27, toHex(1n, { size: 32 }), toHex(2n, { size: 32 })]);
+    },
+  );
+
+  test("behavior: encodes Permit2 SignatureTransfer with the raw signature", () => {
+    const tokenPermit = getBundlesTokenPermit({
+      ...params,
+      requirementSignature: permit2,
+    });
+    expect(tokenPermit.kind).toBe(2);
+    expect(
+      decodeAbiParameters(
+        [{ type: "uint256" }, { type: "uint256" }, { type: "bytes" }],
+        tokenPermit.data,
+      ),
+    ).toEqual([9n, 11n, "0x1234"]);
+  });
+
+  test.each([
+    { overrides: { userAddress: spender }, error: DepositOwnerMismatchError },
+    { overrides: { token: spender }, error: DepositAssetMismatchError },
+    { overrides: { amount: 8n }, error: DepositAmountMismatchError },
+    { overrides: { spender: owner }, error: DepositSpenderMismatchError },
+  ])("error: $error.name", ({ overrides, error }) => {
+    expect(() =>
+      getBundlesTokenPermit({
+        ...params,
+        ...overrides,
+        requirementSignature: permit,
+      }),
+    ).toThrow(error);
+  });
+
+  test("error: DepositAmountMismatchError for an inconsistent action amount", () => {
+    expect(() =>
+      getBundlesTokenPermit({
+        ...params,
+        requirementSignature: {
+          ...permit,
+          action: {
+            ...permit.action,
+            args: { ...permit.action.args, amount: 8n },
+          },
+        },
+      }),
+    ).toThrow(DepositAmountMismatchError);
+  });
+
+  test.each([
+    {
+      field: "deadline",
+      requirementSignature: {
+        ...permit,
+        action: {
+          ...permit.action,
+          args: { ...permit.action.args, deadline: 12n },
+        },
+      },
+    },
+    {
+      field: "nonce",
+      requirementSignature: {
+        ...permit2,
+        action: {
+          ...permit2.action,
+          args: { ...permit2.action.args, nonce: 10n },
+        },
+      },
+    },
+  ])(
+    "error: BundlesRequirementSignatureMismatchError for inconsistent $field",
+    ({ requirementSignature }) => {
+      expect(() =>
+        getBundlesTokenPermit({ ...params, requirementSignature }),
+      ).toThrow(BundlesRequirementSignatureMismatchError);
+    },
+  );
+
+  test("error: BundlesRequirementSignatureMismatchError preserves the malformed-signature cause", () => {
+    let thrown: unknown;
+    try {
+      getBundlesTokenPermit({
+        ...params,
+        requirementSignature: {
+          ...permit,
+          args: { ...permit.args, signature: "0x1234" },
+        },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(BundlesRequirementSignatureMismatchError);
+    expect(thrown).toHaveProperty(
+      "cause",
+      expect.any(BundlesPermitMismatchError),
+    );
+  });
+
+  test("error: UnexpectedRequirementSignatureError for Permit2 AllowanceTransfer", () => {
+    const requirementSignature = {
+      args: { ...permit.args, expiration: 11n },
+      action: {
+        type: "permit2",
+        args: { ...permit.action.args, expiration: 11n },
+      },
+    } satisfies Permit2AllowanceRequirementSignature;
+    expect(() =>
+      getBundlesTokenPermit({ ...params, requirementSignature }),
+    ).toThrow(UnexpectedRequirementSignatureError);
   });
 });
 

--- a/packages/morpho-sdk/src/actions/bundles/common.ts
+++ b/packages/morpho-sdk/src/actions/bundles/common.ts
@@ -64,7 +64,7 @@ export interface BundlesTokenPermit {
 }
 
 /** ABI-ready ERC-2612 share permit consumed by vault bundles. */
-export interface BundlesSharesPermit {
+export interface BundleSharesPermit {
   /** Exact vault-share allowance authorized by the permit. */
   readonly value: bigint;
   /** Vault permit nonce signed by the owner. */
@@ -78,6 +78,9 @@ export interface BundlesSharesPermit {
   /** ECDSA signature `s`, or zero for the empty sentinel. */
   readonly s: Hex;
 }
+
+/** Compatibility alias for the canonical {@link BundleSharesPermit} tuple. */
+export type BundlesSharesPermit = BundleSharesPermit;
 
 /** Common deadline and referral fields shared by fixed bundles calls. */
 export interface BundlesCommonParams {
@@ -155,8 +158,11 @@ export const normalizeBundlesCommonParams = (
  * Resolves mutually exclusive ERC-20/native funding into the entrypoint amount and transaction value.
  *
  * @param params - Exclusive bundles funding.
+ * @param params.amount - ERC-20 funding in the token's smallest unit; mutually exclusive with `nativeAmount`.
+ * @param params.nativeAmount - Native funding in wei; mutually exclusive with `amount`.
  * @returns The gross ABI asset amount and native transaction value.
  * @throws {MixedBundlesFundingError} when both funding keys are present.
+ * @throws {NegativeInputError} when the selected amount is negative.
  * @throws {NonPositiveInputError} when the selected amount is not positive.
  * @example
  * ```ts
@@ -195,6 +201,11 @@ export const resolveBundlesFunding = (
  * Converts an optional signed token requirement into the ABI-ready TokenLib permit tuple.
  *
  * @param params - Expected funding values and optional signed requirement.
+ * @param params.userAddress - Account funding the operation; must match the signature owner.
+ * @param params.token - ERC-20 funding token; must match the signed asset.
+ * @param params.spender - Fixed bundles contract authorized to pull the token.
+ * @param params.amount - Exact pull amount in the token's smallest unit; must match both signed amount fields.
+ * @param params.requirementSignature - Optional signed ERC-2612 or Permit2 SignatureTransfer requirement; omit for allowance funding.
  * @returns An empty, ERC-2612, or Permit2 SignatureTransfer token permit.
  * @throws {UnexpectedRequirementSignatureError} when Permit2 AllowanceTransfer is supplied.
  * @throws {DepositOwnerMismatchError} when the signature owner differs from `userAddress`.
@@ -366,6 +377,12 @@ export const normalizeBundlesSignature = (
  * Converts an optional vault-share ERC-2612 requirement into the ABI-ready Permit tuple.
  *
  * @param params - Vault token, empty-sentinel deadline, and optional signed requirement.
+ * @param params.vault - Vault share token authorized by the permit.
+ * @param params.deadline - Unix timestamp in seconds used by the empty-permit sentinel.
+ * @param params.owner - Optional expected signature owner.
+ * @param params.spender - Optional expected fixed bundles contract authorized to pull shares.
+ * @param params.amount - Optional exact share allowance in the vault share token's smallest unit.
+ * @param params.requirementSignature - Optional signed ERC-2612 share requirement; omit for the empty-permit sentinel.
  * @returns The signed share permit or the contract's empty-permit sentinel.
  * @throws {BundlesPermitMismatchError} when the requirement kind, token, or signature is invalid.
  * @example
@@ -387,7 +404,7 @@ export const getBundlesSharesPermit = (params: {
   readonly spender?: Address;
   readonly amount?: bigint;
   readonly requirementSignature?: PermitRequirementSignature;
-}): BundlesSharesPermit => {
+}): BundleSharesPermit => {
   const { requirementSignature } = params;
   if (requirementSignature == null) {
     return {

--- a/packages/morpho-sdk/src/actions/bundles/common.ts
+++ b/packages/morpho-sdk/src/actions/bundles/common.ts
@@ -1,0 +1,656 @@
+import { MathLib } from "@morpho-org/blue-sdk";
+import { deepFreeze, getChainAddress } from "@morpho-org/morpho-ts";
+import {
+  type Address,
+  compactSignatureToSignature,
+  encodeAbiParameters,
+  type Hex,
+  isAddressEqual,
+  maxUint256,
+  parseCompactSignature,
+  parseSignature,
+  type Signature,
+  size,
+  zeroAddress,
+  zeroHash,
+} from "viem";
+import { addTransactionMetadata } from "../../helpers/index.js";
+import {
+  AmbiguousRequirementSignaturesError,
+  type BaseAction,
+  type BundlesFundingArgs,
+  BundlesPermitMismatchError,
+  BundlesRequirementSignatureMismatchError,
+  type BundlesTokenRequirementSignature,
+  DepositAmountMismatchError,
+  DepositAssetMismatchError,
+  DepositOwnerMismatchError,
+  DepositSpenderMismatchError,
+  type Erc2612RequirementSignature,
+  InputExceedsMaxError,
+  type Metadata,
+  MixedBundlesFundingError,
+  NegativeInputError,
+  NonPositiveInputError,
+  type Permit2SignatureTransferAction,
+  type PermitAction,
+  type PermitRequirementSignature,
+  ReferralFeePctExceededError,
+  ReferralFeeRecipientMissingError,
+  type RequirementSignature,
+  selectRequirementSignatures,
+  type TokenRequirementSignature,
+  type Transaction,
+  UnexpectedRequirementSignatureError,
+} from "../../types/index.js";
+
+/** Numeric permit kinds consumed by `TokenLib.pullToken`. */
+export const BundlesPermitKind = {
+  None: 0,
+  ERC2612: 1,
+  Permit2: 2,
+} as const;
+
+/** A numeric permit kind consumed by `TokenLib.pullToken`. */
+export type BundlesPermitKind =
+  (typeof BundlesPermitKind)[keyof typeof BundlesPermitKind];
+
+/** ABI-ready token permit consumed by fixed bundles deposit and funding entrypoints. */
+export interface BundlesTokenPermit {
+  /** TokenLib permit dispatch kind. */
+  readonly kind: BundlesPermitKind;
+  /** ABI-encoded permit payload, or empty bytes for classic allowance funding. */
+  readonly data: Hex;
+}
+
+/** ABI-ready ERC-2612 share permit consumed by vault bundles. */
+export interface BundlesSharesPermit {
+  /** Exact vault-share allowance authorized by the permit. */
+  readonly value: bigint;
+  /** Vault permit nonce signed by the owner. */
+  readonly nonce: bigint;
+  /** Permit signature deadline. */
+  readonly deadline: bigint;
+  /** ECDSA recovery identifier, or zero for the empty sentinel. */
+  readonly v: number;
+  /** ECDSA signature `r`, or zero for the empty sentinel. */
+  readonly r: Hex;
+  /** ECDSA signature `s`, or zero for the empty sentinel. */
+  readonly s: Hex;
+}
+
+/** Common deadline and referral fields shared by fixed bundles calls. */
+export interface BundlesCommonParams {
+  /** Contract execution deadline. */
+  readonly deadline: bigint;
+  /** Optional WAD-scaled referral fee percentage. */
+  readonly referralFeePct?: bigint;
+  /** Recipient required when `referralFeePct` is positive. */
+  readonly referralFeeRecipient?: Address;
+}
+
+/** Normalized deadline and referral fields encoded by fixed bundles calls. */
+export interface NormalizedBundlesCommonParams {
+  /** Validated contract execution deadline. */
+  readonly deadline: bigint;
+  /** Validated WAD-scaled referral fee percentage. */
+  readonly referralFeePct: bigint;
+  /** Referral recipient, or the zero address when fees are disabled. */
+  readonly referralFeeRecipient: Address;
+}
+
+const EMPTY_TOKEN_PERMIT: BundlesTokenPermit = {
+  kind: BundlesPermitKind.None,
+  data: "0x",
+};
+
+/**
+ * Validates and normalizes a bundles deadline and referral fee configuration.
+ *
+ * @internal
+ *
+ * @param params - Common bundles parameters.
+ * @returns Validated values with explicit zero defaults.
+ * @throws {NonPositiveInputError} when `deadline` is not positive.
+ * @throws {InputExceedsMaxError} when `deadline` exceeds uint256.
+ * @throws {NegativeInputError} when `referralFeePct` is negative.
+ * @throws {ReferralFeePctExceededError} when `referralFeePct >= WAD`.
+ * @throws {ReferralFeeRecipientMissingError} when a positive fee has no recipient.
+ */
+export const normalizeBundlesCommonParams = (
+  params: BundlesCommonParams,
+): NormalizedBundlesCommonParams => {
+  if (params.deadline <= 0n) {
+    throw new NonPositiveInputError("deadline", params.deadline);
+  }
+  if (params.deadline > maxUint256) {
+    throw new InputExceedsMaxError({
+      field: "deadline",
+      value: params.deadline,
+      max: maxUint256,
+    });
+  }
+  const referralFeePct = params.referralFeePct ?? 0n;
+  if (referralFeePct < 0n) {
+    throw new NegativeInputError("referralFeePct", referralFeePct);
+  }
+  if (referralFeePct >= MathLib.WAD) {
+    throw new ReferralFeePctExceededError(referralFeePct);
+  }
+  if (
+    referralFeePct > 0n &&
+    (params.referralFeeRecipient == null ||
+      isAddressEqual(params.referralFeeRecipient, zeroAddress))
+  ) {
+    throw new ReferralFeeRecipientMissingError();
+  }
+  return {
+    deadline: params.deadline,
+    referralFeePct,
+    referralFeeRecipient: params.referralFeeRecipient ?? zeroAddress,
+  };
+};
+
+/**
+ * Resolves mutually exclusive ERC-20/native funding into the entrypoint amount and transaction value.
+ *
+ * @param params - Exclusive bundles funding.
+ * @returns The gross ABI asset amount and native transaction value.
+ * @throws {MixedBundlesFundingError} when both funding keys are present.
+ * @throws {NonPositiveInputError} when the selected amount is not positive.
+ * @example
+ * ```ts
+ * import { resolveBundlesFunding } from "@morpho-org/morpho-sdk";
+ *
+ * const funding = resolveBundlesFunding({ amount: 1_000_000n });
+ * // funding is { assets: 1_000_000n, value: 0n }
+ * ```
+ */
+export const resolveBundlesFunding = (
+  params: BundlesFundingArgs,
+): { readonly assets: bigint; readonly value: bigint } => {
+  const amount = "amount" in params ? params.amount : undefined;
+  const nativeAmount =
+    "nativeAmount" in params ? params.nativeAmount : undefined;
+  if (amount != null && nativeAmount != null) {
+    throw new MixedBundlesFundingError();
+  }
+  const assets = amount ?? nativeAmount ?? 0n;
+  if (assets < 0n) {
+    throw new NegativeInputError(
+      amount != null ? "amount" : "nativeAmount",
+      assets,
+    );
+  }
+  if (assets === 0n) {
+    throw new NonPositiveInputError(
+      amount != null ? "amount" : "nativeAmount",
+      assets,
+    );
+  }
+  return { assets, value: nativeAmount ?? 0n };
+};
+
+/**
+ * Converts an optional signed token requirement into the ABI-ready TokenLib permit tuple.
+ *
+ * @param params - Expected funding values and optional signed requirement.
+ * @returns An empty, ERC-2612, or Permit2 SignatureTransfer token permit.
+ * @throws {UnexpectedRequirementSignatureError} when Permit2 AllowanceTransfer is supplied.
+ * @throws {DepositOwnerMismatchError} when the signature owner differs from `userAddress`.
+ * @throws {DepositAssetMismatchError} when the signed token differs from `token`.
+ * @throws {DepositAmountMismatchError} when the signed amount differs from `amount`.
+ * @throws {DepositSpenderMismatchError} when the signed spender differs from `spender`.
+ * @throws {BundlesRequirementSignatureMismatchError} when signature metadata is malformed.
+ * @example
+ * ```ts
+ * import { getBundlesTokenPermit } from "@morpho-org/morpho-sdk";
+ * import { zeroAddress } from "viem";
+ *
+ * const permit = getBundlesTokenPermit({
+ *   userAddress: zeroAddress,
+ *   token: zeroAddress,
+ *   spender: zeroAddress,
+ *   amount: 1n,
+ * });
+ * // permit is { kind: 0, data: "0x" }
+ * ```
+ */
+export const getBundlesTokenPermit = (params: {
+  readonly userAddress: Address;
+  readonly token: Address;
+  readonly spender: Address;
+  readonly amount: bigint;
+  readonly requirementSignature?: TokenRequirementSignature;
+}): BundlesTokenPermit => {
+  const { requirementSignature } = params;
+  if (requirementSignature == null) return { ...EMPTY_TOKEN_PERMIT };
+  if (requirementSignature.action.type === "permit2") {
+    throw new UnexpectedRequirementSignatureError("permit");
+  }
+  if (!isAddressEqual(requirementSignature.args.owner, params.userAddress)) {
+    throw new DepositOwnerMismatchError(
+      params.userAddress,
+      requirementSignature.args.owner,
+    );
+  }
+  if (!isAddressEqual(requirementSignature.args.asset, params.token)) {
+    throw new DepositAssetMismatchError(
+      params.token,
+      requirementSignature.args.asset,
+    );
+  }
+  if (
+    requirementSignature.args.amount !== params.amount ||
+    requirementSignature.action.args.amount !== params.amount
+  ) {
+    throw new DepositAmountMismatchError(
+      params.amount,
+      requirementSignature.args.amount,
+    );
+  }
+  if (
+    !isAddressEqual(requirementSignature.action.args.spender, params.spender)
+  ) {
+    throw new DepositSpenderMismatchError(
+      params.spender,
+      requirementSignature.action.args.spender,
+    );
+  }
+  if (
+    requirementSignature.action.args.deadline !==
+    requirementSignature.args.deadline
+  ) {
+    throw new BundlesRequirementSignatureMismatchError({
+      field: "deadline",
+      expected: String(requirementSignature.args.deadline),
+      actual: String(requirementSignature.action.args.deadline),
+    });
+  }
+  if (
+    requirementSignature.action.type === "permit2SignatureTransfer" &&
+    requirementSignature.action.args.nonce !== requirementSignature.args.nonce
+  ) {
+    throw new BundlesRequirementSignatureMismatchError({
+      field: "nonce",
+      expected: String(requirementSignature.args.nonce),
+      actual: String(requirementSignature.action.args.nonce),
+    });
+  }
+
+  if (requirementSignature.action.type === "permit2SignatureTransfer") {
+    return {
+      kind: BundlesPermitKind.Permit2,
+      data: encodeAbiParameters(
+        [
+          { type: "uint256", name: "nonce" },
+          { type: "uint256", name: "deadline" },
+          { type: "bytes", name: "signature" },
+        ],
+        [
+          requirementSignature.args.nonce,
+          requirementSignature.args.deadline,
+          requirementSignature.args.signature,
+        ],
+      ),
+    };
+  }
+
+  let signature: { readonly v: number; readonly r: Hex; readonly s: Hex };
+  try {
+    signature = normalizeBundlesSignature(requirementSignature.args.signature);
+  } catch (cause) {
+    if (cause instanceof BundlesPermitMismatchError) {
+      throw new BundlesRequirementSignatureMismatchError({
+        field: "signature",
+        expected: cause.expected,
+        actual: cause.actual,
+        cause,
+      });
+    }
+    throw cause;
+  }
+  return {
+    kind: BundlesPermitKind.ERC2612,
+    data: encodeAbiParameters(
+      [
+        { type: "uint256", name: "deadline" },
+        { type: "uint8", name: "v" },
+        { type: "bytes32", name: "r" },
+        { type: "bytes32", name: "s" },
+      ],
+      [
+        requirementSignature.args.deadline,
+        signature.v,
+        signature.r,
+        signature.s,
+      ],
+    ),
+  };
+};
+
+/** @internal Normalizes a compact or serialized ECDSA signature for bundles permit tuples. */
+export const normalizeBundlesSignature = (
+  serializedSignature: Hex,
+): { readonly v: number; readonly r: Hex; readonly s: Hex } => {
+  let parsed: Signature;
+  try {
+    parsed =
+      size(serializedSignature) === 64
+        ? compactSignatureToSignature(
+            parseCompactSignature(serializedSignature),
+          )
+        : parseSignature(serializedSignature);
+  } catch (cause) {
+    throw new BundlesPermitMismatchError({
+      field: "signature",
+      expected: "a 64-byte compact or 65-byte serialized ECDSA signature",
+      actual: serializedSignature,
+      cause,
+    });
+  }
+  const normalizedV =
+    parsed.v ??
+    (parsed.yParity == null ? undefined : BigInt(parsed.yParity + 27));
+  if (normalizedV == null) {
+    throw new BundlesPermitMismatchError({
+      field: "signature",
+      expected: "a signature containing v or yParity",
+      actual: serializedSignature,
+    });
+  }
+  return { v: Number(normalizedV), r: parsed.r, s: parsed.s };
+};
+
+/**
+ * Converts an optional vault-share ERC-2612 requirement into the ABI-ready Permit tuple.
+ *
+ * @param params - Vault token, empty-sentinel deadline, and optional signed requirement.
+ * @returns The signed share permit or the contract's empty-permit sentinel.
+ * @throws {BundlesPermitMismatchError} when the requirement kind, token, or signature is invalid.
+ * @example
+ * ```ts
+ * import { getBundlesSharesPermit } from "@morpho-org/morpho-sdk";
+ * import { zeroAddress } from "viem";
+ *
+ * const permit = getBundlesSharesPermit({
+ *   vault: zeroAddress,
+ *   deadline: 1_900_000_000n,
+ * });
+ * // permit.value === 0n
+ * ```
+ */
+export const getBundlesSharesPermit = (params: {
+  readonly vault: Address;
+  readonly deadline: bigint;
+  readonly owner?: Address;
+  readonly spender?: Address;
+  readonly amount?: bigint;
+  readonly requirementSignature?: PermitRequirementSignature;
+}): BundlesSharesPermit => {
+  const { requirementSignature } = params;
+  if (requirementSignature == null) {
+    return {
+      value: 0n,
+      nonce: 0n,
+      deadline: params.deadline,
+      v: 0,
+      r: zeroHash,
+      s: zeroHash,
+    };
+  }
+  if (requirementSignature.action.type !== "permit") {
+    throw new BundlesPermitMismatchError({
+      field: "type",
+      expected: "permit",
+      actual: requirementSignature.action.type,
+    });
+  }
+  if (!isAddressEqual(requirementSignature.args.asset, params.vault)) {
+    throw new BundlesPermitMismatchError({
+      field: "asset",
+      expected: params.vault,
+      actual: requirementSignature.args.asset,
+    });
+  }
+  if (
+    params.owner != null &&
+    !isAddressEqual(requirementSignature.args.owner, params.owner)
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "owner",
+      expected: params.owner,
+      actual: requirementSignature.args.owner,
+    });
+  }
+  if (
+    params.spender != null &&
+    !isAddressEqual(requirementSignature.action.args.spender, params.spender)
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "spender",
+      expected: params.spender,
+      actual: requirementSignature.action.args.spender,
+    });
+  }
+  if (
+    params.amount != null &&
+    (requirementSignature.args.amount !== params.amount ||
+      requirementSignature.action.args.amount !== params.amount)
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "amount",
+      expected: String(params.amount),
+      actual: String(requirementSignature.args.amount),
+    });
+  }
+  if (
+    (params.owner != null || params.spender != null || params.amount != null) &&
+    requirementSignature.action.args.deadline !==
+      requirementSignature.args.deadline
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "deadline",
+      expected: String(requirementSignature.args.deadline),
+      actual: String(requirementSignature.action.args.deadline),
+    });
+  }
+  const signature = normalizeBundlesSignature(
+    requirementSignature.args.signature,
+  );
+  return {
+    value: requirementSignature.args.amount,
+    nonce: requirementSignature.args.nonce,
+    deadline: requirementSignature.args.deadline,
+    ...signature,
+  };
+};
+
+/**
+ * Selects the one token signature accepted by a bundles-funded call.
+ *
+ * @internal
+ *
+ * @param signatures - Signatures passed to `buildTx`.
+ * @param expectedRequirement - Signature requirement captured by this prepared operation.
+ * @returns The selected ERC-2612 or Permit2 SignatureTransfer signature.
+ * @throws {UnexpectedRequirementSignatureError} when a non-token signature is supplied.
+ * @throws {AmbiguousRequirementSignaturesError} when both token signature kinds are supplied.
+ */
+export const selectBundlesTokenRequirementSignature = (
+  signatures: readonly RequirementSignature[] | undefined,
+  expectedRequirement?: PermitAction | Permit2SignatureTransferAction,
+): BundlesTokenRequirementSignature | undefined => {
+  if (signatures == null || signatures.length === 0) return undefined;
+  const selected = signatures.filter(
+    (signature): signature is BundlesTokenRequirementSignature =>
+      signature.action.type === "permit" ||
+      signature.action.type === "permit2SignatureTransfer",
+  );
+  if (selected.length !== signatures.length) {
+    const unexpected = signatures.find(
+      (signature) =>
+        signature.action.type !== "permit" &&
+        signature.action.type !== "permit2SignatureTransfer",
+    );
+    throw new UnexpectedRequirementSignatureError(
+      unexpected?.action.type === "authorization"
+        ? "authorization"
+        : unexpected?.action.type === "midnightOfferRootSignature"
+          ? "midnightOfferRootSignature"
+          : "permit",
+    );
+  }
+  if (selected.length > 1) {
+    throw new AmbiguousRequirementSignaturesError("permit", selected.length);
+  }
+  const selectedSignature = selected[0];
+  if (selectedSignature == null) return undefined;
+  validatePreparedBundlesRequirementSignature(
+    selectedSignature,
+    expectedRequirement,
+  );
+  return selectedSignature;
+};
+
+const validatePreparedBundlesRequirementSignature = (
+  signature: BundlesTokenRequirementSignature | Erc2612RequirementSignature,
+  expectedRequirement:
+    | PermitAction
+    | Permit2SignatureTransferAction
+    | undefined,
+): void => {
+  if (expectedRequirement == null) {
+    throw new BundlesPermitMismatchError({
+      field: "nonce",
+      expected: "the nonce from getRequirements()",
+      actual: String(signature.args.nonce),
+    });
+  }
+  if (signature.action.type !== expectedRequirement.type) {
+    throw new BundlesPermitMismatchError({
+      field: "type",
+      expected: expectedRequirement.type,
+      actual: signature.action.type,
+    });
+  }
+  const expectedArgs = expectedRequirement.args;
+  if (!isAddressEqual(signature.action.args.spender, expectedArgs.spender)) {
+    throw new BundlesPermitMismatchError({
+      field: "spender",
+      expected: expectedArgs.spender,
+      actual: signature.action.args.spender,
+    });
+  }
+  if (
+    signature.args.amount !== expectedArgs.amount ||
+    signature.action.args.amount !== expectedArgs.amount
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "amount",
+      expected: String(expectedArgs.amount),
+      actual: String(signature.args.amount),
+    });
+  }
+  if (
+    signature.args.deadline !== expectedArgs.deadline ||
+    signature.action.args.deadline !== expectedArgs.deadline
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "deadline",
+      expected: String(expectedArgs.deadline),
+      actual: String(signature.args.deadline),
+    });
+  }
+  if (
+    expectedArgs.nonce == null ||
+    signature.args.nonce !== expectedArgs.nonce ||
+    signature.action.args.nonce !== expectedArgs.nonce
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "nonce",
+      expected:
+        expectedArgs.nonce == null
+          ? "the nonce from getRequirements()"
+          : String(expectedArgs.nonce),
+      actual: String(signature.args.nonce),
+    });
+  }
+};
+
+/**
+ * Selects the exact ERC-2612 vault-share permit produced for one prepared exit.
+ *
+ * @internal
+ *
+ * @param signatures - Signatures passed to the prepared operation's `buildTx` function.
+ * @param prepared - Exact share cap and permit requirement captured by this prepared operation.
+ * @returns The matching ERC-2612 signature, or `undefined` when no signature is supplied.
+ * @throws {BundlesPermitMismatchError} when the signature is not ERC-2612, was built for another
+ *   share cap, or is supplied before this operation resolves its share cap.
+ */
+export const selectBundlesSharesRequirementSignature = (
+  signatures: readonly RequirementSignature[] | undefined,
+  prepared: {
+    readonly requiredShareAllowance: bigint | undefined;
+    readonly expectedRequirement?: PermitAction;
+  },
+): Erc2612RequirementSignature | undefined => {
+  const { permit } = selectRequirementSignatures(signatures, { permit: true });
+  if (permit == null) return undefined;
+  const { action } = permit;
+  if (action.type !== "permit") {
+    throw new BundlesPermitMismatchError({
+      field: "type",
+      expected: "permit",
+      actual: action.type,
+    });
+  }
+  if (
+    prepared.requiredShareAllowance == null ||
+    permit.args.amount !== prepared.requiredShareAllowance ||
+    action.args.amount !== prepared.requiredShareAllowance
+  ) {
+    throw new BundlesPermitMismatchError({
+      field: "amount",
+      expected:
+        prepared.requiredShareAllowance == null
+          ? "the current cap from getRequirements()"
+          : String(prepared.requiredShareAllowance),
+      actual: String(permit.args.amount),
+    });
+  }
+  const selectedPermit = { args: permit.args, action };
+  validatePreparedBundlesRequirementSignature(
+    selectedPermit,
+    prepared.expectedRequirement,
+  );
+  return selectedPermit;
+};
+
+/** @internal Returns the exact referral fee deducted from a fixed gross asset amount. */
+export const getBundlesReferralFeeAssets = (
+  assets: bigint,
+  referralFeePct: bigint,
+): bigint => MathLib.mulDivDown(assets, referralFeePct, MathLib.WAD);
+
+/** @internal Finalizes a direct VaultBundlesV1 transaction with metadata and immutable action data. */
+export const finalizeVaultBundlesV1Transaction = <
+  TAction extends BaseAction,
+>(params: {
+  readonly chainId: number;
+  readonly value: bigint;
+  readonly data: Hex;
+  readonly action: TAction;
+  readonly metadata?: Metadata;
+}): Readonly<Transaction<TAction>> => {
+  let transaction = {
+    to: getChainAddress(params.chainId, "bundles.vaultBundlesV1"),
+    value: params.value,
+    data: params.data,
+  };
+  if (params.metadata != null) {
+    transaction = addTransactionMetadata(transaction, params.metadata);
+  }
+  return deepFreeze({ ...transaction, action: params.action });
+};

--- a/packages/morpho-sdk/src/actions/bundles/index.ts
+++ b/packages/morpho-sdk/src/actions/bundles/index.ts
@@ -1,0 +1,2 @@
+export * from "./common.js";
+export * from "./resolveBundlesTokenRequirements.js";

--- a/packages/morpho-sdk/src/actions/bundles/index.ts
+++ b/packages/morpho-sdk/src/actions/bundles/index.ts
@@ -1,4 +1,5 @@
 export type {
+  BundleSharesPermit,
   BundlesCommonParams,
   BundlesSharesPermit,
   BundlesTokenPermit,

--- a/packages/morpho-sdk/src/actions/bundles/index.ts
+++ b/packages/morpho-sdk/src/actions/bundles/index.ts
@@ -1,2 +1,13 @@
-export * from "./common.js";
+export type {
+  BundlesCommonParams,
+  BundlesSharesPermit,
+  BundlesTokenPermit,
+  NormalizedBundlesCommonParams,
+} from "./common.js";
+export {
+  BundlesPermitKind,
+  getBundlesSharesPermit,
+  getBundlesTokenPermit,
+  resolveBundlesFunding,
+} from "./common.js";
 export * from "./resolveBundlesTokenRequirements.js";

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
@@ -1,0 +1,130 @@
+import { addressesRegistry, MathLib } from "@morpho-org/blue-sdk";
+import { getChainAddress } from "@morpho-org/morpho-ts";
+import fc from "fast-check";
+import { maxUint256 } from "viem";
+import { mainnet } from "viem/chains";
+import { describe, expect, test } from "vitest";
+import {
+  isRequirementApproval,
+  isRequirementSignature,
+  Permit2SignatureTransferNonceAlreadyUsedError,
+} from "../../types/index.js";
+import { resolveBundlesTokenRequirements } from "./resolveBundlesTokenRequirements.js";
+
+const chainId = mainnet.id;
+const { usdc, permit2 } = addressesRegistry[chainId];
+const spender = getChainAddress(chainId, "bundles.vaultBundlesV1");
+const owner = "0x0000000000000000000000000000000000000001" as const;
+const deadline = 1_900_000_000n;
+
+describe("resolveBundlesTokenRequirements", () => {
+  test("behavior: direct approval resolution is deterministic", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1n, max: (1n << 128n) - 1n }),
+        fc.boolean(),
+        (amount, sufficient) => {
+          const requirements = resolveBundlesTokenRequirements({
+            token: usdc,
+            spender,
+            owner,
+            chainId,
+            amount,
+            deadline,
+            state: {
+              type: "approval",
+              allowance: sufficient ? amount : amount - 1n,
+              approvalAmount: amount,
+            },
+          });
+          expect(requirements).toHaveLength(sufficient ? 0 : 1);
+          if (!sufficient) {
+            expect(isRequirementApproval(requirements[0])).toBe(true);
+            expect(requirements[0]?.action).toMatchObject({
+              type: "erc20Approval",
+              args: { spender, amount },
+            });
+          }
+        },
+      ),
+      { numRuns: 100, seed: 20_260_910 },
+    );
+  });
+
+  test("behavior: Permit2 approval precedes SignatureTransfer and preserves nonce", () => {
+    const amount = MathLib.MAX_UINT_160 + 1n;
+    const requirements = resolveBundlesTokenRequirements({
+      token: usdc,
+      spender,
+      owner,
+      chainId,
+      amount,
+      deadline,
+      state: {
+        type: "permit2SignatureTransfer",
+        permit2,
+        permit2Allowance: 0n,
+        permit2Nonce: 257n,
+        nonceBitmap: 0n,
+      },
+    });
+
+    expect(isRequirementApproval(requirements[0])).toBe(true);
+    expect(requirements[0]?.action).toMatchObject({
+      type: "erc20Approval",
+      args: { spender: permit2, amount: maxUint256 },
+    });
+    expect(isRequirementSignature(requirements[1])).toBe(true);
+    expect(requirements[1]?.action).toEqual({
+      type: "permit2SignatureTransfer",
+      args: { spender, amount, nonce: 257n, deadline },
+    });
+  });
+
+  test("behavior: distinct caller-selected nonces remain distinct", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 255 }), (nonce) => {
+        const requirement = resolveBundlesTokenRequirements({
+          token: usdc,
+          spender,
+          owner,
+          chainId,
+          amount: 1n,
+          deadline,
+          state: {
+            type: "permit2SignatureTransfer",
+            permit2,
+            permit2Allowance: maxUint256,
+            permit2Nonce: BigInt(nonce),
+            nonceBitmap: 0n,
+          },
+        })[0];
+        expect(requirement?.action).toMatchObject({
+          type: "permit2SignatureTransfer",
+          args: { nonce: BigInt(nonce) },
+        });
+      }),
+      { numRuns: 100, seed: 20_260_911 },
+    );
+  });
+
+  test("error: Permit2SignatureTransferNonceAlreadyUsedError", () => {
+    expect(() =>
+      resolveBundlesTokenRequirements({
+        token: usdc,
+        spender,
+        owner,
+        chainId,
+        amount: 1n,
+        deadline,
+        state: {
+          type: "permit2SignatureTransfer",
+          permit2,
+          permit2Allowance: maxUint256,
+          permit2Nonce: 7n,
+          nonceBitmap: 1n << 7n,
+        },
+      }),
+    ).toThrow(Permit2SignatureTransferNonceAlreadyUsedError);
+  });
+});

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
@@ -51,6 +51,46 @@ describe("resolveBundlesTokenRequirements", () => {
     );
   });
 
+  test("behavior: a raised approval target is the allowance level the caller must reach", () => {
+    const amount = 1_000_000n;
+    // A saturated share repay quotes `amount` now but pulls more once interest accrues, so an
+    // allowance covering only the quote must still be raised to the target.
+    const requirements = resolveBundlesTokenRequirements({
+      token: usdc,
+      spender,
+      owner,
+      chainId,
+      amount,
+      deadline,
+      state: {
+        type: "approval",
+        allowance: amount,
+        approvalAmount: maxUint256,
+      },
+    });
+    expect(requirements).toHaveLength(1);
+    expect(requirements[0]?.action).toMatchObject({
+      type: "erc20Approval",
+      args: { spender, amount: maxUint256 },
+    });
+
+    expect(
+      resolveBundlesTokenRequirements({
+        token: usdc,
+        spender,
+        owner,
+        chainId,
+        amount,
+        deadline,
+        state: {
+          type: "approval",
+          allowance: maxUint256,
+          approvalAmount: maxUint256,
+        },
+      }),
+    ).toHaveLength(0);
+  });
+
   test("behavior: Permit2 approval precedes SignatureTransfer and preserves nonce", () => {
     const amount = MathLib.MAX_UINT_160 + 1n;
     const requirements = resolveBundlesTokenRequirements({

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
@@ -5,11 +5,17 @@ import { maxUint256 } from "viem";
 import { mainnet } from "viem/chains";
 import { describe, expect, test } from "vitest";
 import {
+  ApprovalAmountLessThanSpendAmountError,
+  InputExceedsMaxError,
   isRequirementApproval,
   isRequirementSignature,
+  NegativeInputError,
   Permit2SignatureTransferNonceAlreadyUsedError,
 } from "../../types/index.js";
-import { resolveBundlesTokenRequirements } from "./resolveBundlesTokenRequirements.js";
+import {
+  type BundlesTokenRequirementsState,
+  resolveBundlesTokenRequirements,
+} from "./resolveBundlesTokenRequirements.js";
 
 const chainId = mainnet.id;
 const { usdc, permit2 } = addressesRegistry[chainId];
@@ -18,6 +24,113 @@ const owner = "0x0000000000000000000000000000000000000001" as const;
 const deadline = 1_900_000_000n;
 
 describe("resolveBundlesTokenRequirements", () => {
+  const states = [
+    { type: "approval", allowance: 0n, approvalAmount: maxUint256 },
+    {
+      type: "permit2SignatureTransfer",
+      permit2,
+      permit2Allowance: maxUint256,
+      permit2Nonce: 0n,
+      nonceBitmap: 0n,
+    },
+  ] as const satisfies readonly BundlesTokenRequirementsState[];
+
+  test.each(states)(
+    "behavior: zero amount returns no requirements for $type",
+    (state) => {
+      expect(
+        resolveBundlesTokenRequirements({
+          token: usdc,
+          spender,
+          owner,
+          chainId,
+          amount: 0n,
+          deadline,
+          state,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  test.each(states)(
+    "behavior: accepts maxUint256 amount for $type",
+    (state) => {
+      const requirements = resolveBundlesTokenRequirements({
+        token: usdc,
+        spender,
+        owner,
+        chainId,
+        amount: maxUint256,
+        deadline,
+        state,
+      });
+      expect(requirements).toHaveLength(1);
+      expect(requirements[0]?.action.args.amount).toBe(maxUint256);
+    },
+  );
+
+  test.each(
+    states.flatMap((state) => [
+      { state, amount: -1n, error: NegativeInputError },
+      { state, amount: maxUint256 + 1n, error: InputExceedsMaxError },
+    ]),
+  )(
+    "error: $error.name for $state.type amount $amount",
+    ({ state, amount, error }) => {
+      expect(() =>
+        resolveBundlesTokenRequirements({
+          token: usdc,
+          spender,
+          owner,
+          chainId,
+          amount,
+          deadline,
+          state,
+        }),
+      ).toThrow(error);
+    },
+  );
+
+  test("error: ApprovalAmountLessThanSpendAmountError", () => {
+    expect(() =>
+      resolveBundlesTokenRequirements({
+        token: usdc,
+        spender,
+        owner,
+        chainId,
+        amount: 2n,
+        deadline,
+        state: { type: "approval", allowance: 0n, approvalAmount: 1n },
+      }),
+    ).toThrow(ApprovalAmountLessThanSpendAmountError);
+  });
+
+  test.each([
+    { permit2Nonce: -1n, error: NegativeInputError },
+    { permit2Nonce: maxUint256 + 1n, error: InputExceedsMaxError },
+  ])(
+    "error: $error.name for Permit2 nonce $permit2Nonce",
+    ({ permit2Nonce, error }) => {
+      expect(() =>
+        resolveBundlesTokenRequirements({
+          token: usdc,
+          spender,
+          owner,
+          chainId,
+          amount: 1n,
+          deadline,
+          state: {
+            type: "permit2SignatureTransfer",
+            permit2,
+            permit2Allowance: maxUint256,
+            permit2Nonce,
+            nonceBitmap: 0n,
+          },
+        }),
+      ).toThrow(error);
+    },
+  );
+
   test("behavior: direct approval resolution is deterministic", () => {
     fc.assert(
       fc.property(

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
@@ -289,8 +289,6 @@ describe("resolveBundlesTokenRequirements", () => {
     ).toMatchObject({ type: "erc20Approval", args: { spender: allowed } });
   });
 
-  // An unregistered spender must never reach an approval or a signature, including on the paths
-  // that never touch the approval encoder: a zero amount and an already-sufficient allowance.
   test.each([
     {
       label: "approval",
@@ -327,7 +325,6 @@ describe("resolveBundlesTokenRequirements", () => {
       expect(() =>
         resolveBundlesTokenRequirements({
           token: usdc,
-          // GeneralAdapter1 is a registered SDK approval spender, but never a bundles spender.
           spender: getChainAddress(chainId, "bundler3.generalAdapter1"),
           owner,
           chainId,

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
@@ -11,6 +11,7 @@ import {
   isRequirementSignature,
   NegativeInputError,
   Permit2SignatureTransferNonceAlreadyUsedError,
+  UnsupportedErc20ApprovalSpenderError,
 } from "../../types/index.js";
 import {
   type BundlesTokenRequirementsState,
@@ -28,7 +29,6 @@ describe("resolveBundlesTokenRequirements", () => {
     { type: "approval", allowance: 0n, approvalAmount: maxUint256 },
     {
       type: "permit2SignatureTransfer",
-      permit2,
       permit2Allowance: maxUint256,
       permit2Nonce: 0n,
       nonceBitmap: 0n,
@@ -121,7 +121,6 @@ describe("resolveBundlesTokenRequirements", () => {
           deadline,
           state: {
             type: "permit2SignatureTransfer",
-            permit2,
             permit2Allowance: maxUint256,
             permit2Nonce,
             nonceBitmap: 0n,
@@ -210,7 +209,6 @@ describe("resolveBundlesTokenRequirements", () => {
       deadline,
       state: {
         type: "permit2SignatureTransfer",
-        permit2,
         permit2Allowance: 0n,
         permit2Nonce: 257n,
         nonceBitmap: 0n,
@@ -241,7 +239,6 @@ describe("resolveBundlesTokenRequirements", () => {
           deadline,
           state: {
             type: "permit2SignatureTransfer",
-            permit2,
             permit2Allowance: maxUint256,
             permit2Nonce: BigInt(nonce),
             nonceBitmap: 0n,
@@ -267,7 +264,6 @@ describe("resolveBundlesTokenRequirements", () => {
         deadline,
         state: {
           type: "permit2SignatureTransfer",
-          permit2,
           permit2Allowance: maxUint256,
           permit2Nonce: 7n,
           nonceBitmap: 1n << 7n,
@@ -275,4 +271,71 @@ describe("resolveBundlesTokenRequirements", () => {
       }),
     ).toThrow(Permit2SignatureTransferNonceAlreadyUsedError);
   });
+
+  test.each([
+    getChainAddress(chainId, "bundles.blueBundlesV1"),
+    getChainAddress(chainId, "bundles.vaultBundlesV1"),
+  ])("behavior: accepts the registered bundles spender %s", (allowed) => {
+    expect(
+      resolveBundlesTokenRequirements({
+        token: usdc,
+        spender: allowed,
+        owner,
+        chainId,
+        amount: 1n,
+        deadline,
+        state: { type: "approval", allowance: 0n, approvalAmount: 1n },
+      })[0]?.action,
+    ).toMatchObject({ type: "erc20Approval", args: { spender: allowed } });
+  });
+
+  // An unregistered spender must never reach an approval or a signature, including on the paths
+  // that never touch the approval encoder: a zero amount and an already-sufficient allowance.
+  test.each([
+    {
+      label: "approval",
+      amount: 1n,
+      state: { type: "approval", allowance: 0n, approvalAmount: 1n },
+    },
+    {
+      label: "sufficient allowance",
+      amount: 1n,
+      state: { type: "approval", allowance: maxUint256, approvalAmount: 1n },
+    },
+    {
+      label: "zero amount",
+      amount: 0n,
+      state: { type: "approval", allowance: 0n, approvalAmount: 0n },
+    },
+    {
+      label: "permit2SignatureTransfer",
+      amount: 1n,
+      state: {
+        type: "permit2SignatureTransfer",
+        permit2Allowance: maxUint256,
+        permit2Nonce: 0n,
+        nonceBitmap: 0n,
+      },
+    },
+  ] as const satisfies readonly {
+    label: string;
+    amount: bigint;
+    state: BundlesTokenRequirementsState;
+  }[])(
+    "error: UnsupportedErc20ApprovalSpenderError for an unregistered spender ($label)",
+    ({ amount, state }) => {
+      expect(() =>
+        resolveBundlesTokenRequirements({
+          token: usdc,
+          // GeneralAdapter1 is a registered SDK approval spender, but never a bundles spender.
+          spender: getChainAddress(chainId, "bundler3.generalAdapter1"),
+          owner,
+          chainId,
+          amount,
+          deadline,
+          state,
+        }),
+      ).toThrow(UnsupportedErc20ApprovalSpenderError);
+    },
+  );
 });

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.test.ts
@@ -51,10 +51,9 @@ describe("resolveBundlesTokenRequirements", () => {
     );
   });
 
-  test("behavior: a raised approval target is the allowance level the caller must reach", () => {
+  test("behavior: a raised approval target does not require replacing a sufficient allowance", () => {
     const amount = 1_000_000n;
-    // A saturated share repay quotes `amount` now but pulls more once interest accrues, so an
-    // allowance covering only the quote must still be raised to the target.
+    // The fixed call cannot pull beyond the supplied amount, even with a reusable approval target.
     const requirements = resolveBundlesTokenRequirements({
       token: usdc,
       spender,
@@ -68,11 +67,7 @@ describe("resolveBundlesTokenRequirements", () => {
         approvalAmount: maxUint256,
       },
     });
-    expect(requirements).toHaveLength(1);
-    expect(requirements[0]?.action).toMatchObject({
-      type: "erc20Approval",
-      args: { spender, amount: maxUint256 },
-    });
+    expect(requirements).toHaveLength(0);
 
     expect(
       resolveBundlesTokenRequirements({

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
@@ -1,0 +1,129 @@
+import type { Address } from "viem";
+import { maxUint256 } from "viem";
+import {
+  ApprovalAmountLessThanSpendAmountError,
+  type BundlesTokenSignatureRequirement,
+  type ERC20ApprovalAction,
+  InputExceedsMaxError,
+  NegativeInputError,
+  Permit2SignatureTransferNonceAlreadyUsedError,
+  type Transaction,
+} from "../../types/index.js";
+import { encodeErc20Permit2SignatureTransfer } from "../requirements/encode/index.js";
+import { getRequirementsApproval } from "../requirements/getRequirementsApproval.js";
+
+/** Plain onchain state used by {@link resolveBundlesTokenRequirements}. */
+export type BundlesTokenRequirementsState =
+  | {
+      readonly type: "approval";
+      readonly allowance: bigint;
+      readonly approvalAmount: bigint;
+    }
+  | {
+      readonly type: "permit2SignatureTransfer";
+      readonly permit2: Address;
+      readonly permit2Allowance: bigint;
+      readonly permit2Nonce: bigint;
+      readonly nonceBitmap: bigint;
+    };
+
+/**
+ * Resolves pre-fetched allowance and Permit2 nonce state into ordered bundles requirements.
+ *
+ * The SignatureTransfer branch always places any ERC-20 approval to canonical Permit2 before the
+ * one-time signature requirement.
+ *
+ * @param params - Funding values, expected bundles spender, and pre-fetched state.
+ * @returns Ordered approval transactions and/or a Permit2 SignatureTransfer requirement.
+ * @throws {NegativeInputError} when an amount or Permit2 nonce is negative.
+ * @throws {InputExceedsMaxError} when the Permit2 nonce exceeds uint256.
+ * @throws {Permit2SignatureTransferNonceAlreadyUsedError} when the selected nonce bit is set.
+ * @throws {ApprovalAmountLessThanSpendAmountError} when a classic approval cannot cover the pull.
+ * @example
+ * ```ts
+ * import { resolveBundlesTokenRequirements } from "@morpho-org/morpho-sdk";
+ * import { zeroAddress } from "viem";
+ *
+ * const requirements = resolveBundlesTokenRequirements({
+ *   token: zeroAddress,
+ *   spender: zeroAddress,
+ *   owner: zeroAddress,
+ *   chainId: 1,
+ *   amount: 1_000_000n,
+ *   deadline: 1_900_000_000n,
+ *   state: { type: "approval", allowance: 1_000_000n, approvalAmount: 1_000_000n },
+ * });
+ * // requirements is empty because the allowance already covers the amount.
+ * ```
+ */
+export const resolveBundlesTokenRequirements = (params: {
+  readonly token: Address;
+  readonly spender: Address;
+  readonly owner: Address;
+  readonly chainId: number;
+  readonly amount: bigint;
+  readonly deadline: bigint;
+  readonly state: BundlesTokenRequirementsState;
+}): readonly (
+  | Readonly<Transaction<ERC20ApprovalAction>>
+  | BundlesTokenSignatureRequirement
+)[] => {
+  if (params.amount < 0n) {
+    throw new NegativeInputError("amount", params.amount);
+  }
+  if (params.amount === 0n) return [];
+
+  if (params.state.type === "approval") {
+    if (params.state.approvalAmount < params.amount) {
+      throw new ApprovalAmountLessThanSpendAmountError();
+    }
+    return getRequirementsApproval({
+      address: params.token,
+      chainId: params.chainId,
+      args: {
+        spender: params.spender,
+        spendAmount: params.state.approvalAmount,
+        approvalAmount: params.state.approvalAmount,
+      },
+      allowances: params.state.allowance,
+    });
+  }
+
+  if (params.state.permit2Nonce < 0n) {
+    throw new NegativeInputError("permit2Nonce", params.state.permit2Nonce);
+  }
+  if (params.state.permit2Nonce > maxUint256) {
+    throw new InputExceedsMaxError({
+      field: "permit2Nonce",
+      value: params.state.permit2Nonce,
+      max: maxUint256,
+    });
+  }
+  const bitPosition = params.state.permit2Nonce & 255n;
+  if ((params.state.nonceBitmap & (1n << bitPosition)) !== 0n) {
+    throw new Permit2SignatureTransferNonceAlreadyUsedError(
+      params.owner,
+      params.state.permit2Nonce,
+    );
+  }
+  return [
+    ...getRequirementsApproval({
+      address: params.token,
+      chainId: params.chainId,
+      args: {
+        spender: params.state.permit2,
+        spendAmount: params.amount,
+        approvalAmount: maxUint256,
+      },
+      allowances: params.state.permit2Allowance,
+    }),
+    encodeErc20Permit2SignatureTransfer({
+      token: params.token,
+      spender: params.spender,
+      amount: params.amount,
+      chainId: params.chainId,
+      nonce: params.state.permit2Nonce,
+      deadline: params.deadline,
+    }),
+  ];
+};

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
@@ -16,7 +16,15 @@ import { getRequirementsApproval } from "../requirements/getRequirementsApproval
 export type BundlesTokenRequirementsState =
   | {
       readonly type: "approval";
+      /** Current allowance of the funding token for `spender`. */
       readonly allowance: bigint;
+      /**
+       * Allowance level the caller must reach, at least `amount`.
+       *
+       * Callers raise it above `amount` when the eventual pull can grow past the quoted amount
+       * between `getRequirements()` and submission — a saturated share repay accruing interest, for
+       * example. The allowance is therefore compared against this target, not against `amount`.
+       */
       readonly approvalAmount: bigint;
     }
   | {
@@ -81,6 +89,8 @@ export const resolveBundlesTokenRequirements = (params: {
       address: params.token,
       chainId: params.chainId,
       args: {
+        // The approval target, not `amount`, is the level the allowance must reach: a caller that
+        // raised it did so because the pull can grow past `amount` before submission.
         spender: params.spender,
         spendAmount: params.state.approvalAmount,
         approvalAmount: params.state.approvalAmount,

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
@@ -95,9 +95,6 @@ export const resolveBundlesTokenRequirements = (params: {
   | Readonly<Transaction<ERC20ApprovalAction>>
   | BundlesTokenSignatureRequirement
 )[] => {
-  // Bind the caller-supplied spender to the chain registry before anything else: a sufficient
-  // allowance short-circuits the approval encoder, so this is the only guard that keeps an
-  // unregistered spender from being accepted on every path, zero-amount requests included.
   validateRequirementSpender({
     chainId: params.chainId,
     spender: params.spender,
@@ -141,8 +138,6 @@ export const resolveBundlesTokenRequirements = (params: {
       params.state.permit2Nonce,
     );
   }
-  // Canonical Permit2 is the only address the signed pull can be funded through, so resolve it from
-  // the chain registry instead of trusting a caller-supplied one. Throws when the chain has none.
   const permit2 = getChainAddress(params.chainId, "permit2");
   return [
     ...getRequirementsApproval({

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
@@ -18,13 +18,7 @@ export type BundlesTokenRequirementsState =
       readonly type: "approval";
       /** Current allowance of the funding token for `spender`. */
       readonly allowance: bigint;
-      /**
-       * Allowance level the caller must reach, at least `amount`.
-       *
-       * Callers raise it above `amount` when the eventual pull can grow past the quoted amount
-       * between `getRequirements()` and submission — a saturated share repay accruing interest, for
-       * example. The allowance is therefore compared against this target, not against `amount`.
-       */
+      /** Allowance to set when the current allowance cannot cover `amount`. */
       readonly approvalAmount: bigint;
     }
   | {
@@ -89,10 +83,9 @@ export const resolveBundlesTokenRequirements = (params: {
       address: params.token,
       chainId: params.chainId,
       args: {
-        // The approval target, not `amount`, is the level the allowance must reach: a caller that
-        // raised it did so because the pull can grow past `amount` before submission.
+        // Compare against the bounded pull to avoid redundant approvals and USDT zero-resets.
         spender: params.spender,
-        spendAmount: params.state.approvalAmount,
+        spendAmount: params.amount,
         approvalAmount: params.state.approvalAmount,
       },
       allowances: params.state.allowance,

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
@@ -1,5 +1,6 @@
 import type { Address } from "viem";
 import { maxUint256 } from "viem";
+import { validateUint256Field } from "../../helpers/validate.js";
 import {
   ApprovalAmountLessThanSpendAmountError,
   type BundlesTokenSignatureRequirement,
@@ -36,9 +37,23 @@ export type BundlesTokenRequirementsState =
  * one-time signature requirement.
  *
  * @param params - Funding values, expected bundles spender, and pre-fetched state.
+ * @param params.token - ERC-20 token funded by the operation.
+ * @param params.spender - Registered fixed bundles contract that pulls the token.
+ * @param params.owner - Account funding the operation and owning the Permit2 nonce bitmap.
+ * @param params.chainId - Target chain id used to resolve supported approval spenders.
+ * @param params.amount - Exact pull amount in the token's smallest unit; zero returns no requirements.
+ * @param params.deadline - Signature expiration as a Unix timestamp in seconds.
+ * @param params.state - Prefetched state for either classic approval or Permit2 SignatureTransfer.
+ * @param params.state.type - `approval` for a direct allowance or `permit2SignatureTransfer` for a signed pull.
+ * @param params.state.allowance - In the approval branch, current token allowance from `owner` to `spender`.
+ * @param params.state.approvalAmount - In the approval branch, allowance to set if needed; must cover `amount`.
+ * @param params.state.permit2 - In the SignatureTransfer branch, canonical Permit2 address for the chain.
+ * @param params.state.permit2Allowance - In the SignatureTransfer branch, current token allowance from `owner` to Permit2.
+ * @param params.state.permit2Nonce - In the SignatureTransfer branch, caller-selected unused uint256 unordered nonce.
+ * @param params.state.nonceBitmap - In the SignatureTransfer branch, owner's Permit2 bitmap word at `permit2Nonce >> 8n`.
  * @returns Ordered approval transactions and/or a Permit2 SignatureTransfer requirement.
  * @throws {NegativeInputError} when an amount or Permit2 nonce is negative.
- * @throws {InputExceedsMaxError} when the Permit2 nonce exceeds uint256.
+ * @throws {InputExceedsMaxError} when `amount` or the Permit2 nonce exceeds uint256.
  * @throws {Permit2SignatureTransferNonceAlreadyUsedError} when the selected nonce bit is set.
  * @throws {ApprovalAmountLessThanSpendAmountError} when a classic approval cannot cover the pull.
  * @example
@@ -70,9 +85,8 @@ export const resolveBundlesTokenRequirements = (params: {
   | Readonly<Transaction<ERC20ApprovalAction>>
   | BundlesTokenSignatureRequirement
 )[] => {
-  if (params.amount < 0n) {
-    throw new NegativeInputError("amount", params.amount);
-  }
+  // Reject invalid pulls before an approval encoder can cap the requested amount.
+  validateUint256Field("amount", params.amount);
   if (params.amount === 0n) return [];
 
   if (params.state.type === "approval") {

--- a/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/actions/bundles/resolveBundlesTokenRequirements.ts
@@ -1,6 +1,8 @@
+import { getChainAddress } from "@morpho-org/morpho-ts";
 import type { Address } from "viem";
 import { maxUint256 } from "viem";
 import { validateUint256Field } from "../../helpers/validate.js";
+import { validateRequirementSpender } from "../../helpers/validateRequirementSpender.js";
 import {
   ApprovalAmountLessThanSpendAmountError,
   type BundlesTokenSignatureRequirement,
@@ -24,7 +26,6 @@ export type BundlesTokenRequirementsState =
     }
   | {
       readonly type: "permit2SignatureTransfer";
-      readonly permit2: Address;
       readonly permit2Allowance: bigint;
       readonly permit2Nonce: bigint;
       readonly nonceBitmap: bigint;
@@ -33,37 +34,46 @@ export type BundlesTokenRequirementsState =
 /**
  * Resolves pre-fetched allowance and Permit2 nonce state into ordered bundles requirements.
  *
+ * `spender` is validated against the chain registry's fixed bundles deployments, and the
+ * SignatureTransfer branch resolves canonical Permit2 from that same registry, so no caller can
+ * route an approval or a signed pull to an address the SDK does not know.
+ *
  * The SignatureTransfer branch always places any ERC-20 approval to canonical Permit2 before the
  * one-time signature requirement.
  *
  * @param params - Funding values, expected bundles spender, and pre-fetched state.
  * @param params.token - ERC-20 token funded by the operation.
- * @param params.spender - Registered fixed bundles contract that pulls the token.
+ * @param params.spender - Registered fixed bundles contract that pulls the token; must be the
+ *   chain's BlueBundlesV1 or VaultBundlesV1 deployment.
  * @param params.owner - Account funding the operation and owning the Permit2 nonce bitmap.
- * @param params.chainId - Target chain id used to resolve supported approval spenders.
+ * @param params.chainId - Target chain id used to resolve supported approval spenders and canonical Permit2.
  * @param params.amount - Exact pull amount in the token's smallest unit; zero returns no requirements.
  * @param params.deadline - Signature expiration as a Unix timestamp in seconds.
  * @param params.state - Prefetched state for either classic approval or Permit2 SignatureTransfer.
  * @param params.state.type - `approval` for a direct allowance or `permit2SignatureTransfer` for a signed pull.
  * @param params.state.allowance - In the approval branch, current token allowance from `owner` to `spender`.
  * @param params.state.approvalAmount - In the approval branch, allowance to set if needed; must cover `amount`.
- * @param params.state.permit2 - In the SignatureTransfer branch, canonical Permit2 address for the chain.
- * @param params.state.permit2Allowance - In the SignatureTransfer branch, current token allowance from `owner` to Permit2.
+ * @param params.state.permit2Allowance - In the SignatureTransfer branch, current token allowance from `owner` to canonical Permit2.
  * @param params.state.permit2Nonce - In the SignatureTransfer branch, caller-selected unused uint256 unordered nonce.
  * @param params.state.nonceBitmap - In the SignatureTransfer branch, owner's Permit2 bitmap word at `permit2Nonce >> 8n`.
  * @returns Ordered approval transactions and/or a Permit2 SignatureTransfer requirement.
+ * @throws {UnsupportedChainIdError} when `chainId` is absent from the address registry.
+ * @throws {UnsupportedErc20ApprovalSpenderError} when `spender` is not the chain's registered
+ *   BlueBundlesV1 or VaultBundlesV1 deployment, including for a zero-amount request.
  * @throws {NegativeInputError} when an amount or Permit2 nonce is negative.
  * @throws {InputExceedsMaxError} when `amount` or the Permit2 nonce exceeds uint256.
  * @throws {Permit2SignatureTransferNonceAlreadyUsedError} when the selected nonce bit is set.
  * @throws {ApprovalAmountLessThanSpendAmountError} when a classic approval cannot cover the pull.
+ * @throws {UnknownAddressError} when the SignatureTransfer branch runs on a chain without canonical Permit2.
  * @example
  * ```ts
  * import { resolveBundlesTokenRequirements } from "@morpho-org/morpho-sdk";
+ * import { getChainAddress } from "@morpho-org/morpho-ts";
  * import { zeroAddress } from "viem";
  *
  * const requirements = resolveBundlesTokenRequirements({
  *   token: zeroAddress,
- *   spender: zeroAddress,
+ *   spender: getChainAddress(1, "bundles.vaultBundlesV1"),
  *   owner: zeroAddress,
  *   chainId: 1,
  *   amount: 1_000_000n,
@@ -85,6 +95,14 @@ export const resolveBundlesTokenRequirements = (params: {
   | Readonly<Transaction<ERC20ApprovalAction>>
   | BundlesTokenSignatureRequirement
 )[] => {
+  // Bind the caller-supplied spender to the chain registry before anything else: a sufficient
+  // allowance short-circuits the approval encoder, so this is the only guard that keeps an
+  // unregistered spender from being accepted on every path, zero-amount requests included.
+  validateRequirementSpender({
+    chainId: params.chainId,
+    spender: params.spender,
+    allowed: ["blueBundlesV1", "vaultBundlesV1"],
+  });
   // Reject invalid pulls before an approval encoder can cap the requested amount.
   validateUint256Field("amount", params.amount);
   if (params.amount === 0n) return [];
@@ -123,12 +141,15 @@ export const resolveBundlesTokenRequirements = (params: {
       params.state.permit2Nonce,
     );
   }
+  // Canonical Permit2 is the only address the signed pull can be funded through, so resolve it from
+  // the chain registry instead of trusting a caller-supplied one. Throws when the chain has none.
+  const permit2 = getChainAddress(params.chainId, "permit2");
   return [
     ...getRequirementsApproval({
       address: params.token,
       chainId: params.chainId,
       args: {
-        spender: params.state.permit2,
+        spender: permit2,
         spendAmount: params.amount,
         approvalAmount: maxUint256,
       },

--- a/packages/morpho-sdk/src/actions/index.ts
+++ b/packages/morpho-sdk/src/actions/index.ts
@@ -6,6 +6,7 @@ export type { MidnightActions } from "../entities/midnight/index.js";
 export type { VaultV1Actions } from "../entities/vaultV1/index.js";
 export type { VaultV2Actions } from "../entities/vaultV2/index.js";
 export * from "./blue/index.js";
+export * from "./bundles/index.js";
 export * from "./midnight/index.js";
 export * from "./requirements/index.js";
 export * from "./signatures/index.js";

--- a/packages/morpho-sdk/src/actions/requirements/blue/getUnusedPermit2Nonce.ts
+++ b/packages/morpho-sdk/src/actions/requirements/blue/getUnusedPermit2Nonce.ts
@@ -21,7 +21,7 @@ const MAX_PERMIT2_NONCE_WORD = maxUint256 >> 8n;
 
 /**
  * Finds the lowest unused Permit2 unordered nonce for `owner`, ready to pass as `permit2Nonce` to
- * {@link getBlueBundlesV1TokenRequirements} or as `nonce` to {@link encodeErc20Permit2TransferFrom}.
+ * {@link getBundlesTokenRequirements} or as `nonce` to {@link encodeErc20Permit2SignatureTransfer}.
  *
  * Permit2 SignatureTransfer consumes an unordered 256-bit nonce; a nonce is free when its bit in
  * `nonceBitmap(owner, word)` is unset. This scans consecutive bitmap words starting at `startNonce`

--- a/packages/morpho-sdk/src/actions/requirements/blue/index.ts
+++ b/packages/morpho-sdk/src/actions/requirements/blue/index.ts
@@ -1,3 +1,2 @@
 export * from "./getBlueAuthorizationRequirement.js";
-export * from "./getBlueBundlesV1TokenRequirements.js";
 export * from "./getUnusedPermit2Nonce.js";

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeBlueSignatureAuthorization.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeBlueSignatureAuthorization.ts
@@ -79,7 +79,7 @@ export const encodeBlueSignatureAuthorization = async (
 
   // Reject an invalid or already-expired caller-supplied deadline before signing, so a direct caller
   // is never walked through a wallet EIP-712 prompt for an authorization Morpho would reject with
-  // `SIGNATURE_EXPIRED`. Mirrors the sibling `encodeErc20Permit2TransferFrom` and the
+  // `SIGNATURE_EXPIRED`. Mirrors the sibling `encodeErc20Permit2SignatureTransfer` and the
   // `getBlueAuthorizationRequirement` resolver guards. An omitted deadline defaults to two hours
   // from now and is always valid.
   if (params.deadline != null) {

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Approval.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Approval.ts
@@ -55,6 +55,7 @@ export const encodeErc20Approval = (
       "midnight",
       "midnightBundles",
       "vaultExitBundlesV1",
+      "vaultBundlesV1",
       "blueBundlesV1",
     ],
   });

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Approval.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Approval.ts
@@ -22,7 +22,7 @@ interface EncodeErc20ApprovalParams {
  * @param params - Encoding parameters.
  * @param params.token - ERC-20 token address to approve.
  * @param params.spender - Address granted the allowance. Must be GeneralAdapter1, Permit2,
- *   Midnight, MidnightBundles, VaultExitBundlesV1, or BlueBundlesV1 for the chain.
+ *   Midnight, MidnightBundles, VaultExitBundlesV1, VaultBundlesV1, or BlueBundlesV1 for the chain.
  * @param params.amount - Allowance amount before per-token cap.
  * @param params.chainId - The chain the transaction targets (used to resolve supported spenders and the per-token cap).
  * @returns A deep-frozen `Transaction<ERC20ApprovalAction>` with the capped approval amount.

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
@@ -85,7 +85,12 @@ export const encodeErc20Permit = async (
   validateRequirementSpender({
     chainId,
     spender,
-    allowed: ["generalAdapter1", "midnightBundles", "blueBundlesV1"],
+    allowed: [
+      "generalAdapter1",
+      "midnightBundles",
+      "vaultBundlesV1",
+      "blueBundlesV1",
+    ],
   });
 
   const now = Time.timestamp();
@@ -119,6 +124,7 @@ export const encodeErc20Permit = async (
       spender,
       amount,
       deadline,
+      nonce,
     },
   };
 

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit.ts
@@ -37,8 +37,8 @@ interface EncodeErc20PermitParams {
  * @param viemClient - Connected viem `Client` whose `chain.id` matches `params.chainId`.
  * @param params - Permit encoding parameters.
  * @param params.token - ERC-20 token address (must support EIP-2612).
- * @param params.spender - Permit spender. Must be GeneralAdapter1, MidnightBundles, or
- *   BlueBundlesV1 for the chain.
+ * @param params.spender - Permit spender. Must be GeneralAdapter1, MidnightBundles,
+ *   VaultBundlesV1, or BlueBundlesV1 for the chain.
  * @param params.amount - Permit allowance amount.
  * @param params.chainId - Target chain id.
  * @param params.nonce - The user's current EIP-2612 nonce on `token`.
@@ -48,7 +48,7 @@ interface EncodeErc20PermitParams {
  * @throws {ChainIdMismatchError} when `viemClient.chain?.id !== params.chainId`.
  * @throws {UnsupportedChainIdError} when `chainId` is absent from the address registry.
  * @throws {UnsupportedErc20ApprovalSpenderError} when `spender` is not GeneralAdapter1,
- *   MidnightBundles, or BlueBundlesV1 for `chainId`.
+ *   MidnightBundles, VaultBundlesV1, or BlueBundlesV1 for `chainId`.
  * @throws {NonPositiveInputError} when an explicit `deadline` is not positive.
  * @throws {InputExceedsMaxError} when an explicit `deadline` exceeds `uint256`.
  * @throws {ExpiredDeadlineError} when an explicit `deadline` is positive but not in the future.

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit2SignatureTransfer.test.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit2SignatureTransfer.test.ts
@@ -16,7 +16,7 @@ import {
   NonPositiveInputError,
   UnsupportedErc20ApprovalSpenderError,
 } from "../../../types/index.js";
-import { encodeErc20Permit2TransferFrom } from "./encodeErc20Permit2TransferFrom.js";
+import { encodeErc20Permit2SignatureTransfer } from "./encodeErc20Permit2SignatureTransfer.js";
 
 const account = privateKeyToAccount(
   "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
@@ -27,13 +27,13 @@ const walletClient = createWalletClient({
   transport: http(),
 });
 
-describe("encodeErc20Permit2TransferFrom", () => {
+describe("encodeErc20Permit2SignatureTransfer", () => {
   test("signs an exact uint256 SignatureTransfer for BlueBundlesV1", async () => {
     const { usdc, bundles } = addressesRegistry[mainnet.id];
     const spender = bundles?.blueBundlesV1;
     if (spender == null) throw new Error("BlueBundlesV1 is not registered");
 
-    const requirement = encodeErc20Permit2TransferFrom({
+    const requirement = encodeErc20Permit2SignatureTransfer({
       token: usdc,
       spender,
       amount: maxUint256,
@@ -44,8 +44,13 @@ describe("encodeErc20Permit2TransferFrom", () => {
     const signed = await requirement.sign(walletClient, account.address);
 
     expect(signed.action).toEqual({
-      type: "permit2TransferFrom",
-      args: { spender, amount: maxUint256, deadline: maxUint256 },
+      type: "permit2SignatureTransfer",
+      args: {
+        spender,
+        amount: maxUint256,
+        nonce: maxUint256,
+        deadline: maxUint256,
+      },
     });
     expect(signed.args.amount).toBe(maxUint256);
     expect(signed.args.nonce).toBe(maxUint256);
@@ -85,43 +90,43 @@ describe("encodeErc20Permit2TransferFrom", () => {
 
   test("error: NegativeInputError when amount is negative", () => {
     expect(() =>
-      encodeErc20Permit2TransferFrom({ ...base(), amount: -1n }),
+      encodeErc20Permit2SignatureTransfer({ ...base(), amount: -1n }),
     ).toThrow(NegativeInputError);
   });
 
   test("error: InputExceedsMaxError when amount exceeds uint256", () => {
     expect(() =>
-      encodeErc20Permit2TransferFrom({ ...base(), amount: maxUint256 + 1n }),
+      encodeErc20Permit2SignatureTransfer({ ...base(), amount: maxUint256 + 1n }),
     ).toThrow(InputExceedsMaxError);
   });
 
   test("error: NegativeInputError when nonce is negative", () => {
     expect(() =>
-      encodeErc20Permit2TransferFrom({ ...base(), nonce: -1n }),
+      encodeErc20Permit2SignatureTransfer({ ...base(), nonce: -1n }),
     ).toThrow(NegativeInputError);
   });
 
   test("error: InputExceedsMaxError when nonce exceeds uint256", () => {
     expect(() =>
-      encodeErc20Permit2TransferFrom({ ...base(), nonce: maxUint256 + 1n }),
+      encodeErc20Permit2SignatureTransfer({ ...base(), nonce: maxUint256 + 1n }),
     ).toThrow(InputExceedsMaxError);
   });
 
   test("error: NonPositiveInputError when deadline is not positive", () => {
     expect(() =>
-      encodeErc20Permit2TransferFrom({ ...base(), deadline: 0n }),
+      encodeErc20Permit2SignatureTransfer({ ...base(), deadline: 0n }),
     ).toThrow(NonPositiveInputError);
   });
 
   test("error: InputExceedsMaxError when deadline exceeds uint256", () => {
     expect(() =>
-      encodeErc20Permit2TransferFrom({ ...base(), deadline: maxUint256 + 1n }),
+      encodeErc20Permit2SignatureTransfer({ ...base(), deadline: maxUint256 + 1n }),
     ).toThrow(InputExceedsMaxError);
   });
 
   test("error: ExpiredDeadlineError when deadline is in the past", () => {
     expect(() =>
-      encodeErc20Permit2TransferFrom({ ...base(), deadline: 1n }),
+      encodeErc20Permit2SignatureTransfer({ ...base(), deadline: 1n }),
     ).toThrow(ExpiredDeadlineError);
   });
 
@@ -131,7 +136,7 @@ describe("encodeErc20Permit2TransferFrom", () => {
     const chainId = ChainId.HyperliquidMainnet;
     const spender = getChainAddress(chainId, "bundles.blueBundlesV1");
     expect(() =>
-      encodeErc20Permit2TransferFrom({
+      encodeErc20Permit2SignatureTransfer({
         token: "0x0000000000000000000000000000000000000001",
         spender,
         amount: 1_000_000n,
@@ -146,7 +151,7 @@ describe("encodeErc20Permit2TransferFrom", () => {
     // Permit2 SignatureTransfer for a direct Blue write must name BlueBundlesV1; any other spender
     // (e.g. GeneralAdapter1) is rejected before signing.
     expect(() =>
-      encodeErc20Permit2TransferFrom({
+      encodeErc20Permit2SignatureTransfer({
         ...base(),
         spender: "0x1111111111111111111111111111111111111111",
       }),

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit2SignatureTransfer.test.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit2SignatureTransfer.test.ts
@@ -96,7 +96,10 @@ describe("encodeErc20Permit2SignatureTransfer", () => {
 
   test("error: InputExceedsMaxError when amount exceeds uint256", () => {
     expect(() =>
-      encodeErc20Permit2SignatureTransfer({ ...base(), amount: maxUint256 + 1n }),
+      encodeErc20Permit2SignatureTransfer({
+        ...base(),
+        amount: maxUint256 + 1n,
+      }),
     ).toThrow(InputExceedsMaxError);
   });
 
@@ -108,7 +111,10 @@ describe("encodeErc20Permit2SignatureTransfer", () => {
 
   test("error: InputExceedsMaxError when nonce exceeds uint256", () => {
     expect(() =>
-      encodeErc20Permit2SignatureTransfer({ ...base(), nonce: maxUint256 + 1n }),
+      encodeErc20Permit2SignatureTransfer({
+        ...base(),
+        nonce: maxUint256 + 1n,
+      }),
     ).toThrow(InputExceedsMaxError);
   });
 
@@ -120,7 +126,10 @@ describe("encodeErc20Permit2SignatureTransfer", () => {
 
   test("error: InputExceedsMaxError when deadline exceeds uint256", () => {
     expect(() =>
-      encodeErc20Permit2SignatureTransfer({ ...base(), deadline: maxUint256 + 1n }),
+      encodeErc20Permit2SignatureTransfer({
+        ...base(),
+        deadline: maxUint256 + 1n,
+      }),
     ).toThrow(InputExceedsMaxError);
   });
 

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit2SignatureTransfer.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeErc20Permit2SignatureTransfer.ts
@@ -9,16 +9,16 @@ import {
   ExpiredDeadlineError,
   InputExceedsMaxError,
   NonPositiveInputError,
-  type Permit2TransferFromAction,
-  type Permit2TransferFromRequirementSignature,
+  type Permit2SignatureTransferAction,
+  type Permit2SignatureTransferRequirementSignature,
   type Requirement,
 } from "../../../types/index.js";
 
-/** Parameters for {@link encodeErc20Permit2TransferFrom}. */
-export interface EncodeErc20Permit2TransferFromParams {
+/** Parameters for {@link encodeErc20Permit2SignatureTransfer}. */
+export interface EncodeErc20Permit2SignatureTransferParams {
   /** ERC-20 token pulled through Permit2. */
   readonly token: Address;
-  /** BlueBundlesV1 deployment receiving permission to pull the token. */
+  /** Registered fixed bundles deployment receiving permission to pull the token. */
   readonly spender: Address;
   /** Exact token amount authorized by the one-time transfer. */
   readonly amount: bigint;
@@ -31,14 +31,14 @@ export interface EncodeErc20Permit2TransferFromParams {
 }
 
 /**
- * Builds a Permit2 SignatureTransfer requirement for a direct BlueBundlesV1 token pull.
+ * Builds a Permit2 SignatureTransfer requirement for a direct fixed-bundles token pull.
  *
  * Unlike Permit2 AllowanceTransfer, this signs a one-time `uint256` amount and unordered nonce;
  * it has no managed allowance expiration.
  *
  * @param params - SignatureTransfer parameters.
  * @param params.token - ERC-20 token pulled through Permit2.
- * @param params.spender - Registered BlueBundlesV1 deployment that performs the pull.
+ * @param params.spender - Registered BlueBundlesV1 or VaultBundlesV1 deployment that performs the pull.
  * @param params.amount - Exact `uint256` token amount authorized.
  * @param params.chainId - Target chain id.
  * @param params.nonce - Unused Permit2 unordered nonce.
@@ -50,7 +50,7 @@ export interface EncodeErc20Permit2TransferFromParams {
  * @throws {ExpiredDeadlineError} when `deadline` is positive but not in the future.
  * @throws {UnsupportedChainIdError} when `chainId` is absent from the address registry.
  * @throws {UnknownAddressError} when the chain has no registered canonical Permit2 deployment.
- * @throws {UnsupportedErc20ApprovalSpenderError} when `spender` is not BlueBundlesV1 for `chainId`.
+ * @throws {UnsupportedErc20ApprovalSpenderError} when `spender` is not a registered fixed bundles deployment for `chainId`.
  * @throws {MissingClientPropertyError} from `sign()` when the wallet client has no account.
  * @throws {AddressMismatchError} from `sign()` when the wallet account differs from `userAddress`.
  * @throws {ChainIdMismatchError} from `sign()` when the wallet chain differs from `chainId`.
@@ -58,24 +58,24 @@ export interface EncodeErc20Permit2TransferFromParams {
  * @example
  * ```ts
  * import { addressesRegistry } from "@morpho-org/blue-sdk";
- * import { encodeErc20Permit2TransferFrom } from "@morpho-org/morpho-sdk";
+ * import { encodeErc20Permit2SignatureTransfer } from "@morpho-org/morpho-sdk";
  * import { getChainAddress } from "@morpho-org/morpho-ts";
  * import { mainnet } from "viem/chains";
  *
- * const requirement = encodeErc20Permit2TransferFrom({
+ * const requirement = encodeErc20Permit2SignatureTransfer({
  *   token: addressesRegistry[mainnet.id].usdc,
- *   spender: getChainAddress(mainnet.id, "bundles.blueBundlesV1"),
+ *   spender: getChainAddress(mainnet.id, "bundles.vaultBundlesV1"),
  *   amount: 1_000_000n,
  *   chainId: mainnet.id,
  *   nonce: 0n,
  *   deadline: BigInt(Math.floor(Date.now() / 1_000) + 3_600),
  * });
- * // requirement satisfies Requirement<Permit2TransferFromRequirementSignature>
+ * // requirement satisfies Requirement<Permit2SignatureTransferRequirementSignature>
  * ```
  */
-export const encodeErc20Permit2TransferFrom = (
-  params: EncodeErc20Permit2TransferFromParams,
-): Requirement<Permit2TransferFromRequirementSignature> => {
+export const encodeErc20Permit2SignatureTransfer = (
+  params: EncodeErc20Permit2SignatureTransferParams,
+): Requirement<Permit2SignatureTransferRequirementSignature> => {
   const { token, spender, amount, chainId, nonce, deadline } = params;
   // Bound every uint256 field before signing: getPermit2TransferFromTypedData silently clamps an
   // oversized allowance to maxUint256, which would desync the signed value from the requirement
@@ -103,7 +103,7 @@ export const encodeErc20Permit2TransferFrom = (
   validateRequirementSpender({
     chainId,
     spender,
-    allowed: ["blueBundlesV1"],
+    allowed: ["vaultBundlesV1", "blueBundlesV1"],
   });
   // getPermit2TransferFromTypedData derives its EIP-712 domain's verifyingContract from
   // getChainAddresses(chainId).permit2. A chain that registers BlueBundlesV1 but no canonical Permit2
@@ -112,9 +112,9 @@ export const encodeErc20Permit2TransferFrom = (
   // this exported encoder is reachable directly, so it must reject the same unsupported chain itself.
   getChainAddress(chainId, "permit2"); // throws UnknownAddressError when Permit2 is unregistered
 
-  const action: Permit2TransferFromAction = {
-    type: "permit2TransferFrom",
-    args: { spender, amount, deadline },
+  const action: Permit2SignatureTransferAction = {
+    type: "permit2SignatureTransfer",
+    args: { spender, amount, nonce, deadline },
   };
 
   return {

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeVaultSharesPermit.test.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeVaultSharesPermit.test.ts
@@ -13,6 +13,7 @@ import {
   AddressMismatchError,
   UnsupportedErc20ApprovalSpenderError,
 } from "../../../types/index.js";
+import { selectBundlesSharesRequirementSignature } from "../../bundles/common.js";
 import { encodeVaultSharesPermit } from "./encodeVaultSharesPermit.js";
 
 const vault = "0x0000000000000000000000000000000000002001" as const;
@@ -57,7 +58,7 @@ describe("encodeVaultSharesPermit", () => {
 
     expect(signed.action).toEqual({
       type: "permit",
-      args: { spender, amount, deadline: 1_900_000_000n },
+      args: { spender, amount, deadline: 1_900_000_000n, nonce: 9n },
     });
     expect(signed.args).toMatchObject({
       owner: account.address,
@@ -67,6 +68,31 @@ describe("encodeVaultSharesPermit", () => {
       deadline: 1_900_000_000n,
     });
     expect(signed.args.signature).toMatch(/^0x[0-9a-f]{130}$/);
+  });
+
+  test("behavior: the signed permit is consumable by the bundles shares selector", async () => {
+    const requirement = encodeVaultSharesPermit({
+      vault: new Token({ address: vault, name: "Vault V2" }),
+      version: "vaultV2",
+      spender,
+      owner: account.address,
+      chainId: mainnet.id,
+      nonce: 9n,
+      amount,
+      deadline: 1_900_000_000n,
+    });
+    const signed = await requirement.sign(walletClient, account.address);
+    const { action } = signed;
+    if (action.type !== "permit") {
+      throw new Error(`expected an ERC-2612 permit action, got ${action.type}`);
+    }
+
+    expect(
+      selectBundlesSharesRequirementSignature([signed], {
+        requiredShareAllowance: amount,
+        expectedRequirement: action,
+      }),
+    ).toEqual(signed);
   });
 
   test("behavior: signs a standard Vault V1 permit", async () => {

--- a/packages/morpho-sdk/src/actions/requirements/encode/encodeVaultSharesPermit.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/encodeVaultSharesPermit.ts
@@ -128,6 +128,7 @@ export const encodeVaultSharesPermit = (
       spender,
       amount,
       deadline,
+      nonce,
     },
   };
 

--- a/packages/morpho-sdk/src/actions/requirements/encode/index.ts
+++ b/packages/morpho-sdk/src/actions/requirements/encode/index.ts
@@ -2,5 +2,5 @@ export * from "./encodeBlueSignatureAuthorization.js";
 export * from "./encodeErc20Approval.js";
 export * from "./encodeErc20Permit.js";
 export * from "./encodeErc20Permit2Approve.js";
-export * from "./encodeErc20Permit2TransferFrom.js";
+export * from "./encodeErc20Permit2SignatureTransfer.js";
 export * from "./encodeVaultSharesPermit.js";

--- a/packages/morpho-sdk/src/actions/requirements/generalAdapter/getGeneralAdapterRequirements.test.ts
+++ b/packages/morpho-sdk/src/actions/requirements/generalAdapter/getGeneralAdapterRequirements.test.ts
@@ -694,10 +694,11 @@ describe("getGeneralAdapterRequirements", () => {
               nonce: 0n,
             },
             action: {
-              type: "permit2TransferFrom",
+              type: "permit2SignatureTransfer",
               args: {
                 spender: generalAdapter1,
                 amount: mockAmount,
+                nonce: 0n,
                 deadline: 1n,
               },
             },

--- a/packages/morpho-sdk/src/actions/requirements/getRequirementsApproval.ts
+++ b/packages/morpho-sdk/src/actions/requirements/getRequirementsApproval.ts
@@ -13,8 +13,8 @@ import { encodeErc20Approval } from "./encode/encodeErc20Approval.js";
  * allowance.
  *
  * The spender is validated by {@link encodeErc20Approval}. Supported spenders are the chain's
- * GeneralAdapter1, Permit2, Midnight, MidnightBundles, VaultExitBundlesV1, and BlueBundlesV1
- * addresses when configured.
+ * GeneralAdapter1, Permit2, Midnight, MidnightBundles, VaultExitBundlesV1, VaultBundlesV1, and
+ * BlueBundlesV1 addresses when configured.
  *
  * Returns an empty array when the allowance already covers `spendAmount`. When the token is in
  * `APPROVE_ONLY_ONCE_TOKENS` (e.g. USDT) and the existing allowance is non-zero, prepends a
@@ -28,7 +28,8 @@ import { encodeErc20Approval } from "./encode/encodeErc20Approval.js";
  * @param params.args.approvalAmount - The amount to approve (often equal to `spendAmount`, but
  *   may be `maxUint256` for reusable Permit2 or saturated-share-repay approvals).
  * @param params.args.spender - Address that will be granted the approval. Must be GeneralAdapter1,
- *   Permit2, Midnight, MidnightBundles, VaultExitBundlesV1, or BlueBundlesV1 for `chainId`.
+ *   Permit2, Midnight, MidnightBundles, VaultExitBundlesV1, VaultBundlesV1, or BlueBundlesV1 for
+ *   `chainId`.
  * @param params.allowances - The user's current allowance of `address` for `spender`.
  * @returns Up to two deep-frozen `Transaction<ERC20ApprovalAction>` entries: an optional reset
  *   followed by the new approval. Empty when no approval is needed.

--- a/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.test.ts
+++ b/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.test.ts
@@ -32,7 +32,7 @@ const permitSignature: Erc2612RequirementSignature = {
   },
   action: {
     type: "permit",
-    args: { spender: SPENDER, amount: AMOUNT, deadline: DEADLINE },
+    args: { spender: SPENDER, amount: AMOUNT, nonce: 0n, deadline: DEADLINE },
   },
 };
 
@@ -130,7 +130,7 @@ describe("getTokenRequirementActions", () => {
       },
       action: {
         type: "permit2SignatureTransfer",
-        args: { spender: SPENDER, amount: AMOUNT, deadline: DEADLINE },
+        args: { spender: SPENDER, amount: AMOUNT, nonce: 0n, deadline: DEADLINE },
       },
     };
 

--- a/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.test.ts
+++ b/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.test.ts
@@ -119,20 +119,26 @@ describe("getTokenRequirementActions", () => {
 
   test("error: UnexpectedRequirementSignatureError rejects a BlueBundlesV1 SignatureTransfer result", () => {
     // permit2SignatureTransfer is a BlueBundlesV1-only result; it must never reach the Bundler3 path.
-    const transferFromSignature: Permit2SignatureTransferRequirementSignature = {
-      args: {
-        owner: OWNER,
-        nonce: 0n,
-        asset: ASSET,
-        signature: SIGNATURE,
-        amount: AMOUNT,
-        deadline: DEADLINE,
-      },
-      action: {
-        type: "permit2SignatureTransfer",
-        args: { spender: SPENDER, amount: AMOUNT, nonce: 0n, deadline: DEADLINE },
-      },
-    };
+    const transferFromSignature: Permit2SignatureTransferRequirementSignature =
+      {
+        args: {
+          owner: OWNER,
+          nonce: 0n,
+          asset: ASSET,
+          signature: SIGNATURE,
+          amount: AMOUNT,
+          deadline: DEADLINE,
+        },
+        action: {
+          type: "permit2SignatureTransfer",
+          args: {
+            spender: SPENDER,
+            amount: AMOUNT,
+            nonce: 0n,
+            deadline: DEADLINE,
+          },
+        },
+      };
 
     expect(() =>
       getTokenRequirementActions({

--- a/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.test.ts
+++ b/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.test.ts
@@ -6,7 +6,7 @@ import {
   type Erc2612RequirementSignature,
   type Permit2AllowanceRequirementSignature,
   Permit2ExpirationMissingError,
-  type Permit2TransferFromRequirementSignature,
+  type Permit2SignatureTransferRequirementSignature,
   type PermitRequirementSignature,
   UnexpectedRequirementSignatureError,
 } from "../../types/index.js";
@@ -118,8 +118,8 @@ describe("getTokenRequirementActions", () => {
   });
 
   test("error: UnexpectedRequirementSignatureError rejects a BlueBundlesV1 SignatureTransfer result", () => {
-    // permit2TransferFrom is a BlueBundlesV1-only result; it must never reach the Bundler3 path.
-    const transferFromSignature: Permit2TransferFromRequirementSignature = {
+    // permit2SignatureTransfer is a BlueBundlesV1-only result; it must never reach the Bundler3 path.
+    const transferFromSignature: Permit2SignatureTransferRequirementSignature = {
       args: {
         owner: OWNER,
         nonce: 0n,
@@ -129,7 +129,7 @@ describe("getTokenRequirementActions", () => {
         deadline: DEADLINE,
       },
       action: {
-        type: "permit2TransferFrom",
+        type: "permit2SignatureTransfer",
         args: { spender: SPENDER, amount: AMOUNT, deadline: DEADLINE },
       },
     };

--- a/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.ts
+++ b/packages/morpho-sdk/src/actions/signatures/getTokenRequirementActions.ts
@@ -3,7 +3,7 @@ import type { Action } from "../../bundler/index.js";
 import {
   DepositAmountMismatchError,
   DepositAssetMismatchError,
-  isPermit2TransferFromSignature,
+  isPermit2SignatureTransferSignature,
   Permit2ExpirationMissingError,
   type PermitRequirementSignature,
   UnexpectedRequirementSignatureError,
@@ -78,8 +78,8 @@ export const getTokenRequirementActions = ({
     ];
   }
 
-  if (isPermit2TransferFromSignature(requirementSignature)) {
-    throw new UnexpectedRequirementSignatureError("permit2TransferFrom");
+  if (isPermit2SignatureTransferSignature(requirementSignature)) {
+    throw new UnexpectedRequirementSignatureError("permit2SignatureTransfer");
   }
 
   if (!isAddressEqual(requirementSignature.args.asset, asset)) {

--- a/packages/morpho-sdk/src/actions/signatures/getVaultExitBundlesV1PermitStruct.ts
+++ b/packages/morpho-sdk/src/actions/signatures/getVaultExitBundlesV1PermitStruct.ts
@@ -1,7 +1,6 @@
 import {
   type Address,
   compactSignatureToSignature,
-  type Hex,
   isAddressEqual,
   parseCompactSignature,
   parseSignature,
@@ -12,22 +11,10 @@ import {
   type PermitRequirementSignature,
   VaultExitBundlesV1PermitMismatchError,
 } from "../../types/index.js";
+import type { BundleSharesPermit } from "../bundles/common.js";
 
-/** Permit tuple consumed by VaultExitBundlesV1. */
-export interface VaultExitBundlesV1PermitStruct {
-  /** Vault-share allowance authorized by the permit. */
-  readonly value: bigint;
-  /** Vault permit nonce signed by the owner. */
-  readonly nonce: bigint;
-  /** Timestamp after which the permit is invalid. */
-  readonly deadline: bigint;
-  /** ECDSA recovery identifier, or zero for the empty-permit sentinel. */
-  readonly v: number;
-  /** ECDSA signature `r`, or zero for the empty-permit sentinel. */
-  readonly r: Hex;
-  /** ECDSA signature `s`, or zero for the empty-permit sentinel. */
-  readonly s: Hex;
-}
+/** Compatibility alias for the canonical {@link BundleSharesPermit} tuple consumed by VaultExitBundlesV1. */
+export type VaultExitBundlesV1PermitStruct = BundleSharesPermit;
 
 /** Parameters for {@link getVaultExitBundlesV1PermitStruct}. */
 export interface GetVaultExitBundlesV1PermitStructParams {

--- a/packages/morpho-sdk/src/bundler/actions.test.ts
+++ b/packages/morpho-sdk/src/bundler/actions.test.ts
@@ -1251,7 +1251,7 @@ describe("BundlerAction", () => {
 
     expect(call.to).toBe(generalAdapter1);
     expect(call.skipRevert).toBe(true);
-    expect(decoded.functionName).toBe("permit2SignatureTransfer");
+    expect(decoded.functionName).toBe("permit2TransferFrom");
     expect(decoded.args).toEqual([asset, recipient, 1n]);
   });
 

--- a/packages/morpho-sdk/src/bundler/actions.test.ts
+++ b/packages/morpho-sdk/src/bundler/actions.test.ts
@@ -1251,7 +1251,7 @@ describe("BundlerAction", () => {
 
     expect(call.to).toBe(generalAdapter1);
     expect(call.skipRevert).toBe(true);
-    expect(decoded.functionName).toBe("permit2TransferFrom");
+    expect(decoded.functionName).toBe("permit2SignatureTransfer");
     expect(decoded.args).toEqual([asset, recipient, 1n]);
   });
 

--- a/packages/morpho-sdk/src/bundler/actions.ts
+++ b/packages/morpho-sdk/src/bundler/actions.ts
@@ -783,7 +783,7 @@ export namespace BundlerAction {
         to: generalAdapter1,
         data: encodeFunctionData({
           abi: generalAdapter1Abi,
-          functionName: "permit2TransferFrom",
+          functionName: "permit2SignatureTransfer",
           args: [asset, recipient, amount],
         }),
         value: 0n,

--- a/packages/morpho-sdk/src/bundler/actions.ts
+++ b/packages/morpho-sdk/src/bundler/actions.ts
@@ -783,7 +783,7 @@ export namespace BundlerAction {
         to: generalAdapter1,
         data: encodeFunctionData({
           abi: generalAdapter1Abi,
-          functionName: "permit2SignatureTransfer",
+          functionName: "permit2TransferFrom",
           args: [asset, recipient, amount],
         }),
         value: 0n,

--- a/packages/morpho-sdk/src/entities/blue/blue.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.test.ts
@@ -20,8 +20,8 @@ import {
 } from "../../helpers/index.js";
 import {
   AccrualPositionUserMismatchError,
-  type BlueBundlesV1TokenRequirementSignature,
   BorrowExceedsSafeLtvError,
+  type BundlesTokenRequirementSignature,
   ChainIdMismatchError,
   ExpiredDeadlineError,
   InputExceedsMaxError,
@@ -30,6 +30,7 @@ import {
   MissingAccrualPositionError,
   MissingReferralFeeRecipientError,
   NegativeInputError,
+  ReferralFeePctExceededError,
   RepayExceedsDebtError,
   RepaySharesExceedDebtError,
   type VaultV2BlueReallocation,
@@ -545,7 +546,7 @@ describe("MorphoBlue common write validation", () => {
       referralFeePct: MathLib.WAD,
       referralFeeRecipient: otherUserAddress,
     })) {
-      expect(call, method).toThrow(InputExceedsMaxError);
+      expect(call, method).toThrow(ReferralFeePctExceededError);
     }
   });
 });
@@ -981,14 +982,15 @@ describe("MorphoBlue position validation", () => {
           deadline,
         },
         action: {
-          type: "permit2TransferFrom",
+          type: "permit2SignatureTransfer",
           args: {
             spender: getChainAddress(mainnet.id, "bundles.blueBundlesV1"),
             amount,
+            nonce: 1n,
             deadline,
           },
         },
-      }) satisfies BlueBundlesV1TokenRequirementSignature;
+      }) satisfies BundlesTokenRequirementSignature;
 
     expect(
       action.buildTx([signature(minimum + 1n)]).action.args.maxRepayAssets,

--- a/packages/morpho-sdk/src/entities/blue/blue.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.test.ts
@@ -547,6 +547,9 @@ describe("MorphoBlue common write validation", () => {
       referralFeeRecipient: otherUserAddress,
     })) {
       expect(call, method).toThrow(ReferralFeePctExceededError);
+      // The Blue JSDoc has always promised InputExceedsMaxError here; the shared
+      // bundles normalizer must not break integrators pattern-matching it.
+      expect(call, method).toThrow(InputExceedsMaxError);
     }
   });
 });

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -38,7 +38,6 @@ import {
   blueWithdraw,
   blueWithdrawCollateral,
   getBlueAuthorizationRequirement,
-  getBlueBundlesV1TokenRequirements,
 } from "../../actions/index.js";
 import {
   computeVaultV1Reallocations,
@@ -85,6 +84,7 @@ import {
   type VaultV2BluePublicAllocatorOptions,
   type VaultV2BlueReallocation,
 } from "../../types/index.js";
+import { getBundlesTokenRequirements } from "../requirements/index.js";
 import { VaultV1ReallocationData } from "../vaultV1ReallocationData.js";
 import { VaultV2BlueReallocationData } from "../vaultV2BlueReallocationData.js";
 
@@ -172,15 +172,15 @@ export interface BlueActions {
    * @throws {NativeAmountOnNonWNativeAssetError} when native funding targets another token.
    * @throws {InputExceedsMaxError} when the referral fee is at least WAD.
    * @throws {MissingReferralFeeRecipientError} when a positive fee has no recipient.
-   * @throws {MissingPermit2TransferFromNonceError} from `getRequirements()` when Permit2 is selected without a nonce.
-   * @throws {Permit2TransferFromNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
+   * @throws {MissingPermit2SignatureTransferNonceError} from `getRequirements()` when Permit2 is selected without a nonce.
+   * @throws {Permit2SignatureTransferNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple token signatures are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when an unsupported signature is supplied.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when the signed owner differs from `userAddress`.
    * @throws {DepositAssetMismatchError} from `buildTx()` when the signed asset differs from the collateral token.
    * @throws {DepositAmountMismatchError} from `buildTx()` when the signed amount differs from `collateralAssets`.
    * @throws {DepositSpenderMismatchError} from `buildTx()` when the signed spender is not BlueBundlesV1.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when an allowance, nonce, or token metadata read fails.
@@ -241,8 +241,8 @@ export interface BlueActions {
    * @throws {NativeAmountOnNonWNativeAssetError} when native funding targets another token.
    * @throws {InputExceedsMaxError} when `assets` or `deadline` exceeds `uint256`, when the referral fee is at least WAD, or from `getRequirements()` when an explicit `permit2Nonce` exceeds `uint256`.
    * @throws {MissingReferralFeeRecipientError} when a positive fee has no recipient.
-   * @throws {MissingPermit2TransferFromNonceError} from `getRequirements()` when Permit2 is selected without an explicit nonce.
-   * @throws {Permit2TransferFromNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
+   * @throws {MissingPermit2SignatureTransferNonceError} from `getRequirements()` when Permit2 is selected without an explicit nonce.
+   * @throws {Permit2SignatureTransferNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
    * @throws {ApprovalAmountLessThanSpendAmountError} from `getRequirements()` when a classic `approvalAmount` is below the funded `assets`.
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple token signatures are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when the route cannot consume a supplied signature.
@@ -250,7 +250,7 @@ export interface BlueActions {
    * @throws {DepositAssetMismatchError} from `buildTx()` when the signed asset differs from the loan token.
    * @throws {DepositAmountMismatchError} from `buildTx()` when the signed amount differs from `assets`.
    * @throws {DepositSpenderMismatchError} from `buildTx()` when the signed spender is not BlueBundlesV1.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when a required allowance, nonce, or token metadata read fails.
@@ -326,7 +326,7 @@ export interface BlueActions {
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple authorization signatures are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when a non-authorization signature is supplied.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when the signed owner differs from `userAddress`.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when authorization reads fail.
@@ -407,7 +407,7 @@ export interface BlueActions {
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple authorization signatures are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when a token signature is supplied.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when the signed owner differs from `userAddress`.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when authorization reads fail.
@@ -483,15 +483,15 @@ export interface BlueActions {
    * @throws {NativeFundingAmountMismatchError} when native funding is partial or mixed.
    * @throws {ChainWNativeMissingError} when native funding is requested on a chain without wNative.
    * @throws {NativeAmountOnNonWNativeAssetError} when native funding targets another token.
-   * @throws {MissingPermit2TransferFromNonceError} from `getRequirements()` when Permit2 is selected without a nonce.
-   * @throws {Permit2TransferFromNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
+   * @throws {MissingPermit2SignatureTransferNonceError} from `getRequirements()` when Permit2 is selected without a nonce.
+   * @throws {Permit2SignatureTransferNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple token signatures are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when an authorization signature is supplied.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when the signed owner differs from `userAddress`.
    * @throws {DepositAssetMismatchError} from `buildTx()` when the signed asset differs from the loan token.
    * @throws {DepositAmountMismatchError} from `buildTx()` when the signed amount differs from the derived funding cap.
    * @throws {DepositSpenderMismatchError} from `buildTx()` when the signed spender is not BlueBundlesV1.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when an allowance, nonce, or token metadata read fails.
@@ -568,7 +568,7 @@ export interface BlueActions {
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple authorization signatures are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when a token signature is supplied.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when the signed owner differs from `userAddress`.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when authorization reads fail.
@@ -653,15 +653,15 @@ export interface BlueActions {
    * @throws {NativeFundingAmountMismatchError} when native funding is partial or mixed.
    * @throws {ChainWNativeMissingError} when native funding is requested on a chain without wNative.
    * @throws {NativeAmountOnNonWNativeAssetError} when native funding targets another token.
-   * @throws {MissingPermit2TransferFromNonceError} from `getRequirements()` when Permit2 is selected without an explicit nonce.
-   * @throws {Permit2TransferFromNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
+   * @throws {MissingPermit2SignatureTransferNonceError} from `getRequirements()` when Permit2 is selected without an explicit nonce.
+   * @throws {Permit2SignatureTransferNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple signatures of one kind are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when an inactive leg cannot consume a supplied signature.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when a signed owner differs from `userAddress`.
    * @throws {DepositAssetMismatchError} from `buildTx()` when the signed asset differs from the loan token.
    * @throws {DepositAmountMismatchError} from `buildTx()` when the signed amount differs from the derived funding cap.
    * @throws {DepositSpenderMismatchError} from `buildTx()` when the signed spender is not BlueBundlesV1.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when a required allowance, nonce, token metadata, or authorization read fails.
@@ -753,15 +753,15 @@ export interface BlueActions {
    * @throws {InconsistentReallocationPenaltyError} when one vault uses different penalties.
    * @throws {ReallocationWithdrawalOnTargetMarketError} when a source is the target market.
    * @throws {ReallocationLoanTokenMismatchError} when a source uses another loan token.
-   * @throws {MissingPermit2TransferFromNonceError} from `getRequirements()` when Permit2 is selected without an explicit nonce.
-   * @throws {Permit2TransferFromNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
+   * @throws {MissingPermit2SignatureTransferNonceError} from `getRequirements()` when Permit2 is selected without an explicit nonce.
+   * @throws {Permit2SignatureTransferNonceAlreadyUsedError} from `getRequirements()` when the explicit Permit2 nonce is consumed.
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple signatures of one kind are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when an inactive leg cannot consume a supplied signature.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when a signed owner differs from `userAddress`.
    * @throws {DepositAssetMismatchError} from `buildTx()` when the signed asset differs from the collateral token.
    * @throws {DepositAmountMismatchError} from `buildTx()` when the signed amount differs from `collateralAssets`.
    * @throws {DepositSpenderMismatchError} from `buildTx()` when the signed spender is not BlueBundlesV1.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when a signature cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when a required allowance, nonce, token metadata, or authorization read fails.
@@ -847,7 +847,7 @@ export interface BlueActions {
    * @throws {AmbiguousRequirementSignaturesError} from `buildTx()` when multiple authorization signatures are supplied.
    * @throws {UnexpectedRequirementSignatureError} from `buildTx()` when a non-authorization signature is supplied.
    * @throws {DepositOwnerMismatchError} from `buildTx()` when the signed owner differs from `userAddress`.
-   * @throws {BlueBundlesV1RequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
+   * @throws {BundlesRequirementSignatureMismatchError} from `buildTx()` when authorization cannot be encoded safely.
    * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
    * @throws {UnknownAddressError} when BlueBundlesV1 is not registered.
    * @throws {viem.BaseError} from `getRequirements()` when authorization reads fail.
@@ -1134,8 +1134,9 @@ export class MorphoBlue implements BlueActions {
     approvalAmount?: bigint;
   }): Promise<readonly ActionRequirement[]> {
     this.validateDeadline(params.deadline);
-    return getBlueBundlesV1TokenRequirements(this.client.viemClient, {
+    return getBundlesTokenRequirements(this.client.viemClient, {
       token: params.token,
+      spender: getChainAddress(this.chainId, "bundles.blueBundlesV1"),
       amount: params.amount,
       owner: params.userAddress,
       chainId: this.chainId,

--- a/packages/morpho-sdk/src/entities/index.ts
+++ b/packages/morpho-sdk/src/entities/index.ts
@@ -185,6 +185,7 @@ export {
   type MidnightActions,
   MorphoMidnight,
 } from "./midnight/index.js";
+export * from "./requirements/index.js";
 export { MorphoVaultV1 } from "./vaultV1/index.js";
 export {
   type InputReallocationData,

--- a/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.test.ts
@@ -1,7 +1,13 @@
 import { addressesRegistry } from "@morpho-org/blue-sdk";
 import { permit2Abi } from "@morpho-org/blue-sdk-viem";
 import { createMockClient, mockRead } from "@morpho-org/test/mock";
-import { createWalletClient, erc20Abi, http, maxUint256 } from "viem";
+import {
+  createWalletClient,
+  erc20Abi,
+  http,
+  maxUint256,
+  zeroAddress,
+} from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains";
 import { describe, expect, test } from "vitest";
@@ -15,6 +21,7 @@ import {
   NegativeInputError,
   NonPositiveInputError,
   Permit2SignatureTransferNonceAlreadyUsedError,
+  UnsupportedErc20ApprovalSpenderError,
 } from "../../types/index.js";
 import { getBundlesTokenRequirements } from "./getBundlesTokenRequirements.js";
 
@@ -33,6 +40,44 @@ describe("getBundlesTokenRequirements", () => {
     throw new Error("BlueBundlesV1 requirements are not registered");
   }
   const blueBundlesV1 = bundles.blueBundlesV1;
+
+  test.each([
+    { supportSignature: false, amount: 0n, allowance: 0n },
+    { supportSignature: false, amount: 1n, allowance: 0n },
+    { supportSignature: false, amount: 1n, allowance: maxUint256 },
+    { supportSignature: true, amount: 1n, useSimplePermit: true },
+    { supportSignature: true, amount: 1n, useSimplePermit: false },
+  ])(
+    "error: UnsupportedErc20ApprovalSpenderError before RPC reads (case %#)",
+    async (options) => {
+      for (const spender of [
+        addressesRegistry[mainnet.id].bundler3.generalAdapter1,
+        permit2,
+        zeroAddress,
+      ]) {
+        const handle = createMockClient(mainnet);
+        mockRead(handle, {
+          address: usdc,
+          abi: erc20Abi,
+          functionName: "allowance",
+          result: options.allowance ?? 0n,
+        });
+
+        await expect(
+          getBundlesTokenRequirements(handle.client, {
+            token: usdc,
+            spender,
+            owner: account.address,
+            chainId: mainnet.id,
+            deadline: maxUint256,
+            permit2Nonce: 0n,
+            ...options,
+          }),
+        ).rejects.toBeInstanceOf(UnsupportedErc20ApprovalSpenderError);
+        expect(handle.request).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   test("returns a direct exact approval when signatures are disabled", async () => {
     const handle = createMockClient(mainnet);

--- a/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.test.ts
@@ -187,6 +187,7 @@ describe("getBundlesTokenRequirements", () => {
     await expect(
       getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: maxUint256 + 1n,
         owner: account.address,
         chainId: mainnet.id,

--- a/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.test.ts
+++ b/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.test.ts
@@ -11,12 +11,12 @@ import {
   InputExceedsMaxError,
   isRequirementApproval,
   isRequirementSignature,
-  MissingPermit2TransferFromNonceError,
+  MissingPermit2SignatureTransferNonceError,
   NegativeInputError,
   NonPositiveInputError,
-  Permit2TransferFromNonceAlreadyUsedError,
-} from "../../../types/index.js";
-import { getBlueBundlesV1TokenRequirements } from "./getBlueBundlesV1TokenRequirements.js";
+  Permit2SignatureTransferNonceAlreadyUsedError,
+} from "../../types/index.js";
+import { getBundlesTokenRequirements } from "./getBundlesTokenRequirements.js";
 
 const account = privateKeyToAccount(
   "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
@@ -27,7 +27,7 @@ const walletClient = createWalletClient({
   transport: http(),
 });
 
-describe("getBlueBundlesV1TokenRequirements", () => {
+describe("getBundlesTokenRequirements", () => {
   const { usdc, permit2, bundles } = addressesRegistry[mainnet.id];
   if (permit2 == null || bundles?.blueBundlesV1 == null) {
     throw new Error("BlueBundlesV1 requirements are not registered");
@@ -43,17 +43,15 @@ describe("getBlueBundlesV1TokenRequirements", () => {
       result: 0n,
     });
 
-    const requirements = await getBlueBundlesV1TokenRequirements(
-      handle.client,
-      {
-        token: usdc,
-        amount: 1_000_000n,
-        owner: account.address,
-        chainId: mainnet.id,
-        deadline: maxUint256,
-        supportSignature: false,
-      },
-    );
+    const requirements = await getBundlesTokenRequirements(handle.client, {
+      token: usdc,
+      spender: blueBundlesV1,
+      amount: 1_000_000n,
+      owner: account.address,
+      chainId: mainnet.id,
+      deadline: maxUint256,
+      supportSignature: false,
+    });
 
     expect(requirements).toHaveLength(1);
     expect(isRequirementApproval(requirements[0])).toBe(true);
@@ -71,10 +69,11 @@ describe("getBlueBundlesV1TokenRequirements", () => {
       functionName: "allowance",
       result: 2_000_000n,
     });
-    const coveredRequirements = await getBlueBundlesV1TokenRequirements(
+    const coveredRequirements = await getBundlesTokenRequirements(
       handle.client,
       {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1_000_000n,
         approvalAmount: maxUint256,
         owner: account.address,
@@ -93,10 +92,11 @@ describe("getBlueBundlesV1TokenRequirements", () => {
       functionName: "allowance",
       result: 0n,
     });
-    const reusableRequirements = await getBlueBundlesV1TokenRequirements(
+    const reusableRequirements = await getBundlesTokenRequirements(
       handle.client,
       {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1_000_000n,
         approvalAmount: maxUint256,
         owner: account.address,
@@ -127,19 +127,17 @@ describe("getBlueBundlesV1TokenRequirements", () => {
       result: 1n,
     });
 
-    const requirements = await getBlueBundlesV1TokenRequirements(
-      handle.client,
-      {
-        token: usdc,
-        amount: maxUint256,
-        owner: account.address,
-        chainId: mainnet.id,
-        deadline: maxUint256,
-        supportSignature: true,
-        useSimplePermit: true,
-        permit2Nonce: maxUint256 - 1n,
-      },
-    );
+    const requirements = await getBundlesTokenRequirements(handle.client, {
+      token: usdc,
+      spender: blueBundlesV1,
+      amount: maxUint256,
+      owner: account.address,
+      chainId: mainnet.id,
+      deadline: maxUint256,
+      supportSignature: true,
+      useSimplePermit: true,
+      permit2Nonce: maxUint256 - 1n,
+    });
     const signatureRequirement = requirements.at(-1);
     if (!isRequirementSignature(signatureRequirement)) {
       throw new Error("SignatureTransfer requirement is missing");
@@ -153,18 +151,19 @@ describe("getBlueBundlesV1TokenRequirements", () => {
       type: "erc20Approval",
       args: { spender: permit2 },
     });
-    if (signed.action.type !== "permit2TransferFrom") {
+    if (signed.action.type !== "permit2SignatureTransfer") {
       throw new Error("Unexpected signature requirement");
     }
-    expect(signed.action.type).toBe("permit2TransferFrom");
+    expect(signed.action.type).toBe("permit2SignatureTransfer");
     expect(signed.args.nonce).toBe(maxUint256 - 1n);
   });
 
   test("rejects invalid amounts and unavailable Permit2 nonces", async () => {
     const handle = createMockClient(mainnet);
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: -1n,
         owner: account.address,
         chainId: mainnet.id,
@@ -174,8 +173,9 @@ describe("getBlueBundlesV1TokenRequirements", () => {
     ).rejects.toBeInstanceOf(NegativeInputError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1n,
         owner: account.address,
         chainId: mainnet.id,
@@ -185,7 +185,7 @@ describe("getBlueBundlesV1TokenRequirements", () => {
     ).rejects.toBeInstanceOf(NonPositiveInputError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
         amount: maxUint256 + 1n,
         owner: account.address,
@@ -196,8 +196,9 @@ describe("getBlueBundlesV1TokenRequirements", () => {
     ).rejects.toBeInstanceOf(InputExceedsMaxError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1n,
         owner: account.address,
         chainId: mainnet.id,
@@ -207,8 +208,9 @@ describe("getBlueBundlesV1TokenRequirements", () => {
     ).rejects.toBeInstanceOf(InputExceedsMaxError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1n,
         owner: account.address,
         chainId: mainnet.id,
@@ -218,8 +220,9 @@ describe("getBlueBundlesV1TokenRequirements", () => {
     ).rejects.toBeInstanceOf(ExpiredDeadlineError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 2n,
         approvalAmount: 1n,
         owner: account.address,
@@ -230,19 +233,21 @@ describe("getBlueBundlesV1TokenRequirements", () => {
     ).rejects.toBeInstanceOf(ApprovalAmountLessThanSpendAmountError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1n,
         owner: account.address,
         chainId: mainnet.id,
         deadline: maxUint256,
         supportSignature: true,
       }),
-    ).rejects.toBeInstanceOf(MissingPermit2TransferFromNonceError);
+    ).rejects.toBeInstanceOf(MissingPermit2SignatureTransferNonceError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1n,
         owner: account.address,
         chainId: mainnet.id,
@@ -253,8 +258,9 @@ describe("getBlueBundlesV1TokenRequirements", () => {
     ).rejects.toBeInstanceOf(NegativeInputError);
 
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1n,
         owner: account.address,
         chainId: mainnet.id,
@@ -277,8 +283,9 @@ describe("getBlueBundlesV1TokenRequirements", () => {
       result: 1n << 7n,
     });
     await expect(
-      getBlueBundlesV1TokenRequirements(handle.client, {
+      getBundlesTokenRequirements(handle.client, {
         token: usdc,
+        spender: blueBundlesV1,
         amount: 1n,
         owner: account.address,
         chainId: mainnet.id,
@@ -286,6 +293,6 @@ describe("getBlueBundlesV1TokenRequirements", () => {
         supportSignature: true,
         permit2Nonce: 7n,
       }),
-    ).rejects.toBeInstanceOf(Permit2TransferFromNonceAlreadyUsedError);
+    ).rejects.toBeInstanceOf(Permit2SignatureTransferNonceAlreadyUsedError);
   });
 });

--- a/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.ts
@@ -224,7 +224,6 @@ export const getBundlesTokenRequirements = async (
         deadline: params.deadline,
         state: {
           type: "permit2SignatureTransfer",
-          permit2,
           permit2Allowance: allowance,
           permit2Nonce: params.permit2Nonce,
           nonceBitmap,

--- a/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.ts
@@ -11,7 +11,10 @@ import {
 import { readContract } from "viem/actions";
 import { resolveBundlesTokenRequirements } from "../../actions/bundles/index.js";
 import { encodeErc20Permit } from "../../actions/requirements/encode/encodeErc20Permit.js";
-import { validateChainId } from "../../helpers/index.js";
+import {
+  validateChainId,
+  validateRequirementSpender,
+} from "../../helpers/index.js";
 import {
   ApprovalAmountLessThanSpendAmountError,
   type BundlesTokenSignatureRequirement,
@@ -78,6 +81,8 @@ export interface GetBundlesTokenRequirementsParams {
  * @throws {NonPositiveInputError} when `deadline` is not positive.
  * @throws {ExpiredDeadlineError} when `deadline` is positive but not in the future.
  * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
+ * @throws {UnsupportedErc20ApprovalSpenderError} when `spender` is not the chain's registered
+ *   BlueBundlesV1 or VaultBundlesV1 deployment, including for a zero-amount request.
  * @throws {MissingPermit2SignatureTransferNonceError} when Permit2 is selected without a nonce.
  * @throws {Permit2SignatureTransferNonceAlreadyUsedError} when `permit2Nonce` is already consumed.
  * @throws {InputExceedsMaxError} when `amount`, `deadline`, or `permit2Nonce` exceeds uint256.
@@ -117,6 +122,11 @@ export const getBundlesTokenRequirements = async (
   )[]
 > => {
   validateChainId(viemClient.chain?.id, params.chainId);
+  validateRequirementSpender({
+    chainId: params.chainId,
+    spender: params.spender,
+    allowed: ["blueBundlesV1", "vaultBundlesV1"],
+  });
   if (params.amount < 0n) {
     throw new NegativeInputError("amount", params.amount);
   }

--- a/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.ts
+++ b/packages/morpho-sdk/src/entities/requirements/getBundlesTokenRequirements.ts
@@ -1,6 +1,6 @@
 import { getChainAddresses } from "@morpho-org/blue-sdk";
 import { erc2612Abi, permit2Abi } from "@morpho-org/blue-sdk-viem";
-import { getChainAddress, isDefined, Time } from "@morpho-org/morpho-ts";
+import { isDefined, Time } from "@morpho-org/morpho-ts";
 import {
   type Address,
   type Client,
@@ -9,28 +9,28 @@ import {
   maxUint256,
 } from "viem";
 import { readContract } from "viem/actions";
-import { validateChainId } from "../../../helpers/index.js";
+import { resolveBundlesTokenRequirements } from "../../actions/bundles/index.js";
+import { encodeErc20Permit } from "../../actions/requirements/encode/encodeErc20Permit.js";
+import { validateChainId } from "../../helpers/index.js";
 import {
   ApprovalAmountLessThanSpendAmountError,
-  type BlueBundlesV1TokenSignatureRequirement,
+  type BundlesTokenSignatureRequirement,
   type ERC20ApprovalAction,
   ExpiredDeadlineError,
   InputExceedsMaxError,
-  MissingPermit2TransferFromNonceError,
+  MissingPermit2SignatureTransferNonceError,
   NegativeInputError,
   NonPositiveInputError,
-  Permit2TransferFromNonceAlreadyUsedError,
   type Transaction,
-} from "../../../types/index.js";
-import { encodeErc20Permit } from "../encode/encodeErc20Permit.js";
-import { encodeErc20Permit2TransferFrom } from "../encode/encodeErc20Permit2TransferFrom.js";
-import { getRequirementsApproval } from "../getRequirementsApproval.js";
+} from "../../types/index.js";
 
-/** Parameters for {@link getBlueBundlesV1TokenRequirements}. */
-export interface GetBlueBundlesV1TokenRequirementsParams {
+/** Parameters for {@link getBundlesTokenRequirements}. */
+export interface GetBundlesTokenRequirementsParams {
   /** ERC-20 token funded by the operation. */
   readonly token: Address;
-  /** Exact amount BlueBundlesV1 will pull. */
+  /** Registered fixed bundles contract that pulls the token. */
+  readonly spender: Address;
+  /** Exact amount the bundles contract will pull. */
   readonly amount: bigint;
   /** Classic approval amount; defaults to the exact pull amount. */
   readonly approvalAmount?: bigint;
@@ -52,17 +52,18 @@ export interface GetBlueBundlesV1TokenRequirementsParams {
 
 /**
  * Resolves direct approval, ERC-2612, or Permit2 SignatureTransfer prerequisites for
- * BlueBundlesV1.
+ * a registered fixed bundles contract.
  *
  * Reads only the allowance and nonce state required by the selected path. Permit2 keeps the
- * ERC-20 allowance on canonical Permit2 while the one-time signed transfer names BlueBundlesV1
+ * ERC-20 allowance on canonical Permit2 while the one-time signed transfer names the bundles contract
  * as spender. Permit2 SignatureTransfer requires an explicit unused unordered nonce so concurrent
  * requirements never silently sign the same owner-global nonce.
  *
  * @param viemClient - Connected viem client used for allowance and nonce reads.
  * @param params - Token requirement parameters.
  * @param params.token - ERC-20 token funded by the operation.
- * @param params.amount - Exact amount BlueBundlesV1 will pull; zero returns no requirements.
+ * @param params.spender - Registered fixed bundles contract that pulls the token.
+ * @param params.amount - Exact amount the contract will pull; zero returns no requirements.
  * @param params.approvalAmount - Classic approval amount; defaults to `amount` and is ignored by signature paths.
  * @param params.owner - Account funding the operation.
  * @param params.chainId - Target chain id; must match the client chain.
@@ -77,9 +78,8 @@ export interface GetBlueBundlesV1TokenRequirementsParams {
  * @throws {NonPositiveInputError} when `deadline` is not positive.
  * @throws {ExpiredDeadlineError} when `deadline` is positive but not in the future.
  * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
- * @throws {UnknownAddressError} when BlueBundlesV1 is not registered for the chain.
- * @throws {MissingPermit2TransferFromNonceError} when Permit2 is selected without a nonce.
- * @throws {Permit2TransferFromNonceAlreadyUsedError} when `permit2Nonce` is already consumed.
+ * @throws {MissingPermit2SignatureTransferNonceError} when Permit2 is selected without a nonce.
+ * @throws {Permit2SignatureTransferNonceAlreadyUsedError} when `permit2Nonce` is already consumed.
  * @throws {InputExceedsMaxError} when `amount`, `deadline`, or `permit2Nonce` exceeds uint256.
  * @throws {ApprovalAmountLessThanSpendAmountError} when `approvalAmount` is below `amount`.
  * @throws {viem.BaseError} when a required allowance, Permit2 nonce-bitmap, or ERC-2612 metadata
@@ -87,13 +87,16 @@ export interface GetBlueBundlesV1TokenRequirementsParams {
  * @example
  * ```ts
  * import { addressesRegistry } from "@morpho-org/blue-sdk";
+ * import { getChainAddress } from "@morpho-org/morpho-ts";
  * import { createPublicClient, http, zeroAddress } from "viem";
  * import { mainnet } from "viem/chains";
- * import { getBlueBundlesV1TokenRequirements } from "@morpho-org/morpho-sdk";
+ * import { getBundlesTokenRequirements } from "@morpho-org/morpho-sdk";
  *
  * const client = createPublicClient({ chain: mainnet, transport: http() });
- * const requirements = await getBlueBundlesV1TokenRequirements(client, {
+ * const vaultBundlesV1 = getChainAddress(mainnet.id, "bundles.vaultBundlesV1");
+ * const requirements = await getBundlesTokenRequirements(client, {
  *   token: addressesRegistry[mainnet.id].usdc,
+ *   spender: vaultBundlesV1,
  *   amount: 1_000_000n,
  *   owner: zeroAddress,
  *   chainId: mainnet.id,
@@ -101,16 +104,16 @@ export interface GetBlueBundlesV1TokenRequirementsParams {
  *   supportSignature: true,
  *   permit2Nonce: 42n,
  * });
- * // requirements contains approvals and/or signable BlueBundlesV1 token requirements.
+ * // requirements contains approvals and/or signable bundles token requirements.
  * ```
  */
-export const getBlueBundlesV1TokenRequirements = async (
+export const getBundlesTokenRequirements = async (
   viemClient: Client,
-  params: GetBlueBundlesV1TokenRequirementsParams,
+  params: GetBundlesTokenRequirementsParams,
 ): Promise<
   readonly (
     | Readonly<Transaction<ERC20ApprovalAction>>
-    | BlueBundlesV1TokenSignatureRequirement
+    | BundlesTokenSignatureRequirement
   )[]
 > => {
   validateChainId(viemClient.chain?.id, params.chainId);
@@ -145,10 +148,6 @@ export const getBlueBundlesV1TokenRequirements = async (
   }
   if (params.amount === 0n) return [];
 
-  const blueBundlesV1 = getChainAddress(
-    params.chainId,
-    "bundles.blueBundlesV1",
-  );
   const { permit2, dai } = getChainAddresses(params.chainId);
 
   if (params.supportSignature) {
@@ -165,7 +164,7 @@ export const getBlueBundlesV1TokenRequirements = async (
         return [
           await encodeErc20Permit(viemClient, {
             token: params.token,
-            spender: blueBundlesV1,
+            spender: params.spender,
             amount: params.amount,
             chainId: params.chainId,
             nonce,
@@ -178,7 +177,7 @@ export const getBlueBundlesV1TokenRequirements = async (
 
     if (permit2 != null) {
       if (params.permit2Nonce == null) {
-        throw new MissingPermit2TransferFromNonceError();
+        throw new MissingPermit2SignatureTransferNonceError();
       }
       if (params.permit2Nonce < 0n) {
         throw new NegativeInputError("permit2Nonce", params.permit2Nonce);
@@ -191,7 +190,6 @@ export const getBlueBundlesV1TokenRequirements = async (
         });
       }
       const wordPosition = params.permit2Nonce >> 8n;
-      const bitPosition = params.permit2Nonce & 255n;
       const [allowance, nonceBitmap] = await Promise.all([
         readContract(viemClient, {
           abi: erc20Abi,
@@ -207,33 +205,21 @@ export const getBlueBundlesV1TokenRequirements = async (
         }),
       ]);
 
-      if ((nonceBitmap & (1n << bitPosition)) !== 0n) {
-        throw new Permit2TransferFromNonceAlreadyUsedError(
-          params.owner,
-          params.permit2Nonce,
-        );
-      }
-
-      return [
-        ...getRequirementsApproval({
-          address: params.token,
-          chainId: params.chainId,
-          args: {
-            spender: permit2,
-            spendAmount: params.amount,
-            approvalAmount: maxUint256,
-          },
-          allowances: allowance,
-        }),
-        encodeErc20Permit2TransferFrom({
-          token: params.token,
-          spender: blueBundlesV1,
-          amount: params.amount,
-          chainId: params.chainId,
-          nonce: params.permit2Nonce,
-          deadline: params.deadline,
-        }),
-      ];
+      return resolveBundlesTokenRequirements({
+        token: params.token,
+        spender: params.spender,
+        owner: params.owner,
+        chainId: params.chainId,
+        amount: params.amount,
+        deadline: params.deadline,
+        state: {
+          type: "permit2SignatureTransfer",
+          permit2,
+          permit2Allowance: allowance,
+          permit2Nonce: params.permit2Nonce,
+          nonceBitmap,
+        },
+      });
     }
   }
 
@@ -245,21 +231,19 @@ export const getBlueBundlesV1TokenRequirements = async (
     abi: erc20Abi,
     address: params.token,
     functionName: "allowance",
-    args: [params.owner, blueBundlesV1],
+    args: [params.owner, params.spender],
   });
-  return getRequirementsApproval({
-    address: params.token,
+  return resolveBundlesTokenRequirements({
+    token: params.token,
+    spender: params.spender,
+    owner: params.owner,
     chainId: params.chainId,
-    args: {
-      spender: blueBundlesV1,
-      // The pull the operation actually performs is `amount`; `approvalAmount`
-      // is only the allowance to set when one is needed. Comparing the existing
-      // allowance against `amount` (not `approvalAmount`) avoids emitting a
-      // redundant approval — and a zero-reset on approve-only-once tokens like
-      // USDT — when the current allowance already covers the pull.
-      spendAmount: params.amount,
+    amount: params.amount,
+    deadline: params.deadline,
+    state: {
+      type: "approval",
+      allowance,
       approvalAmount,
     },
-    allowances: allowance,
   });
 };

--- a/packages/morpho-sdk/src/entities/requirements/index.ts
+++ b/packages/morpho-sdk/src/entities/requirements/index.ts
@@ -1,0 +1,1 @@
+export * from "./getBundlesTokenRequirements.js";

--- a/packages/morpho-sdk/src/helpers/AGENTS.md
+++ b/packages/morpho-sdk/src/helpers/AGENTS.md
@@ -11,6 +11,8 @@ Per-function contracts (arguments, return shapes, behavior) live as JSDoc on eac
 - **Math / share-price helpers** — helpers for vault share-price bounds and public low-level
   composition use `MAX_SLIPPAGE_TOLERANCE` and cap at `MAX_ABSOLUTE_SHARE_PRICE`. The
   high-level Blue write methods do not use these helpers or accept slippage inputs.
+  `computeVaultMaxSharePrice` accrues vault snapshots for fixed-bundle price protection.
+  `grossFromNetAssets` exactly inverts VaultBundlesV1 referral-fee deductions.
 - **Shared-liquidity** — `computeVaultV1Reallocations` builds PublicAllocator V1 reallocations for
   low-level composition. It, its compatibility alias `computeReallocations`, the PublicAllocator V1
   validator, and the other Vault V1 planning and low-level composition helpers are deprecated and

--- a/packages/morpho-sdk/src/helpers/index.ts
+++ b/packages/morpho-sdk/src/helpers/index.ts
@@ -19,12 +19,15 @@ export {
   previewVaultV2InKindRedeem,
   type VaultV2InKindRedeemMarketPreview,
 } from "./previewVaultV2InKindRedeem.js";
+export { grossFromNetAssets } from "./referralFee.js";
 export { signAndVerifyTypedData } from "./signAndVerifyTypedData.js";
 export {
   computeMaxRepaySharePrice,
   computeMaxSupplySharePrice,
   computeMinBorrowSharePrice,
   computeMinWithdrawSharePrice,
+  computeVaultMaxShareAllowance,
+  computeVaultMaxSharePrice,
 } from "./slippage.js";
 export {
   validateAccrualPosition,

--- a/packages/morpho-sdk/src/helpers/referralFee.test.ts
+++ b/packages/morpho-sdk/src/helpers/referralFee.test.ts
@@ -1,0 +1,48 @@
+import { MathLib } from "@morpho-org/blue-sdk";
+import fc from "fast-check";
+import { describe, expect, test } from "vitest";
+import {
+  NegativeInputError,
+  ReferralFeePctExceededError,
+} from "../types/index.js";
+import { grossFromNetAssets } from "./referralFee.js";
+
+describe("grossFromNetAssets", () => {
+  test("default", () => {
+    expect(
+      grossFromNetAssets({
+        netAssets: 90n,
+        referralFeePct: MathLib.WAD / 10n,
+      }),
+    ).toBe(100n);
+  });
+
+  test("behavior: exactly round-trips the contract floor-fee rule", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          netAssets: fc.bigInt({ min: 0n, max: (1n << 128n) - 1n }),
+          referralFeePct: fc.bigInt({ min: 0n, max: MathLib.WAD - 1n }),
+        }),
+        ({ netAssets, referralFeePct }) => {
+          const gross = grossFromNetAssets({ netAssets, referralFeePct });
+          const fee = MathLib.mulDivDown(gross, referralFeePct, MathLib.WAD);
+          expect(gross - fee).toBe(netAssets);
+        },
+      ),
+      { numRuns: 200, seed: 20_260_908 },
+    );
+  });
+
+  test("error: typed boundaries", () => {
+    expect(() =>
+      grossFromNetAssets({ netAssets: -1n, referralFeePct: 0n }),
+    ).toThrow(NegativeInputError);
+    expect(() =>
+      grossFromNetAssets({ netAssets: 1n, referralFeePct: -1n }),
+    ).toThrow(NegativeInputError);
+    expect(() =>
+      grossFromNetAssets({ netAssets: 1n, referralFeePct: MathLib.WAD }),
+    ).toThrow(ReferralFeePctExceededError);
+  });
+});

--- a/packages/morpho-sdk/src/helpers/referralFee.ts
+++ b/packages/morpho-sdk/src/helpers/referralFee.ts
@@ -1,0 +1,40 @@
+import { MathLib } from "@morpho-org/blue-sdk";
+import {
+  NegativeInputError,
+  ReferralFeePctExceededError,
+} from "../types/index.js";
+
+/**
+ * Computes the gross amount whose post-referral-fee proceeds equal `netAssets` exactly.
+ *
+ * @param params - Net target and WAD-scaled referral fee.
+ * @returns The gross asset amount to pass to a bundles entrypoint.
+ * @throws {NegativeInputError} when `netAssets` or `referralFeePct` is negative.
+ * @throws {ReferralFeePctExceededError} when `referralFeePct >= WAD`.
+ * @example
+ * ```ts
+ * import { grossFromNetAssets } from "@morpho-org/morpho-sdk";
+ *
+ * const gross = grossFromNetAssets({ netAssets: 990n, referralFeePct: 10_000000000000000n });
+ * // gross satisfies bigint
+ * ```
+ */
+export const grossFromNetAssets = (params: {
+  readonly netAssets: bigint;
+  readonly referralFeePct: bigint;
+}): bigint => {
+  if (params.netAssets < 0n) {
+    throw new NegativeInputError("netAssets", params.netAssets);
+  }
+  if (params.referralFeePct < 0n) {
+    throw new NegativeInputError("referralFeePct", params.referralFeePct);
+  }
+  if (params.referralFeePct >= MathLib.WAD) {
+    throw new ReferralFeePctExceededError(params.referralFeePct);
+  }
+  return MathLib.mulDivDown(
+    params.netAssets,
+    MathLib.WAD,
+    MathLib.WAD - params.referralFeePct,
+  );
+};

--- a/packages/morpho-sdk/src/helpers/referralFee.ts
+++ b/packages/morpho-sdk/src/helpers/referralFee.ts
@@ -8,6 +8,8 @@ import {
  * Computes the gross amount whose post-referral-fee proceeds equal `netAssets` exactly.
  *
  * @param params - Net target and WAD-scaled referral fee.
+ * @param params.netAssets - Required proceeds after the fee, in the asset's smallest unit.
+ * @param params.referralFeePct - Referral fee fraction scaled by WAD (`1e18`); must be below WAD.
  * @returns The gross asset amount to pass to a bundles entrypoint.
  * @throws {NegativeInputError} when `netAssets` or `referralFeePct` is negative.
  * @throws {ReferralFeePctExceededError} when `referralFeePct >= WAD`.

--- a/packages/morpho-sdk/src/helpers/slippage.test.ts
+++ b/packages/morpho-sdk/src/helpers/slippage.test.ts
@@ -1,4 +1,10 @@
-import { Market, MarketParams, MathLib } from "@morpho-org/blue-sdk";
+import {
+  type AccrualVault,
+  Market,
+  MarketParams,
+  MathLib,
+} from "@morpho-org/blue-sdk";
+import fc from "fast-check";
 import { describe, expect, test } from "vitest";
 import { WethUsdsBlue } from "../../test/fixtures/blue.js";
 import {
@@ -11,6 +17,8 @@ import {
   computeMaxSupplySharePrice,
   computeMinBorrowSharePrice,
   computeMinWithdrawSharePrice,
+  computeVaultMaxShareAllowance,
+  computeVaultMaxSharePrice,
 } from "./slippage.js";
 
 /** 1:1 share-to-asset ratio market for predictable results. */
@@ -346,5 +354,92 @@ describe("computeMinWithdrawSharePrice", () => {
         slippageTolerance: MathLib.WAD + 1n,
       }),
     ).toThrow(ExcessiveSlippageToleranceError);
+  });
+});
+
+describe("computeVaultMaxSharePrice", () => {
+  test("behavior: accrues through the supplied bundles deadline", () => {
+    const deadline = 1_800_010_800n;
+    let accruedAt: bigint | undefined;
+    const vaultData = {
+      accrueInterest: (timestamp: bigint) => {
+        accruedAt = timestamp;
+        return { toShares: (assets: bigint) => assets };
+      },
+    } as unknown as AccrualVault;
+
+    computeVaultMaxSharePrice({
+      vaultData,
+      deadline,
+      assets: 1n,
+      slippageTolerance: 0n,
+    });
+
+    expect(accruedAt).toBe(deadline);
+  });
+
+  test("behavior: is monotonic in slippage tolerance", () => {
+    const vaultData = {
+      accrueInterest: () => ({ toShares: (assets: bigint) => assets }),
+    } as unknown as AccrualVault;
+    fc.assert(
+      fc.property(
+        fc.record({
+          assets: fc.bigInt({ min: 1n, max: (1n << 128n) - 1n }),
+          low: fc.bigInt({ min: 0n, max: MathLib.WAD / 20n }),
+          delta: fc.bigInt({ min: 0n, max: MathLib.WAD / 20n }),
+        }),
+        ({ assets, low, delta }) => {
+          const high = low + delta;
+          expect(
+            computeVaultMaxSharePrice({
+              vaultData,
+              deadline: 1_800_007_200n,
+              assets,
+              slippageTolerance: high,
+            }),
+          ).toBeGreaterThanOrEqual(
+            computeVaultMaxSharePrice({
+              vaultData,
+              deadline: 1_800_007_200n,
+              assets,
+              slippageTolerance: low,
+            }),
+          );
+        },
+      ),
+      { numRuns: 100, seed: 20_260_912 },
+    );
+  });
+});
+
+describe("computeVaultMaxShareAllowance", () => {
+  const vaultData = (lostAssets?: bigint) =>
+    ({
+      lostAssets,
+      toShares: () => 10n,
+      accrueInterest: () => ({ toShares: () => 12n }),
+    }) as unknown as AccrualVault;
+
+  test("behavior: widens MetaMorpho 1.0 against loss realization", () => {
+    expect(
+      computeVaultMaxShareAllowance({
+        vaultData: vaultData(),
+        deadline: 1_900_000_000n,
+        assets: 10n,
+        slippageTolerance: MathLib.WAD / 10n,
+      }),
+    ).toBe(14n);
+  });
+
+  test("behavior: keeps the MetaMorpho 1.1 lost-assets-clamped cap exact", () => {
+    expect(
+      computeVaultMaxShareAllowance({
+        vaultData: vaultData(0n),
+        deadline: 1_900_000_000n,
+        assets: 10n,
+        slippageTolerance: MathLib.WAD / 10n,
+      }),
+    ).toBe(12n);
   });
 });

--- a/packages/morpho-sdk/src/helpers/slippage.test.ts
+++ b/packages/morpho-sdk/src/helpers/slippage.test.ts
@@ -1,5 +1,6 @@
 import {
   type AccrualVault,
+  AccrualVaultV2,
   Market,
   MarketParams,
   MathLib,
@@ -378,6 +379,35 @@ describe("computeVaultMaxSharePrice", () => {
     expect(accruedAt).toBe(deadline);
   });
 
+  test("behavior: previews shares rounding down, matching the on-chain ERC-4626 deposit()", () => {
+    const roundings: ("Up" | "Down")[] = [];
+    const vaultData = {
+      accrueInterest: () => ({
+        toShares: (_assets: bigint, rounding: "Up" | "Down") => {
+          roundings.push(rounding);
+          // Vault V1's own default (`"Up"`) would preview 3n here; the on-chain
+          // `vault.deposit(...)` share count is rounded down, i.e. 2n.
+          return rounding === "Down" ? 2n : 3n;
+        },
+      }),
+    } as unknown as AccrualVault;
+
+    const maxSharePrice = computeVaultMaxSharePrice({
+      vaultData,
+      deadline: 1_900_000_000n,
+      assets: 7n,
+      slippageTolerance: 0n,
+    });
+
+    expect(roundings).toEqual(["Down"]);
+    // Rounding down previews fewer shares, which loosens (raises) the bound relative to the
+    // `"Up"` default; the reverse would falsely tighten the bound and revert small V1 deposits
+    // at zero slippage tolerance.
+    expect(maxSharePrice).toBe(
+      MathLib.mulDivUp(7n, MathLib.wToRay(MathLib.WAD), 2n),
+    );
+  });
+
   test("behavior: is monotonic in slippage tolerance", () => {
     const vaultData = {
       accrueInterest: () => ({ toShares: (assets: bigint) => assets }),
@@ -441,5 +471,57 @@ describe("computeVaultMaxShareAllowance", () => {
         slippageTolerance: MathLib.WAD / 10n,
       }),
     ).toBe(12n);
+  });
+
+  test.each(["MetaMorpho 1.0", "Vault V2"] as const)(
+    "behavior: covers the full permitted price decline for %s",
+    (version) => {
+      const preview = { toShares: () => 100n };
+      const snapshot =
+        version === "Vault V2"
+          ? (Object.assign(Object.create(AccrualVaultV2.prototype), {
+              ...preview,
+              lastUpdate: 1_800_000_000n,
+              accrueInterest: () => ({ vault: preview }),
+            }) as AccrualVaultV2)
+          : ({
+              ...preview,
+              accrueInterest: () => preview,
+            } as unknown as AccrualVault);
+
+      expect(
+        computeVaultMaxShareAllowance({
+          vaultData: snapshot,
+          deadline: 1_900_000_000n,
+          assets: 100n,
+          slippageTolerance: MathLib.WAD / 10n,
+        }),
+      ).toBe(112n);
+    },
+  );
+
+  test("behavior: authorizes the minimum whole-share cap covering the price floor", () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: 1n, max: (1n << 128n) - 1n }),
+        fc.bigInt({ min: 0n, max: MathLib.WAD / 10n }),
+        (shares, slippageTolerance) => {
+          const preview = { toShares: () => shares };
+          const cap = computeVaultMaxShareAllowance({
+            vaultData: {
+              ...preview,
+              accrueInterest: () => preview,
+            } as unknown as AccrualVault,
+            deadline: 1_900_000_000n,
+            assets: shares,
+            slippageTolerance,
+          });
+          const priceFloor = MathLib.WAD - slippageTolerance;
+          expect(cap * priceFloor).toBeGreaterThanOrEqual(shares * MathLib.WAD);
+          expect((cap - 1n) * priceFloor).toBeLessThan(shares * MathLib.WAD);
+        },
+      ),
+      { numRuns: 100, seed: 20_260_907 },
+    );
   });
 });

--- a/packages/morpho-sdk/src/helpers/slippage.test.ts
+++ b/packages/morpho-sdk/src/helpers/slippage.test.ts
@@ -363,6 +363,7 @@ describe("computeVaultMaxSharePrice", () => {
     const deadline = 1_800_010_800n;
     let accruedAt: bigint | undefined;
     const vaultData = {
+      toShares: (assets: bigint) => assets,
       accrueInterest: (timestamp: bigint) => {
         accruedAt = timestamp;
         return { toShares: (assets: bigint) => assets };
@@ -381,15 +382,15 @@ describe("computeVaultMaxSharePrice", () => {
 
   test("behavior: previews shares rounding down, matching the on-chain ERC-4626 deposit()", () => {
     const roundings: ("Up" | "Down")[] = [];
+    const toShares = (_assets: bigint, rounding: "Up" | "Down") => {
+      roundings.push(rounding);
+      // Vault V1's own default (`"Up"`) would preview 3n here; the on-chain
+      // `vault.deposit(...)` share count is rounded down, i.e. 2n.
+      return rounding === "Down" ? 2n : 3n;
+    };
     const vaultData = {
-      accrueInterest: () => ({
-        toShares: (_assets: bigint, rounding: "Up" | "Down") => {
-          roundings.push(rounding);
-          // Vault V1's own default (`"Up"`) would preview 3n here; the on-chain
-          // `vault.deposit(...)` share count is rounded down, i.e. 2n.
-          return rounding === "Down" ? 2n : 3n;
-        },
-      }),
+      toShares,
+      accrueInterest: () => ({ toShares }),
     } as unknown as AccrualVault;
 
     const maxSharePrice = computeVaultMaxSharePrice({
@@ -399,7 +400,7 @@ describe("computeVaultMaxSharePrice", () => {
       slippageTolerance: 0n,
     });
 
-    expect(roundings).toEqual(["Down"]);
+    expect(roundings).toEqual(["Down", "Down"]);
     // Rounding down previews fewer shares, which loosens (raises) the bound relative to the
     // `"Up"` default; the reverse would falsely tighten the bound and revert small V1 deposits
     // at zero slippage tolerance.
@@ -410,6 +411,7 @@ describe("computeVaultMaxSharePrice", () => {
 
   test("behavior: is monotonic in slippage tolerance", () => {
     const vaultData = {
+      toShares: (assets: bigint) => assets,
       accrueInterest: () => ({ toShares: (assets: bigint) => assets }),
     } as unknown as AccrualVault;
     fc.assert(
@@ -440,6 +442,45 @@ describe("computeVaultMaxSharePrice", () => {
       ),
       { numRuns: 100, seed: 20_260_912 },
     );
+  });
+
+  test("behavior: bounds a declining Vault V2 price at the pre-accrual snapshot", () => {
+    // An idle Vault V2 still charges its management fee, minting shares against an unchanged
+    // `_totalAssets`: the deadline preview yields *more* shares, i.e. a *lower* price, than the
+    // current one. Bounding on the deadline snapshot alone would false-revert `SlippageExceeded`
+    // for a deposit included before the deadline.
+    const vaultData = Object.assign(Object.create(AccrualVaultV2.prototype), {
+      lastUpdate: 1_800_000_000n,
+      toShares: () => 100n,
+      accrueInterest: () => ({ vault: { toShares: () => 110n } }),
+    }) as AccrualVaultV2;
+
+    expect(
+      computeVaultMaxSharePrice({
+        vaultData,
+        deadline: 1_900_000_000n,
+        assets: 100n,
+        slippageTolerance: 0n,
+      }),
+    ).toBe(MathLib.mulDivUp(100n, MathLib.wToRay(MathLib.WAD), 100n));
+  });
+
+  test("behavior: keeps a rising price bounded on the deadline-accrued preview", () => {
+    // The common case: interest raises the price, so the deadline preview yields fewer shares
+    // and remains the binding endpoint.
+    const vaultData = {
+      toShares: () => 110n,
+      accrueInterest: () => ({ toShares: () => 100n }),
+    } as unknown as AccrualVault;
+
+    expect(
+      computeVaultMaxSharePrice({
+        vaultData,
+        deadline: 1_900_000_000n,
+        assets: 100n,
+        slippageTolerance: 0n,
+      }),
+    ).toBe(MathLib.mulDivUp(100n, MathLib.wToRay(MathLib.WAD), 100n));
   });
 });
 

--- a/packages/morpho-sdk/src/helpers/slippage.ts
+++ b/packages/morpho-sdk/src/helpers/slippage.ts
@@ -1,9 +1,16 @@
-import { type Market, MathLib } from "@morpho-org/blue-sdk";
+import {
+  type AccrualVault,
+  AccrualVaultV2,
+  type Market,
+  MathLib,
+} from "@morpho-org/blue-sdk";
 import {
   ExcessiveSlippageToleranceError,
+  NonPositiveInputError,
   ShareDivideByZeroError,
 } from "../types/index.js";
 import { MAX_ABSOLUTE_SHARE_PRICE } from "./constant.js";
+import { validateSlippageTolerance } from "./validate.js";
 
 /**
  * Computes the minimum borrow share price (in RAY, 1e27) for slippage protection.
@@ -206,3 +213,125 @@ export function computeMinWithdrawSharePrice(params: {
     shares,
   );
 }
+
+/**
+ * Computes the RAY-scaled maximum share price for a VaultBundlesV1 deposit leg.
+ *
+ * Accrues the supplied Vault V1 or Vault V2 snapshot through the bundles execution deadline before
+ * previewing shares.
+ *
+ * @param params - Vault snapshot, bundles execution deadline, net assets, and slippage.
+ * @returns The capped maximum share price enforced by VaultBundlesV1.
+ * @throws {NonPositiveInputError} when `assets` or the previewed shares are not positive.
+ * @throws {NegativeInputError} when `slippageTolerance` is negative.
+ * @throws {ExcessiveSlippageToleranceError} when `slippageTolerance` exceeds the SDK maximum.
+ * @example
+ * ```ts
+ * import { fetchAccrualVault } from "@morpho-org/blue-sdk-viem";
+ * import { computeVaultMaxSharePrice } from "@morpho-org/morpho-sdk";
+ * import { createPublicClient, http } from "viem";
+ * import { mainnet } from "viem/chains";
+ *
+ * const client = createPublicClient({ chain: mainnet, transport: http() });
+ * const vaultData = await fetchAccrualVault(
+ *   "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+ *   client,
+ * );
+ * const { timestamp } = await client.getBlock();
+ * const maxSharePrice = computeVaultMaxSharePrice({
+ *   vaultData,
+ *   deadline: timestamp + 7_200n,
+ *   assets: 1_000_000n,
+ *   slippageTolerance: 500_000_000_000_000n,
+ * });
+ * // maxSharePrice satisfies bigint
+ * ```
+ */
+export const computeVaultMaxSharePrice = (params: {
+  readonly vaultData: AccrualVault | AccrualVaultV2;
+  readonly deadline: bigint;
+  readonly assets: bigint;
+  readonly slippageTolerance: bigint;
+}): bigint => {
+  if (params.assets <= 0n) {
+    throw new NonPositiveInputError("assets", params.assets);
+  }
+  validateSlippageTolerance(params.slippageTolerance);
+  const accrualTimestamp =
+    params.vaultData instanceof AccrualVaultV2
+      ? MathLib.max(params.deadline, params.vaultData.lastUpdate)
+      : params.deadline;
+  const accruedVault =
+    params.vaultData instanceof AccrualVaultV2
+      ? params.vaultData.accrueInterest(accrualTimestamp).vault
+      : params.vaultData.accrueInterest(accrualTimestamp);
+  const shares = accruedVault.toShares(params.assets);
+  if (shares <= 0n) {
+    throw new NonPositiveInputError("shares", shares);
+  }
+  return MathLib.min(
+    MathLib.mulDivUp(
+      params.assets,
+      MathLib.wToRay(MathLib.WAD + params.slippageTolerance),
+      shares,
+    ),
+    MAX_ABSOLUTE_SHARE_PRICE,
+  );
+};
+
+/**
+ * Computes the exact vault-share authorization cap for an asset-denominated exit.
+ *
+ * The cap covers both the current and deadline-accrued preview. Vault V2 and MetaMorpho 1.0 add
+ * the caller's loss/slippage buffer because their share price can fall before inclusion;
+ * MetaMorpho 1.1's `lostAssets` clamp keeps that preview upper-bounded without widening it.
+ *
+ * @param params - Vault snapshot, execution deadline, asset amount, and WAD-scaled slippage.
+ * @returns The maximum shares the prepared operation may burn.
+ * @throws {NonPositiveInputError} when `assets` or the computed share cap is not positive.
+ * @throws {NegativeInputError} when `slippageTolerance` is negative.
+ * @throws {ExcessiveSlippageToleranceError} when `slippageTolerance` exceeds the SDK maximum.
+ * @example
+ * ```ts
+ * import { computeVaultMaxShareAllowance } from "@morpho-org/morpho-sdk";
+ *
+ * const shares = computeVaultMaxShareAllowance({
+ *   vaultData,
+ *   deadline: 1_900_000_000n,
+ *   assets: 1_000_000n,
+ *   slippageTolerance: 500_000_000_000_000n,
+ * });
+ * // shares is the exact allowance or permit value for the prepared exit.
+ * ```
+ */
+export const computeVaultMaxShareAllowance = (params: {
+  readonly vaultData: AccrualVault | AccrualVaultV2;
+  readonly deadline: bigint;
+  readonly assets: bigint;
+  readonly slippageTolerance: bigint;
+}): bigint => {
+  if (params.assets <= 0n) {
+    throw new NonPositiveInputError("assets", params.assets);
+  }
+  validateSlippageTolerance(params.slippageTolerance);
+  const isVaultV2 = params.vaultData instanceof AccrualVaultV2;
+  const accruedVault = isVaultV2
+    ? params.vaultData.accrueInterest(
+        MathLib.max(params.deadline, params.vaultData.lastUpdate),
+      ).vault
+    : params.vaultData.accrueInterest(params.deadline);
+  const previewedShares = MathLib.max(
+    params.vaultData.toShares(params.assets, "Up"),
+    accruedVault.toShares(params.assets, "Up"),
+  );
+  if (previewedShares <= 0n) {
+    throw new NonPositiveInputError("shares", previewedShares);
+  }
+  const needsLossBuffer =
+    isVaultV2 ||
+    !("lostAssets" in params.vaultData) ||
+    params.vaultData.lostAssets == null;
+  return needsLossBuffer
+    ? MathLib.wMulUp(previewedShares, MathLib.WAD + params.slippageTolerance)
+    : previewedShares;
+};

--- a/packages/morpho-sdk/src/helpers/slippage.ts
+++ b/packages/morpho-sdk/src/helpers/slippage.ts
@@ -223,6 +223,10 @@ export function computeMinWithdrawSharePrice(params: {
  * shares the on-chain `maxSharePrice` check divides by.
  *
  * @param params - Vault snapshot, bundles execution deadline, net assets, and slippage.
+ * @param params.vaultData - Hydrated Vault V1 `AccrualVault` or Vault V2 `AccrualVaultV2` snapshot.
+ * @param params.deadline - Bundle execution deadline as a Unix timestamp in seconds, used for accrual.
+ * @param params.assets - Net assets deposited after referral fees, in the underlying token's smallest unit.
+ * @param params.slippageTolerance - Accepted share-price increase as a WAD-scaled fraction (`1e18` = 100%).
  * @returns The capped maximum share price enforced by VaultBundlesV1.
  * @throws {NonPositiveInputError} when `assets` or the previewed shares are not positive.
  * @throws {NegativeInputError} when `slippageTolerance` is negative.
@@ -297,17 +301,30 @@ export const computeVaultMaxSharePrice = (params: {
  * MetaMorpho 1.1's `lostAssets` clamp keeps that preview upper-bounded without widening it.
  *
  * @param params - Vault snapshot, execution deadline, asset amount, and WAD-scaled slippage.
+ * @param params.vaultData - Hydrated Vault V1 `AccrualVault` or Vault V2 `AccrualVaultV2` snapshot.
+ * @param params.deadline - Bundle execution deadline as a Unix timestamp in seconds, used for accrual.
+ * @param params.assets - Assets withdrawn from the vault, in the underlying token's smallest unit.
+ * @param params.slippageTolerance - Accepted share-price decline as a WAD-scaled fraction (`1e18` = 100%).
  * @returns The maximum shares the prepared operation may burn.
  * @throws {NonPositiveInputError} when `assets` or the computed share cap is not positive.
  * @throws {NegativeInputError} when `slippageTolerance` is negative.
  * @throws {ExcessiveSlippageToleranceError} when `slippageTolerance` exceeds the SDK maximum.
  * @example
  * ```ts
+ * import { fetchAccrualVault } from "@morpho-org/blue-sdk-viem";
  * import { computeVaultMaxShareAllowance } from "@morpho-org/morpho-sdk";
+ * import { createPublicClient, http } from "viem";
+ * import { mainnet } from "viem/chains";
  *
+ * const client = createPublicClient({ chain: mainnet, transport: http() });
+ * const vaultData = await fetchAccrualVault(
+ *   "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+ *   client,
+ * );
+ * const { timestamp } = await client.getBlock();
  * const shares = computeVaultMaxShareAllowance({
  *   vaultData,
- *   deadline: 1_900_000_000n,
+ *   deadline: timestamp + 7_200n,
  *   assets: 1_000_000n,
  *   slippageTolerance: 500_000_000_000_000n,
  * });

--- a/packages/morpho-sdk/src/helpers/slippage.ts
+++ b/packages/morpho-sdk/src/helpers/slippage.ts
@@ -218,7 +218,8 @@ export function computeMinWithdrawSharePrice(params: {
  * Computes the RAY-scaled maximum share price for a VaultBundlesV1 deposit leg.
  *
  * Accrues the supplied Vault V1 or Vault V2 snapshot through the bundles execution deadline before
- * previewing shares.
+ * previewing shares. Shares are previewed rounding down, mirroring the ERC-4626 `deposit()` shares
+ * the on-chain `maxSharePrice` check divides by.
  *
  * @param params - Vault snapshot, bundles execution deadline, net assets, and slippage.
  * @returns The capped maximum share price enforced by VaultBundlesV1.
@@ -265,7 +266,7 @@ export const computeVaultMaxSharePrice = (params: {
     params.vaultData instanceof AccrualVaultV2
       ? params.vaultData.accrueInterest(accrualTimestamp).vault
       : params.vaultData.accrueInterest(accrualTimestamp);
-  const shares = accruedVault.toShares(params.assets);
+  const shares = accruedVault.toShares(params.assets, "Down");
   if (shares <= 0n) {
     throw new NonPositiveInputError("shares", shares);
   }
@@ -282,8 +283,8 @@ export const computeVaultMaxSharePrice = (params: {
 /**
  * Computes the exact vault-share authorization cap for an asset-denominated exit.
  *
- * The cap covers both the current and deadline-accrued preview. Vault V2 and MetaMorpho 1.0 add
- * the caller's loss/slippage buffer because their share price can fall before inclusion;
+ * The cap covers both the current and deadline-accrued preview. Vault V2 and MetaMorpho 1.0 divide
+ * by `1 - slippageTolerance`, rounding up, to cover a share-price decline before inclusion;
  * MetaMorpho 1.1's `lostAssets` clamp keeps that preview upper-bounded without widening it.
  *
  * @param params - Vault snapshot, execution deadline, asset amount, and WAD-scaled slippage.
@@ -332,6 +333,6 @@ export const computeVaultMaxShareAllowance = (params: {
     !("lostAssets" in params.vaultData) ||
     params.vaultData.lostAssets == null;
   return needsLossBuffer
-    ? MathLib.wMulUp(previewedShares, MathLib.WAD + params.slippageTolerance)
+    ? MathLib.wDivUp(previewedShares, MathLib.WAD - params.slippageTolerance)
     : previewedShares;
 };

--- a/packages/morpho-sdk/src/helpers/slippage.ts
+++ b/packages/morpho-sdk/src/helpers/slippage.ts
@@ -217,9 +217,10 @@ export function computeMinWithdrawSharePrice(params: {
 /**
  * Computes the RAY-scaled maximum share price for a VaultBundlesV1 deposit leg.
  *
- * Accrues the supplied Vault V1 or Vault V2 snapshot through the bundles execution deadline before
- * previewing shares. Shares are previewed rounding down, mirroring the ERC-4626 `deposit()` shares
- * the on-chain `maxSharePrice` check divides by.
+ * Previews shares on both the supplied Vault V1 or Vault V2 snapshot and its deadline-accrued
+ * counterpart, dividing by the smaller of the two so the bound covers the highest price the
+ * bundle may execute at. Shares are previewed rounding down, mirroring the ERC-4626 `deposit()`
+ * shares the on-chain `maxSharePrice` check divides by.
  *
  * @param params - Vault snapshot, bundles execution deadline, net assets, and slippage.
  * @returns The capped maximum share price enforced by VaultBundlesV1.
@@ -266,7 +267,15 @@ export const computeVaultMaxSharePrice = (params: {
     params.vaultData instanceof AccrualVaultV2
       ? params.vaultData.accrueInterest(accrualTimestamp).vault
       : params.vaultData.accrueInterest(accrualTimestamp);
-  const shares = accruedVault.toShares(params.assets, "Down");
+  // The deadline snapshot is not necessarily the highest price over `[now, deadline]`: Vault V2
+  // charges its management fee regardless of yield, minting shares against an unchanged
+  // `_totalAssets`, so an idle vault's price *declines*. Bound at the maximum price across both
+  // endpoints — the minimum previewed shares — mirroring the `max(current, accrued)` shares the
+  // sibling `computeVaultMaxShareAllowance` authorizes.
+  const shares = MathLib.min(
+    params.vaultData.toShares(params.assets, "Down"),
+    accruedVault.toShares(params.assets, "Down"),
+  );
   if (shares <= 0n) {
     throw new NonPositiveInputError("shares", shares);
   }

--- a/packages/morpho-sdk/src/helpers/validate.ts
+++ b/packages/morpho-sdk/src/helpers/validate.ts
@@ -32,6 +32,7 @@ import {
   MissingClientPropertyError,
   MissingMarketPriceError,
   NativeAmountOnNonWNativeAssetError,
+  NativeAmountOnNonWNativeVaultError,
   NegativeInputError,
   NonPositiveInputError,
   ReallocationWithdrawalOnTargetMarketError,
@@ -246,6 +247,20 @@ export const validateNativeAsset = (chainId: number, asset: Address): void => {
   }
   if (!isAddressEqual(asset, wNative)) {
     throw new NativeAmountOnNonWNativeAssetError(asset, wNative);
+  }
+};
+
+/** @internal Validates native funding against a vault's wrapped-native asset. */
+export const validateNativeVaultAsset = (
+  chainId: number,
+  vaultAsset: Address,
+): void => {
+  const { wNative } = getChainAddresses(chainId);
+  if (!isDefined(wNative)) {
+    throw new ChainWNativeMissingError(chainId);
+  }
+  if (!isAddressEqual(vaultAsset, wNative)) {
+    throw new NativeAmountOnNonWNativeVaultError(vaultAsset, wNative);
   }
 };
 

--- a/packages/morpho-sdk/src/helpers/validateRequirementSpender.ts
+++ b/packages/morpho-sdk/src/helpers/validateRequirementSpender.ts
@@ -9,6 +9,7 @@ export type RequirementSpenderKey =
   | "midnight"
   | "midnightBundles"
   | "vaultExitBundlesV1"
+  | "vaultBundlesV1"
   | "blueBundlesV1";
 
 /**
@@ -51,6 +52,7 @@ export const validateRequirementSpender = (params: {
     midnight,
     midnightBundles,
     vaultExitBundlesV1: bundles?.vaultExitBundlesV1,
+    vaultBundlesV1: bundles?.vaultBundlesV1,
     blueBundlesV1: bundles?.blueBundlesV1,
   } satisfies Record<RequirementSpenderKey, Address | undefined>;
   const supportedSpenders = params.allowed.map((key) => addresses[key]);

--- a/packages/morpho-sdk/src/index.ts
+++ b/packages/morpho-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./actions/index.js";
 export * from "./client/index.js";
+export * from "./entities/requirements/index.js";
 export * from "./helpers/index.js";
 export * from "./types/index.js";

--- a/packages/morpho-sdk/src/types/AGENTS.md
+++ b/packages/morpho-sdk/src/types/AGENTS.md
@@ -13,6 +13,7 @@ Centralized type definitions and error classes. Barrel-exported via `index.ts`. 
 - `DepositAmountArgs` — union enforcing at least one of `amount` / `nativeAmount`. Used by vault
   deposits and public low-level composition. Direct BlueBundlesV1 native funding is exclusive with
   ERC-20 funding rather than additive.
+- `BundlesFundingArgs` — exclusive `{ amount } | { nativeAmount }` funding used by fixed BlueBundlesV1 and VaultBundlesV1 calls.
 - `AssetsOrSharesArgs` — discriminated union `{ assets } | { shares }`. Used by withdraw (supply-side).
 - Repay funding is expressed with the operation-specific `repayAssets` / `repayShares` inputs, mutually exclusive (`repayShares = maxUint256` requests a saturated full repay); the entity surface pairs them with a `maxRepayAssets` funding cap and optional `nativeAmount`, deriving every amount from live market state, and the flat action arg shapes (`BlueRepayWithdrawCollateralActionArgs`) carry the pre-resolved `{ repayAssets, repayShares, maxRepayAssets, collateralAssets, maxLtv }` so the action does no arithmetic. The former `RepayAmountArgs` / `RepayActionAmountArgs` shapes were removed with the BlueBundlesV1 migration.
 - `MarketParams` — Morpho Blue market params (`loanToken`, `collateralToken`, `oracle`, `irm`, `lltv`).

--- a/packages/morpho-sdk/src/types/action.test.ts
+++ b/packages/morpho-sdk/src/types/action.test.ts
@@ -5,10 +5,10 @@ import {
   type AuthorizationRequirementSignature,
   isAuthorizationSignature,
   isMidnightOfferRootSignature,
-  isPermit2TransferFromSignature,
+  isPermit2SignatureTransferSignature,
   isPermitSignature,
   type MidnightOfferRootSignature,
-  type Permit2TransferFromRequirementSignature,
+  type Permit2SignatureTransferRequirementSignature,
   type PermitRequirementSignature,
   selectRequirementSignatures,
 } from "./action.js";
@@ -59,20 +59,26 @@ const permit2Signature: PermitRequirementSignature = {
   },
 };
 
-const permit2TransferFromSignature: Permit2TransferFromRequirementSignature = {
-  action: {
-    type: "permit2TransferFrom",
-    args: { spender: SPENDER, amount: 1n, deadline: 1_900_000_000n },
-  },
-  args: {
-    owner: OWNER,
-    asset: TOKEN,
-    amount: 1n,
-    nonce: 0n,
-    deadline: 1_900_000_000n,
-    signature: SIGNATURE,
-  },
-};
+const permit2SignatureTransferSignature: Permit2SignatureTransferRequirementSignature =
+  {
+    action: {
+      type: "permit2SignatureTransfer",
+      args: {
+        spender: SPENDER,
+        amount: 1n,
+        nonce: 0n,
+        deadline: 1_900_000_000n,
+      },
+    },
+    args: {
+      owner: OWNER,
+      asset: TOKEN,
+      amount: 1n,
+      nonce: 0n,
+      deadline: 1_900_000_000n,
+      signature: SIGNATURE,
+    },
+  };
 
 const authorizationSignature: AuthorizationRequirementSignature = {
   action: {
@@ -130,15 +136,15 @@ describe("isAuthorizationSignature", () => {
   });
 });
 
-describe("isPermit2TransferFromSignature", () => {
+describe("isPermit2SignatureTransferSignature", () => {
   test("default: true for Permit2 SignatureTransfer", () => {
-    expect(isPermit2TransferFromSignature(permit2TransferFromSignature)).toBe(
-      true,
-    );
+    expect(
+      isPermit2SignatureTransferSignature(permit2SignatureTransferSignature),
+    ).toBe(true);
   });
 
   test("behavior: false for Permit2 AllowanceTransfer", () => {
-    expect(isPermit2TransferFromSignature(permit2Signature)).toBe(false);
+    expect(isPermit2SignatureTransferSignature(permit2Signature)).toBe(false);
   });
 });
 
@@ -179,7 +185,7 @@ describe("selectRequirementSignatures", () => {
       }),
     ).toEqual({
       permit: permitSignature,
-      permit2TransferFrom: undefined,
+      permit2SignatureTransfer: undefined,
       authorization: authorizationSignature,
       midnightOfferRoot: undefined,
     });
@@ -196,7 +202,7 @@ describe("selectRequirementSignatures", () => {
       selectRequirementSignatures([], { permit: true, authorization: true }),
     ).toEqual({
       permit: undefined,
-      permit2TransferFrom: undefined,
+      permit2SignatureTransfer: undefined,
       authorization: undefined,
       midnightOfferRoot: undefined,
     });
@@ -209,7 +215,7 @@ describe("selectRequirementSignatures", () => {
       }),
     ).toEqual({
       permit: undefined,
-      permit2TransferFrom: undefined,
+      permit2SignatureTransfer: undefined,
       authorization: undefined,
       midnightOfferRoot: midnightOfferRootSignature,
     });
@@ -217,12 +223,12 @@ describe("selectRequirementSignatures", () => {
 
   test("behavior: extracts a Permit2 SignatureTransfer", () => {
     expect(
-      selectRequirementSignatures([permit2TransferFromSignature], {
-        permit2TransferFrom: true,
+      selectRequirementSignatures([permit2SignatureTransferSignature], {
+        permit2SignatureTransfer: true,
       }),
     ).toEqual({
       permit: undefined,
-      permit2TransferFrom: permit2TransferFromSignature,
+      permit2SignatureTransfer: permit2SignatureTransferSignature,
       authorization: undefined,
       midnightOfferRoot: undefined,
     });
@@ -230,7 +236,7 @@ describe("selectRequirementSignatures", () => {
 
   test("error: UnexpectedRequirementSignatureError on an unconsumed Permit2 SignatureTransfer", () => {
     expect(() =>
-      selectRequirementSignatures([permit2TransferFromSignature], {
+      selectRequirementSignatures([permit2SignatureTransferSignature], {
         authorization: true,
       }),
     ).toThrow(UnexpectedRequirementSignatureError);

--- a/packages/morpho-sdk/src/types/action.ts
+++ b/packages/morpho-sdk/src/types/action.ts
@@ -470,23 +470,41 @@ export type DepositAmountArgs =
   | { amount: bigint; nativeAmount?: bigint }
   | { nativeAmount: bigint; amount?: bigint };
 
+/** Mutually exclusive ERC-20 or native funding accepted by fixed bundles entrypoints. */
+export type BundlesFundingArgs =
+  | { readonly amount: bigint; readonly nativeAmount?: never }
+  | { readonly nativeAmount: bigint; readonly amount?: never };
+
+/** Controls token requirements generated for a bundles-funded action. */
+export interface BundlesTokenRequirementsOptions {
+  /** Prefer ERC-2612 when the funded token exposes a compatible nonce. */
+  readonly useSimplePermit?: boolean;
+  /** Explicit unused Permit2 SignatureTransfer unordered nonce. */
+  readonly permit2Nonce?: bigint;
+}
+
+/** Mutually exclusive source amount accepted by a Vault V1 to Vault V2 migration. */
+export type VaultV1MigrateToV2AmountArgs =
+  | { readonly shares: bigint; readonly assets?: never }
+  | { readonly assets: bigint; readonly shares?: never };
+
 export interface PermitArgs {
-  owner: Address;
-  nonce: bigint;
-  asset: Address;
-  signature: Hex;
-  amount: bigint;
-  deadline: bigint;
+  readonly owner: Address;
+  readonly nonce: bigint;
+  readonly asset: Address;
+  readonly signature: Hex;
+  readonly amount: bigint;
+  readonly deadline: bigint;
 }
 
 export interface Permit2Args {
-  owner: Address;
-  nonce: bigint;
-  asset: Address;
-  signature: Hex;
-  amount: bigint;
-  deadline: bigint;
-  expiration: bigint;
+  readonly owner: Address;
+  readonly nonce: bigint;
+  readonly asset: Address;
+  readonly signature: Hex;
+  readonly amount: bigint;
+  readonly deadline: bigint;
+  readonly expiration: bigint;
 }
 
 /**
@@ -520,7 +538,13 @@ export interface MidnightOfferRootSignatureArgs {
 export interface PermitAction
   extends BaseAction<
     "permit",
-    { spender: Address; amount: bigint; deadline: bigint }
+    {
+      readonly spender: Address;
+      readonly amount: bigint;
+      readonly deadline: bigint;
+      /** Permit nonce captured by a prepared requirement, when available. */
+      readonly nonce?: bigint;
+    }
   > {}
 
 export interface Permit2Action
@@ -529,13 +553,14 @@ export interface Permit2Action
     { spender: Address; amount: bigint; deadline: bigint; expiration: bigint }
   > {}
 
-/** Signable Permit2 SignatureTransfer requirement for a direct BlueBundlesV1 pull. */
-export interface Permit2TransferFromAction
+/** Signable Permit2 SignatureTransfer requirement for a fixed bundles token pull. */
+export interface Permit2SignatureTransferAction
   extends BaseAction<
-    "permit2TransferFrom",
+    "permit2SignatureTransfer",
     {
       readonly spender: Address;
       readonly amount: bigint;
+      readonly nonce: bigint;
       readonly deadline: bigint;
     }
   > {}
@@ -565,7 +590,7 @@ export interface MidnightOfferRootSignatureAction
 export type SignatureRequirementAction =
   | PermitAction
   | Permit2Action
-  | Permit2TransferFromAction
+  | Permit2SignatureTransferAction
   | AuthorizationAction
   | MidnightOfferRootSignatureAction;
 
@@ -593,10 +618,10 @@ export type PermitRequirementSignature =
   | Erc2612RequirementSignature
   | Permit2AllowanceRequirementSignature;
 
-/** A signed Permit2 SignatureTransfer requirement used by BlueBundlesV1. */
-export interface Permit2TransferFromRequirementSignature {
+/** A signed Permit2 SignatureTransfer requirement used by fixed bundles contracts. */
+export interface Permit2SignatureTransferRequirementSignature {
   readonly args: Readonly<PermitArgs>;
-  readonly action: Permit2TransferFromAction;
+  readonly action: Permit2SignatureTransferAction;
 }
 
 /** A signed Morpho authorization consumed by Bundler3 or a direct BlueBundlesV1 call. */
@@ -613,8 +638,8 @@ export interface MidnightOfferRootSignature {
 
 /**
  * The deep-frozen output of `Requirement.sign()`. Discriminated on `action.type`:
- * `"permit"` / `"permit2"` carry token-approval args, `"permit2TransferFrom"` carries a
- * BlueBundlesV1 SignatureTransfer, `"authorization"` carries the signed Morpho authorization,
+ * `"permit"` / `"permit2"` carry token-approval args, `"permit2SignatureTransfer"` carries a
+ * bundles SignatureTransfer, `"authorization"` carries the signed Morpho authorization,
  * and Midnight adds `"midnightOfferRootSignature"`.
  */
 export type RequirementSignature<
@@ -629,7 +654,7 @@ export type RequirementSignature<
     : never
   :
       | PermitRequirementSignature
-      | Permit2TransferFromRequirementSignature
+      | Permit2SignatureTransferRequirementSignature
       | AuthorizationRequirementSignature
       | MidnightOfferRootSignature;
 
@@ -669,9 +694,9 @@ export interface Requirement<
 export type Bundler3TokenSignatureRequirement =
   Requirement<PermitRequirementSignature>;
 
-/** BlueBundlesV1 ERC-2612 or Permit2 SignatureTransfer requirement. */
-export type BlueBundlesV1TokenSignatureRequirement =
-  Requirement<BlueBundlesV1TokenRequirementSignature>;
+/** ERC-2612 or Permit2 SignatureTransfer requirement consumed by a fixed bundles contract. */
+export type BundlesTokenSignatureRequirement =
+  Requirement<BundlesTokenRequirementSignature>;
 
 /** Midnight Ecrecover offer-root signature requirement. */
 export type MidnightOfferRootRequirement = Requirement<
@@ -682,20 +707,20 @@ export type MidnightOfferRootRequirement = Requirement<
 /** Any token signature requirement supported by an SDK transaction route. */
 export type TokenSignatureRequirement =
   | Bundler3TokenSignatureRequirement
-  | BlueBundlesV1TokenSignatureRequirement;
+  | BundlesTokenSignatureRequirement;
 
 /** Bundler3 token signature result. */
 export type Bundler3TokenRequirementSignature = PermitRequirementSignature;
 
-/** BlueBundlesV1 token signature result. */
-export type BlueBundlesV1TokenRequirementSignature =
+/** Token signature result consumed by a fixed bundles contract. */
+export type BundlesTokenRequirementSignature =
   | Erc2612RequirementSignature
-  | Permit2TransferFromRequirementSignature;
+  | Permit2SignatureTransferRequirementSignature;
 
 /** Any token signature result supported by an SDK transaction route. */
 export type TokenRequirementSignature =
   | Bundler3TokenRequirementSignature
-  | BlueBundlesV1TokenRequirementSignature;
+  | BundlesTokenRequirementSignature;
 
 /** Any signature result returned by an action-output signature requirement. */
 export type AnyRequirementSignature =
@@ -821,22 +846,22 @@ export function isPermitSignature(
  * Narrows a {@link RequirementSignature} to a Permit2 SignatureTransfer result.
  *
  * @param signature - The signed requirement to test.
- * @returns `true` when `signature.action.type` is `"permit2TransferFrom"`.
+ * @returns `true` when `signature.action.type` is `"permit2SignatureTransfer"`.
  * @example
  * ```ts
  * import {
- *   isPermit2TransferFromSignature,
+ *   isPermit2SignatureTransferSignature,
  *   type RequirementSignature,
  * } from "@morpho-org/morpho-sdk";
  *
  * const getPermit2Nonce = (signature: RequirementSignature): bigint | undefined =>
- *   isPermit2TransferFromSignature(signature) ? signature.args.nonce : undefined;
+ *   isPermit2SignatureTransferSignature(signature) ? signature.args.nonce : undefined;
  * ```
  */
-export function isPermit2TransferFromSignature(
+export function isPermit2SignatureTransferSignature(
   signature: RequirementSignature,
-): signature is Permit2TransferFromRequirementSignature {
-  return signature.action.type === "permit2TransferFrom";
+): signature is Permit2SignatureTransferRequirementSignature {
+  return signature.action.type === "permit2SignatureTransfer";
 }
 
 /**
@@ -868,7 +893,7 @@ export interface SelectedRequirementSignatures {
   /** The single ERC-2612 or Permit2 AllowanceTransfer signature, when present. */
   readonly permit?: PermitRequirementSignature;
   /** The single Permit2 SignatureTransfer signature, when present. */
-  readonly permit2TransferFrom?: Permit2TransferFromRequirementSignature;
+  readonly permit2SignatureTransfer?: Permit2SignatureTransferRequirementSignature;
   /** The single Morpho authorization signature, when present. */
   readonly authorization?: AuthorizationRequirementSignature;
   /** The single Midnight offer-root signature, when present. */
@@ -887,7 +912,7 @@ export interface SelectedRequirementSignatures {
  * @param signatures - The signatures passed to `buildTx`.
  * @param accepts - Which signature kinds this operation consumes.
  * @param accepts.permit - Whether an ERC-2612 or Permit2 AllowanceTransfer signature is consumed.
- * @param accepts.permit2TransferFrom - Whether a Permit2 SignatureTransfer is consumed.
+ * @param accepts.permit2SignatureTransfer - Whether a Permit2 SignatureTransfer is consumed.
  * @param accepts.authorization - Whether a Morpho authorization signature is consumed.
  * @param accepts.midnightOfferRoot - Whether a Midnight offer-root signature is consumed.
  * @returns The accepted signature in each typed slot, when present.
@@ -906,23 +931,25 @@ export interface SelectedRequirementSignatures {
 export function selectRequirementSignatures(
   signatures: readonly RequirementSignature[] | undefined,
   accepts: {
-    permit?: boolean;
-    permit2TransferFrom?: boolean;
-    authorization?: boolean;
-    midnightOfferRoot?: boolean;
+    readonly permit?: boolean;
+    readonly permit2SignatureTransfer?: boolean;
+    readonly authorization?: boolean;
+    readonly midnightOfferRoot?: boolean;
   },
 ): SelectedRequirementSignatures {
   if (signatures == null) return {};
 
   const permits = signatures.filter(isPermitSignature);
-  const permit2Transfers = signatures.filter(isPermit2TransferFromSignature);
+  const permit2Transfers = signatures.filter(
+    isPermit2SignatureTransferSignature,
+  );
   const authorizations = signatures.filter(isAuthorizationSignature);
   const midnightOfferRoots = signatures.filter(isMidnightOfferRootSignature);
 
   if (!accepts.permit && permits.length > 0)
     throw new UnexpectedRequirementSignatureError("permit");
-  if (!accepts.permit2TransferFrom && permit2Transfers.length > 0)
-    throw new UnexpectedRequirementSignatureError("permit2TransferFrom");
+  if (!accepts.permit2SignatureTransfer && permit2Transfers.length > 0)
+    throw new UnexpectedRequirementSignatureError("permit2SignatureTransfer");
   if (!accepts.authorization && authorizations.length > 0)
     throw new UnexpectedRequirementSignatureError("authorization");
   if (!accepts.midnightOfferRoot && midnightOfferRoots.length > 0)
@@ -931,7 +958,7 @@ export function selectRequirementSignatures(
     throw new AmbiguousRequirementSignaturesError("permit", permits.length);
   if (permit2Transfers.length > 1)
     throw new AmbiguousRequirementSignaturesError(
-      "permit2TransferFrom",
+      "permit2SignatureTransfer",
       permit2Transfers.length,
     );
   if (authorizations.length > 1)
@@ -947,7 +974,7 @@ export function selectRequirementSignatures(
 
   return {
     permit: permits[0],
-    permit2TransferFrom: permit2Transfers[0],
+    permit2SignatureTransfer: permit2Transfers[0],
     authorization: authorizations[0],
     midnightOfferRoot: midnightOfferRoots[0],
   };

--- a/packages/morpho-sdk/src/types/error.test.ts
+++ b/packages/morpho-sdk/src/types/error.test.ts
@@ -7,11 +7,11 @@ import {
   NegativeNativeAmountError,
   NonPositiveAssetAmountError,
   NonPositiveInputError,
+  ReferralFeePctExceededError,
   RefinanceExceedsBorrowAssetsError,
   RefinanceExceedsBorrowSharesError,
   RefinanceExceedsCollateralError,
   RefinanceSharesMissingBorrowAssetsError,
-  ReferralFeePctExceededError,
 } from "./error.js";
 
 describe("NegativeInputError", () => {

--- a/packages/morpho-sdk/src/types/error.test.ts
+++ b/packages/morpho-sdk/src/types/error.test.ts
@@ -1,6 +1,8 @@
+import { MathLib } from "@morpho-org/blue-sdk";
 import { describe, expect, test } from "vitest";
 import {
   BorrowAmountAndSharesExclusiveError,
+  InputExceedsMaxError,
   NegativeInputError,
   NegativeNativeAmountError,
   NonPositiveAssetAmountError,
@@ -9,6 +11,7 @@ import {
   RefinanceExceedsBorrowSharesError,
   RefinanceExceedsCollateralError,
   RefinanceSharesMissingBorrowAssetsError,
+  ReferralFeePctExceededError,
 } from "./error.js";
 
 describe("NegativeInputError", () => {
@@ -82,5 +85,26 @@ describe("deprecated refinance partial-migration error exports", () => {
     expect(new RefinanceSharesMissingBorrowAssetsError("0x1")).toBeInstanceOf(
       Error,
     );
+  });
+});
+
+describe("ReferralFeePctExceededError", () => {
+  test("default", () => {
+    const error = new ReferralFeePctExceededError(MathLib.WAD);
+
+    expect(error.name).toBe("ReferralFeePctExceededError");
+    expect(error.referralFeePct).toBe(MathLib.WAD);
+    expect(error.message).toBe(
+      'Referral fee percentage "1000000000000000000" must be below WAD. Reduce referralFeePct or disable the referral fee.',
+    );
+  });
+
+  test("behavior: stays catchable as the generic maximum-bound error", () => {
+    const error = new ReferralFeePctExceededError(MathLib.WAD);
+
+    expect(error).toBeInstanceOf(InputExceedsMaxError);
+    expect(error.field).toBe("referralFeePct");
+    expect(error.value).toBe(MathLib.WAD);
+    expect(error.max).toBe(MathLib.WAD - 1n);
   });
 });

--- a/packages/morpho-sdk/src/types/error.ts
+++ b/packages/morpho-sdk/src/types/error.ts
@@ -1,4 +1,4 @@
-import { type MarketId, UnknownDataError } from "@morpho-org/blue-sdk";
+import { type MarketId, MathLib, UnknownDataError } from "@morpho-org/blue-sdk";
 import type { Address, Hash } from "viem";
 
 /**
@@ -493,12 +493,22 @@ export const MissingReferralFeeRecipientError =
 /** @deprecated Use {@link ReferralFeeRecipientMissingError}. */
 export type MissingReferralFeeRecipientError = ReferralFeeRecipientMissingError;
 
-/** Thrown when a referral fee percentage is outside the contract's `[0, WAD)` range. */
-export class ReferralFeePctExceededError extends Error {
+/**
+ * Thrown when a referral fee percentage is outside the contract's `[0, WAD)` range.
+ *
+ * Extends {@link InputExceedsMaxError} — and reports the same `field`, `value`, and `max` the
+ * generic bound error used to carry for this input — so integrators already pattern-matching
+ * `InputExceedsMaxError` keep catching this failure.
+ */
+export class ReferralFeePctExceededError extends InputExceedsMaxError {
+  /** @param referralFeePct - WAD-scaled referral fee percentage supplied by the caller. */
   public constructor(public readonly referralFeePct: bigint) {
-    super(
-      `Referral fee percentage "${referralFeePct}" must be below WAD. Reduce referralFeePct or disable the referral fee.`,
-    );
+    super({
+      field: "referralFeePct",
+      value: referralFeePct,
+      max: MathLib.WAD - 1n,
+    });
+    this.message = `Referral fee percentage "${referralFeePct}" must be below WAD. Reduce referralFeePct or disable the referral fee.`;
     this.name = "ReferralFeePctExceededError";
   }
 }

--- a/packages/morpho-sdk/src/types/error.ts
+++ b/packages/morpho-sdk/src/types/error.ts
@@ -284,8 +284,8 @@ export class VaultIsBlueFeeRecipientError extends Error {
   }
 }
 
-/** Thrown when a vault-shares requirement cannot be safely encoded as an ERC-2612 permit. */
-export class VaultExitBundlesV1PermitMismatchError extends Error {
+/** Thrown when a vault-shares requirement cannot be safely encoded as a bundles permit. */
+export class BundlesPermitMismatchError extends Error {
   /**
    * @param params - Permit mismatch values used to explain the rejection.
    * @param params.field - Permit field that does not match the exit.
@@ -293,37 +293,80 @@ export class VaultExitBundlesV1PermitMismatchError extends Error {
    * @param params.actual - Value supplied by the signature.
    * @param params.cause - Original parser failure when signature decoding is wrapped.
    */
-  public readonly field: "type" | "asset" | "signature";
+  public readonly field:
+    | "type"
+    | "asset"
+    | "owner"
+    | "spender"
+    | "amount"
+    | "nonce"
+    | "deadline"
+    | "signature";
   public readonly expected: string;
   public readonly actual: string;
 
   public constructor(params: {
-    readonly field: "type" | "asset" | "signature";
+    readonly field:
+      | "type"
+      | "asset"
+      | "owner"
+      | "spender"
+      | "amount"
+      | "nonce"
+      | "deadline"
+      | "signature";
     readonly expected: string;
     readonly actual: string;
     readonly cause?: unknown;
   }) {
     super(
-      `VaultExitBundlesV1 permit ${params.field} mismatch: expected "${params.expected}", got "${params.actual}". Rebuild and sign the vault-exit permit.`,
+      `Bundles permit ${params.field} mismatch: expected "${params.expected}", got "${params.actual}". Resolve and sign the requirements returned by this prepared operation.`,
       { cause: params.cause },
     );
     this.field = params.field;
     this.expected = params.expected;
     this.actual = params.actual;
+    this.name = "BundlesPermitMismatchError";
+  }
+}
+
+/**
+ * Thrown by the deprecated VaultExitBundlesV1 permit compatibility helper.
+ *
+ * @deprecated Use {@link BundlesPermitMismatchError} with `getBundlesSharesPermit`.
+ */
+export class VaultExitBundlesV1PermitMismatchError extends BundlesPermitMismatchError {
+  public constructor(params: {
+    readonly field:
+      | "type"
+      | "asset"
+      | "owner"
+      | "spender"
+      | "amount"
+      | "nonce"
+      | "deadline"
+      | "signature";
+    readonly expected: string;
+    readonly actual: string;
+    readonly cause?: unknown;
+  }) {
+    super(params);
+    this.message = `VaultExitBundlesV1 permit ${params.field} mismatch: expected "${params.expected}", got "${params.actual}". Rebuild and sign the vault-exit permit.`;
     this.name = "VaultExitBundlesV1PermitMismatchError";
   }
 }
 
-/** Thrown when a signed requirement cannot be safely encoded for BlueBundlesV1. */
-export class BlueBundlesV1RequirementSignatureMismatchError extends Error {
-  /** Field whose signed value or encoding is invalid for the direct BlueBundlesV1 call. */
+/** Thrown when a signed requirement cannot be safely encoded for a fixed bundles call. */
+export class BundlesRequirementSignatureMismatchError extends Error {
+  /** Field whose signed value or encoding is invalid for the fixed bundles call. */
   public readonly field:
     | "type"
     | "authorized"
     | "isAuthorized"
+    | "nonce"
     | "deadline"
     | "signature";
-  /** Value required by BlueBundlesV1. */
+  /** Value required by the fixed bundles call. */
   public readonly expected: string;
   /** Value supplied by the signed requirement. */
   public readonly actual: string;
@@ -336,34 +379,50 @@ export class BlueBundlesV1RequirementSignatureMismatchError extends Error {
    * @param params.cause - Original signature parser failure, when applicable.
    */
   public constructor(params: {
-    field: "type" | "authorized" | "isAuthorized" | "deadline" | "signature";
+    field:
+      | "type"
+      | "authorized"
+      | "isAuthorized"
+      | "nonce"
+      | "deadline"
+      | "signature";
     expected: string;
     actual: string;
     cause?: unknown;
   }) {
     super(
-      `BlueBundlesV1 requirement ${params.field} mismatch: expected "${params.expected}", got "${params.actual}". Resolve and sign the requirements returned by this Blue action.`,
+      `Bundles requirement ${params.field} mismatch: expected "${params.expected}", got "${params.actual}". Resolve and sign the requirements returned by this prepared operation.`,
       { cause: params.cause },
     );
     this.field = params.field;
     this.expected = params.expected;
     this.actual = params.actual;
-    this.name = "BlueBundlesV1RequirementSignatureMismatchError";
+    this.name = "BundlesRequirementSignatureMismatchError";
   }
 }
 
+/** @deprecated Use {@link BundlesRequirementSignatureMismatchError}. */
+export {
+  BundlesRequirementSignatureMismatchError as BlueBundlesV1RequirementSignatureMismatchError,
+};
+
 /** Thrown when Permit2 SignatureTransfer is selected without an explicit unordered nonce. */
-export class MissingPermit2TransferFromNonceError extends Error {
+export class MissingPermit2SignatureTransferNonceError extends Error {
   public constructor() {
     super(
       "Permit2 SignatureTransfer requires an explicit unused permit2Nonce. Generate a unique uint256 nonce, pass it to getRequirements(), and resolve the requirements again.",
     );
-    this.name = "MissingPermit2TransferFromNonceError";
+    this.name = "MissingPermit2SignatureTransferNonceError";
   }
 }
 
+/** @deprecated Use {@link MissingPermit2SignatureTransferNonceError}. */
+export {
+  MissingPermit2SignatureTransferNonceError as MissingPermit2TransferFromNonceError,
+};
+
 /** Thrown when an explicit Permit2 SignatureTransfer unordered nonce is already consumed. */
-export class Permit2TransferFromNonceAlreadyUsedError extends Error {
+export class Permit2SignatureTransferNonceAlreadyUsedError extends Error {
   /**
    * @param owner - Permit2 token owner whose nonce is unavailable.
    * @param nonce - Explicit unordered nonce that has already been consumed.
@@ -375,7 +434,7 @@ export class Permit2TransferFromNonceAlreadyUsedError extends Error {
     super(
       `Permit2 nonce "${nonce}" is already used for owner "${owner}". Generate a different uint256 permit2Nonce and resolve the requirements again.`,
     );
-    this.name = "Permit2TransferFromNonceAlreadyUsedError";
+    this.name = "Permit2SignatureTransferNonceAlreadyUsedError";
   }
 }
 
@@ -396,6 +455,11 @@ export class NoUnusedPermit2NonceError extends Error {
   }
 }
 
+/** @deprecated Use {@link Permit2SignatureTransferNonceAlreadyUsedError}. */
+export {
+  Permit2SignatureTransferNonceAlreadyUsedError as Permit2TransferFromNonceAlreadyUsedError,
+};
+
 /** Thrown when native funding does not exactly match the contract's gross token pull. */
 export class NativeFundingAmountMismatchError extends Error {
   /**
@@ -414,12 +478,58 @@ export class NativeFundingAmountMismatchError extends Error {
 }
 
 /** Thrown when a positive referral fee has no recipient. */
-export class MissingReferralFeeRecipientError extends Error {
+export class ReferralFeeRecipientMissingError extends Error {
   public constructor() {
     super(
       "A positive referralFeePct requires referralFeeRecipient. Provide the recipient or set referralFeePct to zero.",
     );
-    this.name = "MissingReferralFeeRecipientError";
+    this.name = "ReferralFeeRecipientMissingError";
+  }
+}
+
+/** @deprecated Use {@link ReferralFeeRecipientMissingError}. */
+export const MissingReferralFeeRecipientError =
+  ReferralFeeRecipientMissingError;
+/** @deprecated Use {@link ReferralFeeRecipientMissingError}. */
+export type MissingReferralFeeRecipientError = ReferralFeeRecipientMissingError;
+
+/** Thrown when a referral fee percentage is outside the contract's `[0, WAD)` range. */
+export class ReferralFeePctExceededError extends Error {
+  public constructor(public readonly referralFeePct: bigint) {
+    super(
+      `Referral fee percentage "${referralFeePct}" must be below WAD. Reduce referralFeePct or disable the referral fee.`,
+    );
+    this.name = "ReferralFeePctExceededError";
+  }
+}
+
+/** Thrown when a fixed bundles call mixes ERC-20 and native funding. */
+export class MixedBundlesFundingError extends Error {
+  public constructor() {
+    super(
+      "Bundles funding accepts either amount or nativeAmount, not both. Choose one funding source and rebuild the transaction.",
+    );
+    this.name = "MixedBundlesFundingError";
+  }
+}
+
+/** Thrown when a vault migration specifies both assets and shares, or neither. */
+export class AmountAndSharesExclusiveError extends Error {
+  public constructor() {
+    super(
+      "Vault migration requires exactly one of assets or shares. Choose the desired withdrawal mode and rebuild the transaction.",
+    );
+    this.name = "AmountAndSharesExclusiveError";
+  }
+}
+
+/** Thrown when a vault migration selects the same source and destination vault. */
+export class SameVaultMigrationError extends Error {
+  public constructor(public readonly vault: Address) {
+    super(
+      `Source and destination vault are both "${vault}". Select a different destination vault.`,
+    );
+    this.name = "SameVaultMigrationError";
   }
 }
 
@@ -698,7 +808,7 @@ export namespace BundlerErrors {
 /** Requirement signature kind accepted by action-output transaction builders. */
 export type RequirementSignatureKind =
   | "permit"
-  | "permit2TransferFrom"
+  | "permit2SignatureTransfer"
   | "authorization"
   | "midnightOfferRootSignature";
 

--- a/packages/morpho-sdk/test/entities/blue/blueBundlesV1.integration.test.ts
+++ b/packages/morpho-sdk/test/entities/blue/blueBundlesV1.integration.test.ts
@@ -184,7 +184,7 @@ describe("BlueBundlesV1 Blue writes", () => {
     const requirements = await action.getRequirements({ permit2Nonce: 0n });
     expect(
       requirements.map(({ action: requirement }) => requirement.type),
-    ).toEqual(["erc20Approval", "permit2TransferFrom"]);
+    ).toEqual(["erc20Approval", "permit2SignatureTransfer"]);
     const signatures = await satisfyBlueBundlesV1Requirements(client, {
       requirements,
     });
@@ -507,13 +507,13 @@ describe("BlueBundlesV1 Blue writes", () => {
     const requirements = await action.getRequirements({ permit2Nonce });
     expect(
       requirements.map(({ action: requirement }) => requirement.type),
-    ).toEqual(["erc20Approval", "permit2TransferFrom", "authorization"]);
+    ).toEqual(["erc20Approval", "permit2SignatureTransfer", "authorization"]);
     const signatures = await satisfyBlueBundlesV1Requirements(client, {
       requirements,
     });
     expect(signatures).toMatchObject([
       {
-        action: { type: "permit2TransferFrom" },
+        action: { type: "permit2SignatureTransfer" },
         args: { nonce: permit2Nonce },
       },
       { action: { type: "authorization" } },

--- a/packages/morpho-sdk/test/entities/requirements/getBundlesTokenRequirements.integration.test.ts
+++ b/packages/morpho-sdk/test/entities/requirements/getBundlesTokenRequirements.integration.test.ts
@@ -1,0 +1,203 @@
+import { addressesRegistry } from "@morpho-org/blue-sdk";
+import { erc2612Abi, permit2Abi } from "@morpho-org/blue-sdk-viem";
+import { getChainAddress } from "@morpho-org/morpho-ts";
+import { createViemTest } from "@morpho-org/test/vitest";
+import { erc20Abi, maxUint256, parseSignature } from "viem";
+import { mainnet } from "viem/chains";
+import { assert, describe, expect } from "vitest";
+import {
+  getBundlesTokenRequirements,
+  isRequirementApproval,
+  isRequirementSignature,
+  Permit2SignatureTransferNonceAlreadyUsedError,
+} from "../../../src/index.js";
+
+const test = createViemTest(mainnet, {
+  forkUrl: process.env.MAINNET_RPC_URL,
+  forkBlockNumber: 25_832_676n,
+  stepsTracing: false,
+});
+const { usdc } = addressesRegistry[mainnet.id];
+const permit2 = getChainAddress(mainnet.id, "permit2");
+
+describe.each(["blueBundlesV1", "vaultBundlesV1"] as const)(
+  "getBundlesTokenRequirements: %s",
+  (deployment) => {
+    const spender = getChainAddress(mainnet.id, `bundles.${deployment}`);
+    const params = {
+      token: usdc,
+      spender,
+      chainId: mainnet.id,
+      amount: 1_000_000n,
+      deadline: maxUint256,
+    } as const;
+
+    test("default: approves the registered spender and skips a covered pull", async ({
+      client,
+    }) => {
+      await client.approve({ address: usdc, args: [spender, 0n] });
+      const request = {
+        ...params,
+        owner: client.account.address,
+        supportSignature: false,
+      };
+      const requirements = await getBundlesTokenRequirements(client, request);
+      expect(requirements).toHaveLength(1);
+      const [approval] = requirements;
+      assert(isRequirementApproval(approval));
+      expect(approval.action.args).toMatchObject({
+        spender,
+        amount: params.amount,
+      });
+      await client.sendTransaction(approval);
+      expect(
+        await client.readContract({
+          abi: erc20Abi,
+          address: usdc,
+          functionName: "allowance",
+          args: [client.account.address, spender],
+        }),
+      ).toBe(params.amount);
+      expect(
+        await getBundlesTokenRequirements(client, {
+          ...request,
+          approvalAmount: maxUint256,
+        }),
+      ).toEqual([]);
+    });
+
+    test("behavior: reads the ERC-2612 nonce and produces an executable permit", async ({
+      client,
+    }) => {
+      const nonce = await client.readContract({
+        abi: erc2612Abi,
+        address: usdc,
+        functionName: "nonces",
+        args: [client.account.address],
+      });
+      const requirements = await getBundlesTokenRequirements(client, {
+        ...params,
+        owner: client.account.address,
+        supportSignature: true,
+        useSimplePermit: true,
+        supportDeployless: false,
+      });
+      expect(requirements).toHaveLength(1);
+      const [requirement] = requirements;
+      assert(isRequirementSignature(requirement));
+      expect(requirement.action).toMatchObject({
+        type: "permit",
+        args: { spender, amount: params.amount, nonce },
+      });
+      const signed = await requirement.sign(client, client.account.address);
+      const { r, s, v } = parseSignature(signed.args.signature);
+      assert(v != null);
+      await client.writeContract({
+        abi: erc2612Abi,
+        address: usdc,
+        functionName: "permit",
+        args: [
+          client.account.address,
+          spender,
+          params.amount,
+          params.deadline,
+          Number(v),
+          r,
+          s,
+        ],
+      });
+      expect(
+        await client.readContract({
+          abi: erc20Abi,
+          address: usdc,
+          functionName: "allowance",
+          args: [client.account.address, spender],
+        }),
+      ).toBe(params.amount);
+      expect(
+        await client.readContract({
+          abi: erc2612Abi,
+          address: usdc,
+          functionName: "nonces",
+          args: [client.account.address],
+        }),
+      ).toBe(nonce + 1n);
+    });
+
+    test("behavior: approves canonical Permit2, executes a signature transfer, and rejects nonce reuse", async ({
+      client,
+    }) => {
+      const wordPosition = 12_345n;
+      const bit = 1n << 7n;
+      const nonce = (wordPosition << 8n) | 7n;
+      await client.deal({ erc20: usdc, amount: params.amount });
+      await client.approve({ address: usdc, args: [permit2, 0n] });
+      const request = {
+        ...params,
+        owner: client.account.address,
+        supportSignature: true,
+        permit2Nonce: nonce,
+      };
+      const requirements = await getBundlesTokenRequirements(client, request);
+      expect(requirements.map(({ action }) => action.type)).toEqual([
+        "erc20Approval",
+        "permit2SignatureTransfer",
+      ]);
+      const [approval, requirement] = requirements;
+      assert(isRequirementApproval(approval));
+      assert(isRequirementSignature(requirement));
+      expect(approval.action.args).toMatchObject({
+        spender: permit2,
+        amount: maxUint256,
+      });
+      expect(requirement.action.args).toMatchObject({
+        spender,
+        amount: params.amount,
+        nonce,
+      });
+      await client.sendTransaction(approval);
+      expect(
+        (await getBundlesTokenRequirements(client, request)).map(
+          ({ action }) => action.type,
+        ),
+      ).toEqual(["permit2SignatureTransfer"]);
+      const signed = await requirement.sign(client, client.account.address);
+      const beforeBalance = await client.balanceOf({
+        erc20: usdc,
+        owner: spender,
+      });
+
+      // Execute as the registered spender to verify Permit2 accepts the fetched nonce and signed domain.
+      await client.setBalance({ address: spender, value: 10n ** 18n });
+      await client.writeContract({
+        account: spender,
+        address: permit2,
+        abi: permit2Abi,
+        functionName: "permitTransferFrom",
+        args: [
+          {
+            permitted: { token: usdc, amount: params.amount },
+            nonce,
+            deadline: params.deadline,
+          },
+          { to: spender, requestedAmount: params.amount },
+          client.account.address,
+          signed.args.signature,
+        ],
+      });
+      expect(await client.balanceOf({ erc20: usdc, owner: spender })).toBe(
+        beforeBalance + params.amount,
+      );
+      const bitmap = await client.readContract({
+        address: permit2,
+        abi: permit2Abi,
+        functionName: "nonceBitmap",
+        args: [client.account.address, wordPosition],
+      });
+      expect(bitmap & bit).toBe(bit);
+      await expect(
+        getBundlesTokenRequirements(client, request),
+      ).rejects.toBeInstanceOf(Permit2SignatureTransferNonceAlreadyUsedError);
+    });
+  },
+);

--- a/packages/wdk-protocol-lending-morpho-evm/MIGRATION.md
+++ b/packages/wdk-protocol-lending-morpho-evm/MIGRATION.md
@@ -23,8 +23,8 @@ Version 2 routes Morpho Blue writes through `BlueBundlesV1` instead of Bundler3.
 - `RequirementApproval` and `RequirementAuthorization` are readonly transactions.
 - `RequirementSignatureRequest<TSignature>` is now generic. Vault token requirements use
   `PermitRequirementSignature`, Blue token requirements use
-  `BlueBundlesV1TokenRequirementSignature`, and Blue authorization requirements use
-  `AuthorizationRequirementSignature`.
+  `BundlesTokenRequirementSignature` (renamed from `BlueBundlesV1TokenRequirementSignature`),
+  and Blue authorization requirements use `AuthorizationRequirementSignature`.
 - Use `ApprovalOrSignatureRequirement` for vault deposits,
   `BlueApprovalOrSignatureRequirement` for Blue token-funded writes, and
   `AuthorizationOrSignatureRequirement` for Blue borrow or withdrawal authorization.

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
@@ -1,6 +1,6 @@
 import type {
   AuthorizationRequirementSignature,
-  BlueBundlesV1TokenRequirementSignature,
+  BundlesTokenRequirementSignature,
   PermitRequirementSignature,
   VaultV2BlueReallocation,
 } from "@morpho-org/morpho-sdk";
@@ -737,7 +737,7 @@ describe.sequential("MorphoProtocolEvm", () => {
       const requirementSignature = {
         args: { deadline: SIGNATURE_DEADLINE },
         action: { type: "permit2TransferFrom" },
-      } as unknown as BlueBundlesV1TokenRequirementSignature;
+      } as unknown as BundlesTokenRequirementSignature;
 
       await protocol.repay({
         token: TOKEN,

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
@@ -736,7 +736,7 @@ describe.sequential("MorphoProtocolEvm", () => {
         .mockResolvedValue({ hash: "dummy-repay-hash", fee: 12_345n });
       const requirementSignature = {
         args: { deadline: SIGNATURE_DEADLINE },
-        action: { type: "permit2TransferFrom" },
+        action: { type: "permit2SignatureTransfer" },
       } as unknown as BundlesTokenRequirementSignature;
 
       await protocol.repay({

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
@@ -7,7 +7,7 @@ import { fetchMarket } from "@morpho-org/blue-sdk-viem";
 import {
   type AuthorizationRequirementSignature,
   type BlueAuthorizationAction,
-  type BlueBundlesV1TokenRequirementSignature,
+  type BundlesTokenRequirementSignature,
   type ERC20ApprovalAction,
   type Metadata,
   type MorphoClientType,
@@ -124,7 +124,7 @@ export type ApprovalOrSignatureRequirement =
 /** A BlueBundlesV1 token approval or ERC-2612/Permit2 SignatureTransfer request. */
 export type BlueApprovalOrSignatureRequirement =
   | RequirementApproval
-  | RequirementSignatureRequest<BlueBundlesV1TokenRequirementSignature>;
+  | RequirementSignatureRequest<BundlesTokenRequirementSignature>;
 /** A Blue authorization transaction or authorization-signature request. */
 export type AuthorizationOrSignatureRequirement =
   | RequirementAuthorization
@@ -193,7 +193,7 @@ export type MorphoCollateralSupplyOptions =
         "nativeAmount" | "requirementSignature" | "slippageTolerance"
       > & {
         nativeAmount?: never;
-        requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+        requirementSignature?: BundlesTokenRequirementSignature;
         slippageTolerance?: never;
       }
     >
@@ -231,7 +231,7 @@ export interface MorphoRepayOptions {
   /** The address on behalf of which the repay operation should be performed. Must match the wallet account address when set. */
   readonly onBehalfOf?: string;
   /** Signature returned by a Morpho SDK approval requirement. */
-  readonly requirementSignature?: BlueBundlesV1TokenRequirementSignature;
+  readonly requirementSignature?: BundlesTokenRequirementSignature;
 }
 
 /**
@@ -355,7 +355,7 @@ const BLUE_BUNDLES_V1_DEADLINE_WINDOW_SECONDS = 7_200n;
 
 function getBlueBundlesV1Deadline(
   signature?:
-    | BlueBundlesV1TokenRequirementSignature
+    | BundlesTokenRequirementSignature
     | AuthorizationRequirementSignature,
 ): bigint {
   return (
@@ -970,8 +970,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param requirementOptions.useSimplePermit - Prefer ERC-2612 when the token supports it.
    * @param requirementOptions.permit2Nonce - Explicit unused Permit2 SignatureTransfer nonce.
    * @returns A readonly list of BlueBundlesV1 loan-token approvals or signable token requirements.
-   * @throws {MissingPermit2TransferFromNonceError} when Permit2 is selected without a nonce.
-   * @throws {Permit2TransferFromNonceAlreadyUsedError} when the supplied Permit2 nonce is consumed.
+   * @throws {MissingPermit2SignatureTransferNonceError} when Permit2 is selected without a nonce.
+   * @throws {Permit2SignatureTransferNonceAlreadyUsedError} when the supplied Permit2 nonce is consumed.
    * @throws {InputExceedsMaxError} when a nonce or full-share quote deadline exceeds its bound.
    * @throws {viem.BaseError} when a position, allowance, or nonce read fails.
    * @throws {Error} when an address, target token, or account configuration is invalid.
@@ -1175,8 +1175,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns A readonly list of BlueBundlesV1 collateral-token approvals or signable requirements;
    *   native funding returns an empty list.
    * @throws {MixedBlueCollateralFundingError} when ERC-20 and native funding are both supplied.
-   * @throws {MissingPermit2TransferFromNonceError} when Permit2 is selected without a nonce.
-   * @throws {Permit2TransferFromNonceAlreadyUsedError} when the supplied Permit2 nonce is consumed.
+   * @throws {MissingPermit2SignatureTransferNonceError} when Permit2 is selected without a nonce.
+   * @throws {Permit2SignatureTransferNonceAlreadyUsedError} when the supplied Permit2 nonce is consumed.
    * @throws {viem.BaseError} when an allowance, nonce, or token-metadata read fails.
    * @throws {Error} when an address, target token, or account configuration is invalid.
    * @example


### PR DESCRIPTION
## Summary

Implements the shared prerequisites from #951 on top of `next`, which includes the merged BlueBundlesV1 stack (#990):

- rename Blue-specific approval/signature APIs to fixed-bundle names, retaining deprecated compatibility aliases where applicable
- add the shared immutable bundle funding, referral-fee, requirement-selection, and resolution primitives used by Blue and Vault actions
- add the VaultBundlesV1 ABI surface and reusable share-price/slippage helpers
- keep Blue actions on the same common implementation so Vault support does not create a second source of truth

## Stack

1. This PR — shared prerequisites
2. #998 — Vault V1/V2 deposits
3. #999 — Vault V1/V2 withdrawals
4. #1000 — Vault V1/V2 redemptions and Vault V1-to-V2 migration

## Verification

Revalidated while rebasing the stack onto `next`:

- SDK and WDK TypeScript checks passed on all four PR heads.
- This PR's SDK/WDK unit suites: 87 files / 1,041 tests passed.
- Combined stack: 39 tests passed across 8 pinned Anvil fork suites covering BlueBundlesV1 and vault deposits, withdrawals, redemptions, and V1-to-V2 migration.
- Repository Biome, JSDoc coverage self-check, address checks, and `git diff --check` passed.

## Release sequencing

This stack implements TIB #951, but must not merge into a releasable major until the required published-minor deprecation runway is resolved. The earlier runway PR #991 was closed without merge.
