### PR TITLE
ci(publish): derive package tags from the published set, not HEAD^..HEAD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -319,6 +319,17 @@ jobs:
             fi
           done
 
+          # Record the bijection-verified release set (name + version) for the
+          # tag step. Package tags are derived from what is actually published
+          # here — anchored to these tarballs — rather than from a HEAD^..HEAD
+          # diff, which misses the release when publish runs on a later recovery
+          # commit (e.g. a workflow fix) instead of the version-bump commit.
+          published_manifest="${RUNNER_TEMP}/published-packages.txt"
+          : > "$published_manifest"
+          for name in "${!received_version[@]}"; do
+            printf '%s\t%s\n' "$name" "${received_version[$name]}" >> "$published_manifest"
+          done
+
           # Publish, skipping versions already on the registry (idempotent reruns).
           published=0
           for name in "${!received_version[@]}"; do
@@ -367,16 +378,20 @@ jobs:
           trap 'rm -f "$local_tags" "$remote_tags"; reset_origin_url' EXIT
 
           # Create package git tags after npm publish succeeds. This also
-          # recovers reruns after publish succeeded but tag push failed.
-          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
-            while IFS= read -r -d '' manifest; do
-              tag="$(
-                node scripts/release/compute-pending-tag.mjs "$manifest"
-              )"
-
-              if [ -z "$tag" ]; then
+          # recovers reruns after publish succeeded but tag push failed. The tag
+          # set is derived from the bijection-verified release set the publish
+          # step recorded (not a HEAD^..HEAD diff), so the released versions are
+          # tagged even when publish runs on a later recovery commit rather than
+          # the version-bump commit. The existence guards keep this idempotent
+          # and skip already-tagged (unchanged) packages.
+          published_manifest="${RUNNER_TEMP}/published-packages.txt"
+          if [ -f "$published_manifest" ]; then
+            while IFS=$'\t' read -r name version; do
+              if [ -z "$name" ] || [ -z "$version" ]; then
                 continue
               fi
+
+              tag="${name}-v${version}"
 
               if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
                 continue
@@ -387,7 +402,7 @@ jobs:
               fi
 
               git tag "$tag" -m "$tag"
-            done < <(git diff --name-only -z --diff-filter=ACMRT HEAD^ HEAD -- 'packages/*/package.json')
+            done < "$published_manifest"
           fi
 
           git tag --list | LC_ALL=C sort > "$local_tags"


### PR DESCRIPTION
## Why

The `Prepare package tags` step in `publish.yml` created package tags only for manifests changed in `git diff HEAD^ HEAD -- 'packages/*/package.json'` (via `compute-pending-tag.mjs`, which also returns nothing when the version equals `HEAD^`).

That assumes the publish job **runs on the version-bump commit**. When publish instead runs on a **later recovery commit** — e.g. a workflow fix landing on top of an already-bumped branch — the diff is empty:

- `npm publish` still succeeds (it is upstream of `has_tags`), so packages reach npm, **but**
- `has_tags=false` → the **Push package tags** step and the **GitHub releases** job are both skipped → released versions get **no git tags and no GitHub releases**.

This was reported by Devin on #1017, whose recovery shape (a workflow fix committed on top of `chore: version packages`) triggers it exactly.

## Fix

Derive the tag set from the **bijection-verified release set** the publish step already computes — the packed tarballs, validated name+version against source at `github.sha` — persisted to a per-job file (`${RUNNER_TEMP}/published-packages.txt`). The tag step reads that file instead of the `HEAD^..HEAD` diff.

- **Idempotent / unchanged-package-safe:** the existing local + remote tag-existence guards are unchanged. Unchanged stable packages already carry their remote tag → skipped; reruns skip already-created tags.
- **Normal flow unchanged:** the pack step already packs *all* non-private packages every run, so the received set = full set; deriving tags from it and skipping already-tagged versions produces the same tags as the old changed-subset logic on a normal version commit.
- **Recovery flow fixed:** released versions are now tagged and released regardless of which commit publish runs on.

## Scope / notes

- Only the tag-derivation is touched; the split-job pack/publish security boundary, provenance, and bijection checks are untouched.
- `scripts/release/compute-pending-tag.mjs` is **no longer referenced by any workflow** after this change (its unit test still runs). Left in place here; a separate cleanup should remove it (and its test) once this is on both `main` and `next`.

## Convergence with `next`

`next`'s release is blocked by the same `publish.yml` (via #1017). `next` cannot be reset to `main` to inherit the fix — it carries 7 pre-mode release changesets `main` does not have. So #1017 ports this **same** hardened `publish.yml` (byte-identical to this branch). Merging both leaves `next` and `main` with an identical workflow — no lasting divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->