### PR TITLE
fix(morpho-sdk): address BlueBundles supply and withdraw review

### DIFF
--- a/.changeset/deprecate-v1-blue-reallocations.md
+++ b/.changeset/deprecate-v1-blue-reallocations.md
@@ -1,9 +1,0 @@
----
-"@morpho-org/morpho-sdk": minor
-"@morpho-org/wdk-protocol-lending-morpho-evm": minor
----
-
-Publish the pinned BlueBundlesV1 ABI and deprecate all Vault V1 shared-liquidity algorithm and
-Bundler3 composition surfaces in Morpho SDK, plus the WDK Vault V1 borrow input. Use Vault V2
-BluePublicAllocator reallocations for new integrations; all deprecated Vault V1 surfaces will be
-removed in the next major.

--- a/.changeset/fix-arc-explorer-url.md
+++ b/.changeset/fix-arc-explorer-url.md
@@ -1,5 +1,0 @@
----
-"@morpho-org/morpho-ts": patch
----
-
-Fix malformed `explorerUrl` values in `ChainUtils.CHAIN_METADATA`. Arc mainnet (5042) pointed at `http://explorer.arc.io/`, the only non-HTTPS explorer of the 43 registered chains, so every link built from it was an insecure navigation out of an HTTPS app. It is now `https://explorer.arc.io`. The trailing slash is also dropped from Tac, Celo, Abstract and Soneium so all 43 entries match the bare-origin convention and consumers concatenating `/tx/<hash>` or `/address/<addr>` no longer produce a double slash.

--- a/.changeset/permit2-signature-transfer-uint256.md
+++ b/.changeset/permit2-signature-transfer-uint256.md
@@ -1,7 +1,0 @@
----
-"@morpho-org/blue-sdk-viem": patch
-"@morpho-org/morpho-sdk": patch
----
-
-Clamp Permit2 SignatureTransfer allowances to the full uint256 range instead of the uint160
-AllowanceTransfer limit.

--- a/docs/jsdoc-style.md
+++ b/docs/jsdoc-style.md
@@ -113,7 +113,7 @@ Rules for examples:
  * @example
  * ```ts
  * import { vaults } from "@morpho-org/morpho-test";
- * import { createPublicClient, http } from "viem";
+ * import { createPublicClient, http, zeroAddress } from "viem";
  * import { mainnet } from "viem/chains";
  * import { morphoViemExtension } from "@morpho-org/morpho-sdk";
  *
@@ -123,7 +123,7 @@ Rules for examples:
  * const vault = client.morpho.vaultV1(vaults[mainnet.id].steakUsdc.address, mainnet.id);
  * const vaultData = await vault.getData();
  * const { buildTx } = vault.deposit({
- *   userAddress: depositor,
+ *   userAddress: zeroAddress,
  *   amount: 1_000_000n,
  *   vaultData,
  * });
@@ -214,6 +214,7 @@ What's wrong:
  * @example
  * ```ts
  * import { vaults } from "@morpho-org/morpho-test";
+ * import { zeroAddress } from "viem";
  * import { mainnet } from "viem/chains";
  * import { vaultV1Deposit } from "@morpho-org/morpho-sdk";
  *
@@ -223,7 +224,7 @@ What's wrong:
  *   args: {
  *     amount: 1_000_000n,
  *     maxSharePrice: 1_010_000_000_000_000_000_000_000_000n,
- *     recipient: depositor,
+ *     recipient: zeroAddress,
  *   },
  * });
  * // tx satisfies Readonly<Transaction<VaultV1DepositAction>>

--- a/packages/morpho-sdk/src/actions/blue/common.test.ts
+++ b/packages/morpho-sdk/src/actions/blue/common.test.ts
@@ -30,8 +30,8 @@ import {
   selectBlueBundlesV1RequirementSignatures,
 } from "./common.js";
 
