### PR TITLE
chore(blue-sdk-viem): deprecate getDaiPermitTypedData and DaiPermitArgs

### DIFF
--- a/.changeset/deprecate-dai-permit-typed-data.md
+++ b/.changeset/deprecate-dai-permit-typed-data.md
@@ -1,0 +1,6 @@
+---
+"@morpho-org/blue-sdk-viem": minor
+"@morpho-org/morpho-sdk": minor
+---
+
+Deprecate `getDaiPermitTypedData` and `DaiPermitArgs`. The SDK routes DAI approvals through Permit2 / classic approval internally — DAI's non-standard boolean permit (any positive `allowance` authorizes `type(uint256).max`, not the passed amount) is incompatible with the ERC-2612 simple-permit path — so this standalone helper is unused by every SDK flow. It stays exported for one more minor and will be removed in the next major; prefer the Permit2 flow. The `morpho-sdk` facade re-exports (`utils`, `/blue/utils`, `/blue/types`) carry the same `@deprecated` annotation.

--- a/packages/blue-sdk-viem/src/signatures/permit.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit.ts
@@ -120,7 +120,12 @@ export const getPermitTypedData = (
   };
 };
 
-/** Message fields for DAI-style permit typed data. */
+/**
+ * Message fields for DAI-style permit typed data.
+ *
+ * @deprecated Arguments for the deprecated {@link getDaiPermitTypedData}; DAI is
+ * routed through Permit2 internally. Scheduled for removal in the next major.
+ */
 export interface DaiPermitArgs {
   owner: Address;
   spender: Address;
@@ -141,6 +146,15 @@ const daiPermitTypes = {
 
 /**
  * Builds DAI-style permit typed data for signing.
+ *
+ * @deprecated Not used by any SDK flow — DAI approvals are routed through
+ * Permit2 / classic approval internally (DAI's non-standard permit is
+ * incompatible with the ERC-2612 simple-permit path). Prefer the Permit2 flow.
+ * Scheduled for removal in the next major.
+ *
+ * @remarks DAI's permit is **boolean**: any `allowance > 0n` authorizes the
+ * spender for `type(uint256).max`, not the passed amount — there is no
+ * finite-allowance DAI permit.
  *
  * @param args - DAI permit message fields.
  * @param chainId - Chain id whose DAI deployment verifies the signature.

--- a/packages/morpho-sdk/src/blue/types.ts
+++ b/packages/morpho-sdk/src/blue/types.ts
@@ -17,6 +17,7 @@ export type {
 } from "@morpho-org/blue-sdk";
 export type {
   AuthorizationArgs,
+  /** @deprecated Args for the deprecated getDaiPermitTypedData; scheduled for removal in the next major. */
   DaiPermitArgs,
   DeploylessFetchParameters,
   FetchParameters,

--- a/packages/morpho-sdk/src/blue/utils.ts
+++ b/packages/morpho-sdk/src/blue/utils.ts
@@ -15,6 +15,7 @@ export {
 export {
   decodeBytes32String,
   getAuthorizationTypedData,
+  /** @deprecated DAI is routed through Permit2 internally; scheduled for removal in the next major. */
   getDaiPermitTypedData,
   getPermit2PermitTypedData,
   getPermit2TransferFromTypedData,

--- a/packages/morpho-sdk/src/types.ts
+++ b/packages/morpho-sdk/src/types.ts
@@ -27,6 +27,7 @@ export type {
 } from "@morpho-org/blue-sdk";
 export type {
   AuthorizationArgs as BlueAuthorizationTypedDataArgs,
+  /** @deprecated Args for the deprecated getDaiPermitTypedData; scheduled for removal in the next major. */
   DaiPermitArgs,
   DeploylessFetchParameters as BlueDeploylessFetchParameters,
   /** @deprecated Use `BlueDeploylessFetchParameters` or the raw `/blue/types` subpath. */

--- a/packages/morpho-sdk/src/utils.ts
+++ b/packages/morpho-sdk/src/utils.ts
@@ -23,6 +23,7 @@ export {
   getAuthorizationTypedData as getBlueAuthorizationTypedData,
   /** @deprecated Use getBlueAuthorizationTypedData or the raw protocol subpath. */
   getAuthorizationTypedData,
+  /** @deprecated DAI is routed through Permit2 internally; scheduled for removal in the next major. */
   getDaiPermitTypedData,
   getPermit2PermitTypedData,
   getPermit2TransferFromTypedData,


### PR DESCRIPTION
## What

Cantina AI SDKs Scan #1 **SDKS-142** flagged that `getDaiPermitTypedData` maps any positive `allowance: bigint` to DAI's boolean `allowed: true`, which on-chain authorizes `type(uint256).max` — a finite requested approval silently becomes unlimited.

That behavior is **faithful to DAI's permit ABI** (there is no finite-allowance DAI permit), and the SDK **never uses this helper**: `getGeneralAdapterRequirements` detects DAI and routes it through Permit2 / classic approval because its non-standard permit is incompatible with the ERC-2612 simple-permit path. The helper is a standalone public re-export only.

Rather than a hard removal (which would be a breaking change outside a major, against §7), this **deprecates** it — the §7-compliant first step. Removal will follow in the next major.

## Change

- `@deprecated` on `getDaiPermitTypedData` and `DaiPermitArgs` in `blue-sdk-viem`, with an `@remarks` documenting the boolean-permit footgun and the Permit2-routing rationale.
- Same annotation mirrored on the `morpho-sdk` facade re-exports (`utils`, `/blue/utils`, `/blue/types`) — the §4 facade audit.
- Minor changeset for both packages (deprecations are minor per §7).

## Verification

- Typecheck green (`blue-sdk-viem`, `morpho-sdk`).
- Facade parity test `protocolFacades.test.ts` (37/37) and `signatures.test.ts` (8/8) still green — no runtime/behavior change.

## Note

This supersedes a hard delete: removing a public symbol requires a major bump and the 4-step deprecation flow (§7). Ready to schedule the actual removal for the next major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->