### PR TITLE
fix(evm-simulation): key native ETH sentinel by ethAddress in Tenderly asset changes

### DIFF
--- a/.changeset/evm-simulation-native-sentinel-normalization.md
+++ b/.changeset/evm-simulation-native-sentinel-normalization.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/evm-simulation": patch
+---
+
+Normalize the native-ETH sentinel case-insensitively when mapping Tenderly asset changes. A sentinel carried (checksummed or otherwise non-lowercase) in `assetInfo.contractAddress` was previously `getAddress`-checksummed and no longer matched the lowercase `ethAddress` key used by `assertNoBundlerRetention`, so a retained Bundler3 native residual could escape the retention gate and return a false-safe simulation. The transfer-log parser and the Tenderly asset-change mapper now share a single `normalizeAssetToken` helper, removing the drift between the two normalization paths.

--- a/packages/evm-simulation/src/simulate/asset-changes.test.ts
+++ b/packages/evm-simulation/src/simulate/asset-changes.test.ts
@@ -1,9 +1,29 @@
-import { type Address, ethAddress, zeroAddress } from "viem";
-import { groupAssetChanges } from "./asset-changes.js";
+import { type Address, ethAddress, getAddress, zeroAddress } from "viem";
+import { groupAssetChanges, normalizeAssetToken } from "./asset-changes.js";
 
 const USER: Address = "0x1111111111111111111111111111111111111111";
 const VAULT: Address = "0x2222222222222222222222222222222222222222";
 const USDC: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+describe("normalizeAssetToken", () => {
+  test("default", () => {
+    // A real token address is checksummed regardless of input casing.
+    expect(normalizeAssetToken(USDC.toLowerCase() as Address)).toBe(USDC);
+  });
+
+  test("behavior: collapses the lowercase native sentinel to ethAddress", () => {
+    expect(normalizeAssetToken(ethAddress)).toBe(ethAddress);
+  });
+
+  test("behavior: collapses the checksummed native sentinel to ethAddress", () => {
+    // Security invariant (SDKS-102/46): a checksummed sentinel must still key
+    // native ETH by the exact `ethAddress` constant, otherwise a Bundler3 native
+    // residual lands on a separate map key and escapes `assertNoBundlerRetention`.
+    const checksummed = getAddress(ethAddress);
+    expect(checksummed).not.toBe(ethAddress);
+    expect(normalizeAssetToken(checksummed)).toBe(ethAddress);
+  });
+});
 
 describe("groupAssetChanges", () => {
   test("default", () => {

--- a/packages/evm-simulation/src/simulate/asset-changes.ts
+++ b/packages/evm-simulation/src/simulate/asset-changes.ts
@@ -1,4 +1,4 @@
-import { type Address, getAddress } from "viem";
+import { type Address, ethAddress, getAddress, type Hex } from "viem";
 import type { AccountAssetChanges, AssetChange } from "../types.js";
 
 /** A single signed contribution to one account's balance for one token. */
@@ -8,6 +8,26 @@ export interface AssetChangeEntry {
   diff: bigint;
   symbol?: string;
   decimals?: number;
+}
+
+/**
+ * Collapse the native-ETH sentinel to viem's lowercase `ethAddress`, checksumming
+ * any real token address. `eth_simulateV1` synthesizes native moves from the
+ * sentinel `0xeee…eee`, and Tenderly may echo it — in checksummed or any other
+ * case — as an asset change's `contractAddress`. Native ETH is keyed by the exact
+ * `ethAddress` constant here and in the bundler-retention guard, so a checksummed
+ * sentinel would land on a separate map key and silently escape retention checks.
+ * This is the single source of truth for token normalization shared by the
+ * transfer-log parser and the Tenderly asset-change mapper.
+ *
+ * @param address - Token address emitting a transfer or carried by an asset change.
+ * @returns `ethAddress` for the native sentinel, else the checksummed address.
+ * @internal
+ */
+export function normalizeAssetToken(address: Hex): Address {
+  return address.toLowerCase() === ethAddress
+    ? ethAddress
+    : getAddress(address);
 }
 
 // Locale-independent byte-order compare on lowercased hex, matching `sortTransfers`.

--- a/packages/evm-simulation/src/simulate/backends/tenderly-rpc.test.ts
+++ b/packages/evm-simulation/src/simulate/backends/tenderly-rpc.test.ts
@@ -1,4 +1,10 @@
-import { type Address, ethAddress, type Hex, zeroAddress } from "viem";
+import {
+  type Address,
+  ethAddress,
+  getAddress,
+  type Hex,
+  zeroAddress,
+} from "viem";
 import { vi } from "vitest";
 import {
   ExternalServiceError,
@@ -252,6 +258,50 @@ describe.sequential("simulateTenderlyRpc — single tx", () => {
             assetChanges: [
               assetChange({
                 from: USER,
+                rawAmount: "0xde0b6b3a7640000",
+                symbol: "ETH",
+                decimals: 18,
+              }),
+            ],
+          }),
+        ),
+    });
+    installFetchMock(fetchMock);
+
+    const result = await simulateTenderlyRpc({
+      config: CONFIG,
+      transactions: [TX1],
+    });
+
+    expect(result.assetChanges).toEqual([
+      {
+        account: USER,
+        changes: [
+          {
+            token: ethAddress,
+            symbol: "ETH",
+            decimals: 18,
+            diff: -1_000_000_000_000_000_000n,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("maps a checksummed native sentinel in contractAddress to the eth sentinel", async () => {
+    // SDKS-102/46: Tenderly may echo the native sentinel (checksummed) as an
+    // asset change's contractAddress. It must still key native ETH by the exact
+    // `ethAddress` constant so a Bundler3 native residual is not silently dropped
+    // by `assertNoBundlerRetention`.
+    const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        envelope(
+          successResult({
+            assetChanges: [
+              assetChange({
+                from: USER,
+                token: getAddress(ethAddress),
                 rawAmount: "0xde0b6b3a7640000",
                 symbol: "ETH",
                 decimals: 18,

--- a/packages/evm-simulation/src/simulate/backends/tenderly-rpc.ts
+++ b/packages/evm-simulation/src/simulate/backends/tenderly-rpc.ts
@@ -2,7 +2,6 @@ import {
   type Address,
   type BlockTag,
   ethAddress,
-  getAddress,
   type Hex,
   isAddress,
   isHex,
@@ -23,7 +22,11 @@ import type {
   SimulationTransaction,
   TenderlyRpcConfig,
 } from "../../types.js";
-import { type AssetChangeEntry, groupAssetChanges } from "../asset-changes.js";
+import {
+  type AssetChangeEntry,
+  groupAssetChanges,
+  normalizeAssetToken,
+} from "../asset-changes.js";
 
 interface TenderlyRpcCall {
   from: Address;
@@ -283,7 +286,7 @@ function toAssetChanges(results: SimResult[]): AccountAssetChanges[] {
     for (const change of result.assetChanges ?? []) {
       const amount = BigInt(change.rawAmount);
       const token = change.assetInfo.contractAddress
-        ? getAddress(change.assetInfo.contractAddress)
+        ? normalizeAssetToken(change.assetInfo.contractAddress)
         : ethAddress;
       const { symbol, decimals } = change.assetInfo;
       if (change.to)

--- a/packages/evm-simulation/src/simulate/parsing/transfers.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.ts
@@ -1,11 +1,4 @@
-import {
-  type Address,
-  ethAddress,
-  getAddress,
-  type Hex,
-  zeroAddress,
-  zeroHash,
-} from "viem";
+import { getAddress, type Hex, zeroAddress, zeroHash } from "viem";
 
 import type {
   RawCall,
@@ -13,6 +6,7 @@ import type {
   SimulationLogger,
   Transfer,
 } from "../../types.js";
+import { normalizeAssetToken } from "../asset-changes.js";
 
 // keccak256("Transfer(address,address,uint256)") — ERC-20 transfer event
 export const TRANSFER_TOPIC =
@@ -186,7 +180,7 @@ export function parseTransfers(
             }
 
             transfers.push({
-              token: normalizeTransferToken(log.address),
+              token: normalizeAssetToken(log.address),
               from: getAddress(`0x${fromTopic.slice(26)}`),
               to: getAddress(`0x${toTopic.slice(26)}`),
               amount: BigInt(log.data),
@@ -209,22 +203,6 @@ export function parseTransfers(
   }
 
   return sortTransfers(transfers);
-}
-
-/**
- * Normalize a `Transfer` log's emitting address into a transfer `token`.
- *
- * `eth_simulateV1` with `traceTransfers` enabled synthesizes native-ETH moves
- * (including internal calls) as `Transfer` events emitted from the native
- * sentinel `0xeee…eee`. The rest of the SDK keys native ETH by viem's
- * `ethAddress` constant, so we collapse the sentinel to that exact value rather
- * than the checksummed form `getAddress` would produce — keeping native deltas
- * on a single map key across backends. Real ERC20 tokens are checksummed.
- */
-function normalizeTransferToken(address: Hex): Address {
-  return address.toLowerCase() === ethAddress
-    ? ethAddress
-    : getAddress(address);
 }
 
 function isTopicHex(value: Hex | undefined): value is Hex {


### PR DESCRIPTION
## What

Cantina AI SDKs Scan #1 flagged two related evm-simulation findings — **SDKS-102** and **SDKS-46** — about the native-ETH sentinel escaping the Bundler3 retention gate. This PR fixes the genuine internal inconsistency behind them.

`toAssetChanges()` in the Tenderly backend checksummed every `assetInfo.contractAddress` with `getAddress()`. If Tenderly echoes the native sentinel `0xeee…eee` there (checksummed → `0xEeee…EEeE`), it no longer equalled the **lowercase** `ethAddress` that `assertNoBundlerRetention()` strict-compares against (`bundler-retention.ts` `change.token !== ethAddress`). A positive Bundler3 native residual could then land on a separate map key and slip past retention → false-safe `SimulationResult`.

The transfer-log parser already handled this correctly (`normalizeTransferToken`), so the two normalization paths had **drifted** — exactly the root cause.

## Change

- New shared `normalizeAssetToken(address)` in `simulate/asset-changes.ts` (single source of truth): collapses the native sentinel to viem's `ethAddress` in any casing, checksums real tokens.
- Tenderly `toAssetChanges()` now uses it (the fix).
- `transfers.ts` drops its local `normalizeTransferToken` duplicate and reuses the shared helper (kills the drift).

## Tests

- `asset-changes.test.ts`: direct invariant tests for `normalizeAssetToken` (lowercase sentinel, **checksummed sentinel**, real token) — fails if the collapse is removed.
- `tenderly-rpc.test.ts`: a checksummed sentinel in `contractAddress` maps to `ethAddress`.
- Full `evm-simulation` unit project green (239/239).

## Severity / scope

Low. This is a real internal inconsistency (defense-in-depth for the retention gate), not an honest-RPC exploit — an honest Tenderly response omits `contractAddress` for native ETH. Patch changeset; no dependent bumps (leaf package, internal helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->