-const owner = getAddress("0x00000000000000000000000000000000000000a1");
-const spender = getAddress("0x00000000000000000000000000000000000000b1");
+const owner = getAddress("0x00000000000000000000000000000000000000A1");
+const spender = getAddress("0x00000000000000000000000000000000000000B1");
 const asset = getAddress("0x0000000000000000000000000000000000000011");
 
 const permit = {

--- a/packages/morpho-sdk/src/actions/requirements/blue/getBlueAuthorizationRequirement.ts
+++ b/packages/morpho-sdk/src/actions/requirements/blue/getBlueAuthorizationRequirement.ts
@@ -73,12 +73,12 @@ import { encodeBlueSignatureAuthorization } from "../encode/encodeBlueSignatureA
  * ```
  */
 export const getBlueAuthorizationRequirement = async (params: {
-  viemClient: Client;
-  chainId: number;
-  userAddress: Address;
-  supportSignature?: boolean;
-  authorized?: Address;
-  deadline?: bigint;
+  readonly viemClient: Client;
+  readonly chainId: number;
+  readonly userAddress: Address;
+  readonly supportSignature?: boolean;
+  readonly authorized?: Address;
+  readonly deadline?: bigint;
 }): Promise<
   | Readonly<Transaction<BlueAuthorizationAction>>
   | Requirement<AuthorizationRequirementSignature>

--- a/packages/morpho-sdk/src/actions/requirements/blue/getUnusedPermit2Nonce.ts
+++ b/packages/morpho-sdk/src/actions/requirements/blue/getUnusedPermit2Nonce.ts
@@ -40,6 +40,7 @@ const MAX_PERMIT2_NONCE_WORD = maxUint256 >> 8n;
  * @throws {InputExceedsMaxError} when `startNonce` exceeds `uint256`.
  * @throws {UnsupportedChainIdError} when the chain is absent from the address registry.
  * @throws {UnknownAddressError} when the chain has no registered canonical Permit2 deployment.
+ * @throws {viem.BaseError} when a Permit2 nonce-bitmap RPC read fails.
  * @throws {NoUnusedPermit2NonceError} when every nonce at or after `startNonce` is consumed.
  * @example
  * ```ts

--- a/packages/morpho-sdk/src/types/action.ts
+++ b/packages/morpho-sdk/src/types/action.ts
@@ -864,13 +864,13 @@ export function isMidnightOfferRootSignature(
 /** The typed requirement-signature slots a transaction builder consumes, split from a `buildTx` array. */
 export interface SelectedRequirementSignatures {
   /** The single ERC-2612 or Permit2 AllowanceTransfer signature, when present. */
-  permit?: PermitRequirementSignature;
+  readonly permit?: PermitRequirementSignature;
   /** The single Permit2 SignatureTransfer signature, when present. */
-  permit2TransferFrom?: Permit2TransferFromRequirementSignature;
+  readonly permit2TransferFrom?: Permit2TransferFromRequirementSignature;
   /** The single Morpho authorization signature, when present. */
-  authorization?: AuthorizationRequirementSignature;
+  readonly authorization?: AuthorizationRequirementSignature;
   /** The single Midnight offer-root signature, when present. */
-  midnightOfferRoot?: MidnightOfferRootSignature;
+  readonly midnightOfferRoot?: MidnightOfferRootSignature;
 }
 
 /**

--- a/packages/morpho-sdk/test/entities/blue/blueBundlesV1.integration.test.ts
+++ b/packages/morpho-sdk/test/entities/blue/blueBundlesV1.integration.test.ts
@@ -27,7 +27,11 @@ import {
   isRequirementBlueAuthorization,
   morphoViemExtension,
 } from "../../../src/index.js";
-import { CbbtcUsdcBlue, WethUsdsBlue } from "../../fixtures/blue.js";
+import {
+  CbbtcUsdcBlue,
+  WethUsdsBlue,
+  WstethWethBlue,
+} from "../../fixtures/blue.js";
 import { borrow, supplyCollateral, supplyLoan } from "../../helpers/blue.js";
 import {
   satisfyBlueBundlesV1Requirements,
@@ -167,13 +171,50 @@ describe("BlueBundlesV1 Blue writes", () => {
     );
   });
 
+  test("supply: executes with native funding without retaining assets", async ({
+    client,
+  }) => {
+    const amount = parseUnits("1", 18);
+    await client.setBalance({
+      address: client.account.address,
+      value: amount * 2n,
+    });
+
+    const market = client
+      .extend(morphoViemExtension())
+      .morpho.blue(WstethWethBlue, mainnet.id);
+    const beforePosition = await market.getPositionData(client.account.address);
+    const beforeBalances = await getBlueBundlesBalances(client, [
+      WstethWethBlue,
+    ]);
+    const action = market.supply({
+      userAddress: client.account.address,
+      assets: amount,
+      nativeAmount: amount,
+      deadline: maxUint256,
+    });
+
+    expect(await action.getRequirements()).toEqual([]);
+    const transaction = action.buildTx();
+    expect(transaction.value).toBe(amount);
+    await client.sendTransaction(transaction);
+
+    const afterPosition = await market.getPositionData(client.account.address);
+    expect(afterPosition.supplyShares).toBeGreaterThan(
+      beforePosition.supplyShares,
+    );
+    expect(await getBlueBundlesBalances(client, [WstethWethBlue])).toEqual(
+      beforeBalances,
+    );
+  });
+
   test("supply: carves the referral fee to the recipient", async ({
     client,
   }) => {
     const amount = parseUnits("1000", 6);
     const referralFeePct = MathLib.WAD / 100n;
     const referralFeeRecipient = getAddress(
-      "0x000000000000000000000000000000000000dead",
+      "0x000000000000000000000000000000000000dEaD",
     );
     await client.deal({ erc20: CbbtcUsdcBlue.loanToken, amount });
 
@@ -336,7 +377,7 @@ describe("BlueBundlesV1 Blue writes", () => {
     const supplied = parseUnits("1000", 6);
     const referralFeePct = MathLib.WAD / 100n;
     const referralFeeRecipient = getAddress(
-      "0x000000000000000000000000000000000000dead",
+      "0x000000000000000000000000000000000000dEaD",
     );
     await supplyLoan({
       client,
@@ -708,9 +749,9 @@ describe("BlueBundlesV1 Blue writes", () => {
 });
 
 describe("BlueBundlesV1 Vault V2 reallocations", () => {
-  baseTest(
-    "borrow: executes market and idle reallocations through live Base contracts",
-    async ({ client }) => {
+  baseTest.for(["borrow", "withdraw"] as const)(
+    "%s: executes market and idle reallocations through live Base contracts",
+    async (operation, { client }) => {
       const anvilClient = client as AnvilTestClient;
       const { morpho, vaultV2BluePublicAllocator: allocator } =
         getChainAddresses(base.id);
@@ -718,7 +759,7 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
       const sourceDepositAssets = parseUnits("100", 6);
       const initialIdleAssets = parseUnits("20", 6);
       const penalty = MathLib.WAD / 100n;
-      const borrowAssets = parseUnits("2", 6);
+      const operationAssets = parseUnits("2", 6);
 
       for (const marketParams of [baseSourceMarket, baseTargetMarket]) {
         const marketState = await readContractRestructured(client, {
@@ -878,12 +919,21 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
         functionName: "decreaseRelativeCap",
         args: [sharedCapId, (MathLib.WAD * 9n) / 10n],
       });
-      await supplyCollateral({
-        client: anvilClient,
-        chainId: base.id,
-        market: baseTargetMarket,
-        collateralAmount: parseUnits("1", 18),
-      });
+      if (operation === "borrow") {
+        await supplyCollateral({
+          client: anvilClient,
+          chainId: base.id,
+          market: baseTargetMarket,
+          collateralAmount: parseUnits("1", 18),
+        });
+      } else {
+        await supplyLoan({
+          client: anvilClient,
+          chainId: base.id,
+          market: baseTargetMarket,
+          supplyAmount: operationAssets * 2n,
+        });
+      }
 
       const market = client
         .extend(morphoViemExtension())
@@ -910,6 +960,7 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
         0n,
       );
       expect(totalPenaltyAssets).toBeGreaterThan(0n);
+      expect(totalPenaltyAssets).toBeLessThan(operationAssets);
 
       const positionData = await market.getPositionData(client.account.address);
       const [
@@ -917,6 +968,7 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
         targetPositionBefore,
         vaultBalanceBefore,
         bundleBalancesBefore,
+        userBalanceBefore,
       ] = await Promise.all([
         readContractRestructured(client, {
           address: morpho,
@@ -938,25 +990,46 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
           baseSourceMarket,
           baseTargetMarket,
         ]),
+        client.balanceOf({
+          erc20: baseTargetMarket.loanToken,
+          owner: client.account.address,
+        }),
       ]);
-      const action = market.borrow({
-        userAddress: client.account.address,
-        positionData,
-        borrowAssets,
-        reallocations: discovery.reallocations,
-        deadline: maxUint256,
-      });
+      const action =
+        operation === "borrow"
+          ? market.borrow({
+              userAddress: client.account.address,
+              positionData,
+              borrowAssets: operationAssets,
+              reallocations: discovery.reallocations,
+              deadline: maxUint256,
+            })
+          : market.withdraw({
+              userAddress: client.account.address,
+              positionData,
+              assets: operationAssets,
+              reallocations: discovery.reallocations,
+              deadline: maxUint256,
+            });
       const signatures = await satisfyBlueBundlesV1Requirements(anvilClient, {
         requirements: await action.getRequirements(),
         approvalFundingToken: baseTargetMarket.loanToken,
       });
-      await client.sendTransaction(action.buildTx(signatures));
+      const transaction = action.buildTx(signatures);
+      expect(transaction.action.args.reallocations).toBe(
+        discovery.reallocations.length,
+      );
+      expect(transaction.action.args.reallocationPenaltyAssets).toBe(
+        totalPenaltyAssets,
+      );
+      await client.sendTransaction(transaction);
 
       const [
         positionAfter,
         sourcePositionAfter,
         targetPositionAfter,
         vaultBalanceAfter,
+        userBalanceAfter,
       ] = await Promise.all([
         market.getPositionData(client.account.address),
         readContractRestructured(client, {
@@ -975,9 +1048,22 @@ describe("BlueBundlesV1 Vault V2 reallocations", () => {
           erc20: baseTargetMarket.loanToken,
           owner: vault,
         }),
+        client.balanceOf({
+          erc20: baseTargetMarket.loanToken,
+          owner: client.account.address,
+        }),
       ]);
-      expect(positionAfter.borrowShares).toBeGreaterThan(
-        positionData.borrowShares,
+      if (operation === "borrow") {
+        expect(positionAfter.borrowShares).toBeGreaterThan(
+          positionData.borrowShares,
+        );
+      } else {
+        expect(positionAfter.supplyShares).toBeLessThan(
+          positionData.supplyShares,
+        );
+      }
+      expect(userBalanceAfter - userBalanceBefore).toBe(
+        operationAssets - totalPenaltyAssets,
       );
       expect(sourcePositionAfter.supplyShares).toBeLessThan(
         sourcePositionBefore.supplyShares,


### PR DESCRIPTION
## Motivation

Follow up on the BlueBundlesV1 supply/withdraw review before the parent `next` stack lands. The review found missing live coverage for native supply and allocator-backed withdrawal, plus mechanical release, documentation, and readonly-shape issues.

## Solution

- Add pinned-fork coverage for native WETH supply and Vault V2 reallocation withdrawal accounting.
- Make the touched public authorization and signature-selection shapes readonly.
- Document propagated Permit2 RPC errors and repair the runnable JSDoc examples.
- Checksum the affected address fixtures.
- Remove three changesets already consumed by the current `main` release.

## Validation

- `pnpm lint`
- `pnpm --filter @morpho-org/morpho-sdk exec tsc --noEmit`
- `pnpm test --run --project morpho-sdk` — 999 tests passed
- `pnpm test --run --project morpho-sdk-fork packages/morpho-sdk/test/entities/blue/blueBundlesV1.integration.test.ts` — 14 tests passed
- `pnpm jsdoc:coverage`
- `pnpm changeset status --since=origin/main`
