### PR TITLE
fix(morpho-sdk): address Blue refinance review

### DIFF
--- a/.changeset/blue-bundles-refinance.md
+++ b/.changeset/blue-bundles-refinance.md
@@ -4,11 +4,10 @@
 
 Route the established Blue refinance flow through BlueBundlesV1 as a full compatible-position
 migration. Replace partial migration inputs while preserving the method and builder names.
-`userAddress` must be the account that signs the Morpho authorization and sends the transaction:
-the migration operates on the `msg.sender` position, so on-behalf refinance is no longer supported.
-The route rejects a reallocation plan whose rounded aggregate penalty exceeds the migrated source
-debt (`InputExceedsMaxError`), matching the borrow and withdraw BlueBundlesV1 caps. The v5
-partial-migration error classes (`BorrowAmountAndSharesExclusiveError`,
+`userAddress` identifies the intended transaction sender and, when used, Morpho authorization
+signer. The migration operates on the `msg.sender` position, so on-behalf refinance is no longer
+supported. Builders cannot enforce this alignment because `userAddress` is not encoded in calldata.
+The v5 partial-migration error classes (`BorrowAmountAndSharesExclusiveError`,
 `RefinanceExceedsCollateralError`, `RefinanceExceedsBorrowSharesError`,
 `RefinanceExceedsBorrowAssetsError`, `RefinanceSharesMissingBorrowAssetsError`) are deprecated rather
 than removed and stay exported through v6 for pattern-matching consumers.

--- a/packages/morpho-sdk/MIGRATION-v5-to-v6.md
+++ b/packages/morpho-sdk/MIGRATION-v5-to-v6.md
@@ -134,12 +134,13 @@ the full live source debt and collateral always move, the source and destination
 same loan and collateral tokens and must not be the same market, and Morpho authorization targets
 BlueBundlesV1.
 
-`userAddress` must be the account that signs the Morpho authorization **and** sends the transaction.
-The BlueBundlesV1 migration calldata carries no owner field: it migrates the position of the
-authorization signer, which the contract binds to `msg.sender`. Unlike the v5 Bundler3 route (where
-`args.user` was encoded as `onBehalf` in every leg), a relayer can no longer migrate a third party's
-position — supplying a `userAddress` other than the sender reverts on-chain. On-behalf refinance is no
-longer supported; the SDK uses `userAddress` only to build the authorization requirement and action
+`userAddress` must be the account that sends the transaction and, when used, signs the Morpho
+authorization. BlueBundlesV1 migration calldata carries no owner field and always migrates
+`msg.sender`; a supplied authorization signature is likewise bound to that sender. Unlike the v5
+Bundler3 route (where `args.user` was encoded as `onBehalf` in every leg), a relayer can no longer
+migrate a third party's position. Builders cannot enforce that `userAddress` matches the sender; a
+mismatch does not itself revert, and BlueBundlesV1 still migrates `msg.sender`. The SDK uses
+`userAddress` only to validate snapshots, build the authorization requirement, and populate action
 metadata.
 
 `market.refinance(...)` (entity method):
@@ -171,10 +172,10 @@ The partial-migration error classes `BorrowAmountAndSharesExclusiveError`,
 `RefinanceExceedsBorrowAssetsError`, and `RefinanceSharesMissingBorrowAssetsError` are **deprecated,
 not removed**: they stay exported through v6 (marked `@deprecated`) for consumers pattern-matching on
 the v5 surface, are never thrown by the full-position route, and are removed in the next major. The
-full-position route validates ownership and token/market compatibility, rejects a reallocation plan
-whose rounded aggregate penalty exceeds the migrated source debt (`InputExceedsMaxError`), then checks
-the combined destination position against the buffered LLTV (`BorrowExceedsSafeLtvError`);
-`RefinanceSameMarketError` and `RefinanceTokenMismatchError` stay.
+full-position route validates snapshot ownership and token/market compatibility, accounts for
+reallocation penalties in destination debt, then checks the combined destination position against
+the buffered LLTV (`BorrowExceedsSafeLtvError`); `RefinanceSameMarketError` and
+`RefinanceTokenMismatchError` stay.
 
 ## Removed action-output field: `reallocationFee`
 

--- a/packages/morpho-sdk/src/actions/AGENTS.md
+++ b/packages/morpho-sdk/src/actions/AGENTS.md
@@ -48,9 +48,10 @@ chain registry supplies the allocator, and each call passes the vault's configur
 `penalty` — the allocator donates `ceil(assets × penalty / WAD)` of the target loan token per call.
 BluePublicAllocator sources are not sorted and idle uses no synthetic zero-address
 market. BlueBundlesV1 executes every allocation unconditionally; aggregate penalties reduce borrow
-or withdrawal proceeds, or increase destination debt during migration, and the builder rejects an
-aggregate penalty above `borrowAssets` (or, in withdraw assets mode, the withdrawn amount). They do
-not add native value or a separate GeneralAdapter1 funding requirement.
+or withdrawal proceeds, and those builders reject an aggregate penalty above `borrowAssets` (or, in
+withdraw assets mode, the withdrawn amount). Migration instead adds penalties to destination debt,
+which the entity health check and encoded `maxLtv` bound. Penalties do not add native value or a
+separate GeneralAdapter1 funding requirement.
 
 PublicAllocator V1 types, data fetchers, simulations, planners, and low-level Bundler3 builders
 remain public only for compatibility and advanced composition. All Vault V1 planning and low-level

--- a/packages/morpho-sdk/src/actions/blue/refinance.ts
+++ b/packages/morpho-sdk/src/actions/blue/refinance.ts
@@ -31,9 +31,9 @@ export interface BlueRefinanceParams {
   /** Direct BlueBundlesV1 full-position migration arguments. */
   readonly args: {
     /**
-     * User whose live source borrow position is migrated. Must also sign the Morpho authorization and
-     * send the transaction: BlueBundlesV1 migrates the signer's position (bound to `msg.sender`), so
-     * on-behalf refinance by a relayer is not supported.
+     * Intended user used to bind an optional Morpho authorization and action metadata. This value is
+     * not encoded; the caller must send from the same account because BlueBundlesV1 always migrates
+     * `msg.sender`.
      */
     readonly userAddress: Address;
     /** Maximum destination LTV enforced by BlueBundlesV1. */
@@ -64,9 +64,9 @@ export interface BlueRefinanceParams {
  * @param params.market.chainId - Chain containing BlueBundlesV1.
  * @param params.market.sourceMarketParams - Source market scoped by the Blue entity.
  * @param params.market.destinationMarketParams - Distinct compatible destination market.
- * @param params.args.userAddress - User whose live position is migrated; must sign the Morpho
- *   authorization and send the transaction (BlueBundlesV1 migrates the `msg.sender` position, so
- *   on-behalf refinance is unsupported).
+ * @param params.args.userAddress - Intended user used to bind an optional Morpho authorization and
+ *   action metadata. This value is not encoded; the caller must send from the same account because
+ *   BlueBundlesV1 always migrates `msg.sender`.
  * @param params.args.maxLtv - Maximum destination LTV.
  * @param params.args.reallocations - Vault V2 reallocations into the destination.
  * @param params.args.deadline - Final call deadline in Unix seconds.

--- a/packages/morpho-sdk/src/entities/blue/blue.refinance.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.refinance.test.ts
@@ -87,21 +87,25 @@ describe("MorphoBlue.refinance", () => {
     });
   });
 
-  test("error: NonPositiveInputError when the source has no debt", () => {
-    expect(() =>
-      makeEntity().refinance({
-        userAddress,
-        positionData: makePosition(sourceMarketParams, {
-          collateral: 10n ** 18n,
+  test.each([{ borrowShares: 0n }, { borrowShares: -1n }])(
+    "error: NonPositiveInputError when source borrow shares are $borrowShares",
+    ({ borrowShares }) => {
+      expect(() =>
+        makeEntity().refinance({
+          userAddress,
+          positionData: makePosition(sourceMarketParams, {
+            borrowShares,
+            collateral: 10n ** 18n,
+          }),
+          destination: {
+            marketParams: destinationMarketParams,
+            positionData: makePosition(destinationMarketParams),
+          },
+          deadline: maxUint256,
         }),
-        destination: {
-          marketParams: destinationMarketParams,
-          positionData: makePosition(destinationMarketParams),
-        },
-        deadline: maxUint256,
-      }),
-    ).toThrow(NonPositiveInputError);
-  });
+      ).toThrow(NonPositiveInputError);
+    },
+  );
 
   test("error: RefinanceSameMarketError", () => {
     const source = makePosition(sourceMarketParams, {
@@ -121,27 +125,40 @@ describe("MorphoBlue.refinance", () => {
     ).toThrow(RefinanceSameMarketError);
   });
 
-  test("error: RefinanceTokenMismatchError", () => {
-    const mismatchedMarketParams = new MarketParams({
-      loanToken: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-      collateralToken: destinationMarketParams.collateralToken,
-      oracle: destinationMarketParams.oracle,
-      irm: destinationMarketParams.irm,
-      lltv: destinationMarketParams.lltv,
-    });
-    expect(() =>
-      makeEntity().refinance({
-        userAddress,
-        positionData: makePosition(sourceMarketParams, {
-          borrowShares: 1n,
-          collateral: 10n ** 18n,
+  test.each([
+    {
+      field: "loanToken",
+      value: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    },
+    {
+      field: "collateralToken",
+      value: "0x0000000000000000000000000000000000000099",
+    },
+  ] as const)(
+    "error: RefinanceTokenMismatchError for $field",
+    ({ field, value }) => {
+      const mismatchedMarketParams = new MarketParams({
+        loanToken: destinationMarketParams.loanToken,
+        collateralToken: destinationMarketParams.collateralToken,
+        oracle: destinationMarketParams.oracle,
+        irm: destinationMarketParams.irm,
+        lltv: destinationMarketParams.lltv,
+        [field]: value,
+      });
+      expect(() =>
+        makeEntity().refinance({
+          userAddress,
+          positionData: makePosition(sourceMarketParams, {
+            borrowShares: 1n,
+            collateral: 10n ** 18n,
+          }),
+          destination: {
+            marketParams: mismatchedMarketParams,
+            positionData: makePosition(mismatchedMarketParams),
+          },
+          deadline: maxUint256,
         }),
-        destination: {
-          marketParams: mismatchedMarketParams,
-          positionData: makePosition(mismatchedMarketParams),
-        },
-        deadline: maxUint256,
-      }),
-    ).toThrow(RefinanceTokenMismatchError);
-  });
+      ).toThrow(RefinanceTokenMismatchError);
+    },
+  );
 });

--- a/packages/morpho-sdk/src/entities/blue/blue.test.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.test.ts
@@ -433,121 +433,6 @@ describe("MorphoBlue write surface", () => {
     expect(tx.action.args.assets).toBe(assets);
   });
 
-  test("target BlueBundlesV1 for token approval and Morpho authorization", async () => {
-    const handle = createMockClient(mainnet);
-    const blueBundlesV1 = getChainAddress(mainnet.id, "bundles.blueBundlesV1");
-    mockRead(handle, {
-      address: marketParams.loanToken,
-      abi: erc20Abi,
-      functionName: "allowance",
-      result: 0n,
-    });
-    mockRead(handle, {
-      address: getChainAddress(mainnet.id, "morpho"),
-      abi: blueAbi,
-      functionName: "isAuthorized",
-      result: false,
-    });
-    const entity = handle.client
-      .extend(morphoViemExtension({ supportSignature: false }))
-      .morpho.blue(marketParams, mainnet.id);
-
-    const tokenRequirements = await entity
-      .supply({
-        userAddress,
-        assets: 1n,
-        deadline: maxUint256,
-      })
-      .getRequirements();
-    const authorizationRequirements = await entity
-      .withdraw({
-        userAddress,
-        positionData: makePosition(marketParams, {
-          borrowShares: 0n,
-          supplyShares: 10n ** 18n,
-        }),
-        assets: 1n,
-        deadline: maxUint256,
-      })
-      .getRequirements();
-
-    expect(tokenRequirements).toMatchObject([
-      {
-        action: {
-          type: "erc20Approval",
-          args: { spender: blueBundlesV1 },
-        },
-      },
-    ]);
-    expect(authorizationRequirements).toMatchObject([
-      {
-        action: {
-          type: "blueAuthorization",
-          args: { authorized: blueBundlesV1, isAuthorized: true },
-        },
-      },
-    ]);
-  });
-
-  test("supply forwards a reusable approvalAmount to the token requirement", async () => {
-    const handle = createMockClient(mainnet);
-    const blueBundlesV1 = getChainAddress(mainnet.id, "bundles.blueBundlesV1");
-    mockRead(handle, {
-      address: marketParams.loanToken,
-      abi: erc20Abi,
-      functionName: "allowance",
-      result: 0n,
-    });
-    const market = handle.client
-      .extend(morphoViemExtension({ supportSignature: false }))
-      .morpho.blue(marketParams, mainnet.id);
-
-    const requirements = await market
-      .supply({ assets: 1n, userAddress, deadline: maxUint256 })
-      .getRequirements({ approvalAmount: maxUint256 });
-
-    expect(requirements).toMatchObject([
-      {
-        action: {
-          type: "erc20Approval",
-          args: { spender: blueBundlesV1, amount: maxUint256 },
-        },
-      },
-    ]);
-  });
-
-  test("supply funds a wrapped-native market with tx value and no requirements", async () => {
-    const nativeMarketParams = new MarketParams({
-      loanToken: getChainAddress(mainnet.id, "wNative"),
-      collateralToken: marketParams.collateralToken,
-      oracle: marketParams.oracle,
-      irm: marketParams.irm,
-      lltv: marketParams.lltv,
-    });
-    const market = createMockClient(mainnet)
-      .client.extend(morphoViemExtension())
-      .morpho.blue(nativeMarketParams, mainnet.id);
-
-    const assets = 10n ** 18n;
-    const action = market.supply({
-      userAddress,
-      assets,
-      nativeAmount: assets,
-      deadline: maxUint256,
-    });
-
-    // The native branch short-circuits before any on-chain read: it emits no
-    // token approval/permit (and no Morpho authorization), rides the funded
-    // amount as `tx.value`, and leaves the encoded token permit empty. A
-    // regression that dropped the branch would demand a token requirement or
-    // omit the value, and would revert on-chain rather than fail here.
-    expect(await action.getRequirements()).toEqual([]);
-    const tx = action.buildTx();
-    expect(tx.value).toBe(assets);
-    expect(tx.action.args.nativeAmount).toBe(assets);
-    expect(tx.action.args.assets).toBe(assets);
-  });
-
   test("repay forwards a reusable approvalAmount to the token requirement", async () => {
     const handle = createMockClient(mainnet);
     const blueBundlesV1 = getChainAddress(mainnet.id, "bundles.blueBundlesV1");
@@ -828,15 +713,9 @@ describe("MorphoBlue position validation", () => {
     ).toThrow(BorrowExceedsSafeLtvError);
   });
 
-  test("error: InputExceedsMaxError when the migration penalty exceeds current source debt", () => {
-    const now = 1_800_000_000n;
+  test("behavior: migration accepts a penalty above current source debt when healthy", () => {
     const entity = makeEntity();
-    // Interest-bearing source: the current quoted debt is strictly below the `now + 2h` health
-    // projection the method uses elsewhere, so a penalty just above the current debt lands between
-    // the two figures. The cap must bind against the current quote, not the forecast, to reject it.
     const sourcePosition = makePosition(marketParams, {
-      lastUpdate: now - 5n * 24n * 3_600n,
-      rateAtTarget: 3_170_979_198n,
       collateral: 10n ** 24n,
     });
     const destinationPosition = makePosition(destinationMarketParams, {
@@ -844,11 +723,6 @@ describe("MorphoBlue position validation", () => {
       collateral: 0n,
     });
     const currentDebt = sourcePosition.borrowAssets;
-    const forecastDebt = sourcePosition.accrueInterest(
-      now + 7_200n,
-    ).borrowAssets;
-    // Guard the fixture: the penalty sits in the (current, forecast] gap the bug would have missed.
-    expect(forecastDebt).toBeGreaterThan(currentDebt + 1n);
     // penaltyAssets = ceil(assets × penalty / WAD) = currentDebt + 1n with penalty = 100%.
     const reallocation = {
       vault: "0x0000000000000000000000000000000000000031",
@@ -859,19 +733,17 @@ describe("MorphoBlue position validation", () => {
     } satisfies VaultV2BlueReallocation;
 
     expect(() =>
-      withChainTimestamp(now, () =>
-        entity.refinance({
-          userAddress,
-          positionData: sourcePosition,
-          destination: {
-            marketParams: destinationMarketParams,
-            positionData: destinationPosition,
-          },
-          reallocations: [reallocation],
-          deadline: maxUint256,
-        }),
-      ),
-    ).toThrow(InputExceedsMaxError);
+      entity.refinance({
+        userAddress,
+        positionData: sourcePosition,
+        destination: {
+          marketParams: destinationMarketParams,
+          positionData: destinationPosition,
+        },
+        reallocations: [reallocation],
+        deadline: maxUint256,
+      }),
+    ).not.toThrow();
   });
 
   test("error: WithdrawMakesPositionUnhealthyError after collateral withdrawal", () => {

--- a/packages/morpho-sdk/src/entities/blue/blue.ts
+++ b/packages/morpho-sdk/src/entities/blue/blue.ts
@@ -814,10 +814,9 @@ export interface BlueActions {
    * complete position is checked against buffered LLTV. Partial and collateral-only migration are
    * unsupported.
    *
-   * @param params.userAddress - Owner of both source and destination positions. It must also sign the
-   *   Morpho authorization and send the transaction: BlueBundlesV1 migrates the signer's position
-   *   (bound to `msg.sender`), so on-behalf refinance by a relayer is not supported and a mismatched
-   *   sender reverts on-chain.
+   * @param params.userAddress - Intended owner used to validate both snapshots and resolve Morpho
+   *   authorization. It must also send the transaction: the builder cannot enforce this alignment
+   *   because this field is not encoded and BlueBundlesV1 always migrates `msg.sender`.
    * @param params.positionData - Pre-fetched source position with nonzero debt.
    * @param params.destination.marketParams - Distinct destination market with matching tokens.
    * @param params.destination.positionData - User's pre-fetched destination position.
@@ -837,8 +836,7 @@ export interface BlueActions {
    * @throws {MissingMarketPriceError} when destination health cannot be validated without an oracle price.
    * @throws {BorrowExceedsSafeLtvError} when the complete destination exceeds buffered LLTV.
    * @throws {ExpiredDeadlineError} when the deadline is stale.
-   * @throws {InputExceedsMaxError} when a fee or reallocation exceeds its ABI bound, or the rounded
-   *   aggregate reallocation penalty exceeds the migrated source debt.
+   * @throws {InputExceedsMaxError} when a fee or reallocation exceeds its ABI bound.
    * @throws {MissingReferralFeeRecipientError} when a positive fee has no recipient.
    * @throws {InvalidReallocationAddressError} when a vault or adapter address is malformed.
    * @throws {InvalidReallocationShapeError} when a reallocation entry is not a valid Vault V2 reallocation.
@@ -1925,7 +1923,7 @@ export class MorphoBlue implements BlueActions {
       expectedMarketId: this.marketParams.id,
       expectedUser: userAddress,
     });
-    if (positionData.borrowShares === 0n) {
+    if (positionData.borrowShares <= 0n) {
       throw new NonPositiveInputError(
         "positionData.borrowShares",
         positionData.borrowShares,
@@ -1964,21 +1962,6 @@ export class MorphoBlue implements BlueActions {
       destination.marketParams,
     );
     const penaltyAssets = getBlueBundlesV1PenaltyAssets(publicAllocations);
-    // Reject a reallocation plan whose rounded aggregate penalty exceeds the current source debt,
-    // matching the `blueBorrow`/`blueWithdraw` BlueBundlesV1 caps. Bound against the current quoted
-    // debt, not the conservative `now + 2h` health projection below: the on-chain call migrates the
-    // debt live at execution (>= the current quote), so the current quote is the safe floor. Using
-    // the forward projection would let a penalty between the current and forecast debt pass while
-    // still exceeding the debt actually moved, and the health check only adds the penalty to
-    // destination debt, so a collateralized position would silently accept it or encode a reverting
-    // call.
-    if (penaltyAssets > positionData.borrowAssets) {
-      throw new InputExceedsMaxError({
-        field: "reallocationPenaltyAssets",
-        value: penaltyAssets,
-        max: positionData.borrowAssets,
-      });
-    }
     const accrualTimestamp = this.getBlueBundlesV1QuoteTimestamp(
       MathLib.max(
         positionData.market.lastUpdate,

--- a/packages/morpho-sdk/test/entities/blue/blueBundlesV1.integration.test.ts
+++ b/packages/morpho-sdk/test/entities/blue/blueBundlesV1.integration.test.ts
@@ -1479,7 +1479,7 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
   );
 
   baseTest(
-    "refinance: a Vault V2 reallocation penalty and referral fee increase destination debt",
+    "refinance: an above-debt Vault V2 penalty and referral fee increase destination debt",
     async ({ client }) => {
       const anvilClient = client as AnvilTestClient;
       const { morpho, vaultV2BluePublicAllocator: allocator } =
@@ -1487,7 +1487,7 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
       assert(allocator != null);
       const depositAssets = parseUnits("100", 6);
       const destinationLiquidity = parseUnits("20", 6);
-      const penalty = MathLib.WAD / 100n;
+      const penalty = MathLib.WAD / 10n;
       const relativeCap = MathLib.WAD / 2n;
       const referralFeePct = MathLib.WAD / 100n;
       const sourceCollateral = parseUnits("1", 18);
@@ -1708,10 +1708,10 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
         requirements: await action.getRequirements(),
       });
       const transaction = action.buildTx(signatures);
-      // The single reallocation and its positive penalty are recorded in the built action.
+      // The single reallocation and its above-source-debt penalty are recorded in the built action.
       expect(transaction.action.args.reallocations).toBe(1);
       expect(transaction.action.args.reallocationPenaltyAssets).toBeGreaterThan(
-        0n,
+        sourcePositionData.borrowAssets,
       );
       expect(transaction.action.args.referralFeePct).toBe(referralFeePct);
       await client.sendTransaction(transaction);


### PR DESCRIPTION
## Motivation

Address the five local review findings for #990 in an isolated stacked change.

## Solution

- remove the refinance-only cap that rejected valid penalty-bearing migrations while retaining destination health and `maxLtv` protection
- reject nonpositive source borrow shares and cover both token-mismatch branches
- clarify that `userAddress` is not encoded and sender alignment is caller-enforced
- remove duplicated tests and add regression coverage for penalties above source debt
- synchronize the changeset, migration guide, and action-layer guidance

## Validation

- `pnpm --config.verify-deps-before-run=false lint`
- `pnpm --filter @morpho-org/morpho-sdk exec tsc --noEmit`
- Morpho SDK unit project: 83 files, 974 tests passed
- focused refinance tests: 2 files, 30 tests passed

The fork project was attempted but could not initialize without `MAINNET_RPC_URL`; the fallback RPC also returned HTTP 504.
