### PR TITLE
fix(liquidity-sdk-viem): isolate reallocations by target

### DIFF
--- a/.changeset/quiet-targets-plan.md
+++ b/.changeset/quiet-targets-plan.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/liquidity-sdk-viem": patch
+---
+
+Isolate batched shared-liquidity planning to each target market's supplying vaults.

--- a/packages/liquidity-sdk-viem/src/loader.test.ts
+++ b/packages/liquidity-sdk-viem/src/loader.test.ts
@@ -11,6 +11,7 @@ import {
   metaMorphoFactoryAbi,
   vaultV1PublicAllocatorAbi,
 } from "@morpho-org/blue-sdk-viem";
+import { ReallocationData } from "@morpho-org/morpho-sdk/entities";
 import { BLUE_API_GRAPHQL_URL } from "@morpho-org/morpho-ts";
 import { createMockClient, type MockClientHandle } from "@morpho-org/test/mock";
 import nock from "nock";
@@ -26,7 +27,7 @@ import {
   zeroHash,
 } from "viem";
 import { mainnet } from "viem/chains";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { LiquidityLoader } from "./loader.js";
 
 const { morpho, vaultV1PublicAllocator, metaMorphoFactory } = getChainAddresses(
@@ -40,6 +41,7 @@ if (vaultV1PublicAllocator == null || metaMorphoFactory == null) {
 }
 
 const vault = "0x0000000000000000000000000000000000000aaa";
+const otherVault = "0x0000000000000000000000000000000000000bBB";
 const loanToken = "0x0000000000000000000000000000000000000101";
 const targetCollateralToken = "0x0000000000000000000000000000000000000202";
 const sourceCollateralToken = "0x0000000000000000000000000000000000000303";
@@ -72,6 +74,7 @@ type ContractRead = {
 };
 
 type LoaderMockOptions = {
+  readonly additionalVaults?: readonly Address[];
   readonly blockNumber?: bigint;
   readonly blockTimestamp: bigint;
   readonly targetPendingCapValue?: bigint;
@@ -156,6 +159,7 @@ const marketParamsResult = (params: MarketParams) => [
 ];
 
 const setupLoaderMockClient = ({
+  additionalVaults = [],
   blockNumber = 10n,
   blockTimestamp,
   targetPendingCapValue = 100n,
@@ -444,6 +448,33 @@ const setupLoaderMockClient = ({
     result: [0n, 10_000n],
   });
 
+  const baseVaultReads = [...reads];
+  for (const additionalVault of additionalVaults) {
+    for (const read of baseVaultReads) {
+      const referencesVault =
+        read.address.toLowerCase() === vault.toLowerCase() ||
+        read.args?.some(
+          (arg) =>
+            typeof arg === "string" &&
+            arg.toLowerCase() === vault.toLowerCase(),
+        );
+      if (!referencesVault) continue;
+
+      addRead({
+        ...read,
+        address:
+          read.address.toLowerCase() === vault.toLowerCase()
+            ? additionalVault
+            : read.address,
+        args: read.args?.map((arg) =>
+          typeof arg === "string" && arg.toLowerCase() === vault.toLowerCase()
+            ? additionalVault
+            : arg,
+        ),
+      });
+    }
+  }
+
   handle.request.mockImplementation(async ({ method, params }) => {
     if (method === "eth_chainId") return toHex(mainnet.id);
     if (method === "eth_getBlockByNumber")
@@ -580,6 +611,65 @@ describe("LiquidityLoader (constructor + public API)", () => {
 describe.sequential("LiquidityLoader.fetch", () => {
   afterEach(() => {
     nock.cleanAll();
+    vi.restoreAllMocks();
+  });
+
+  test("isolates batched target planning to each target's supplying vaults", async () => {
+    const handle = setupLoaderMockClient({
+      additionalVaults: [otherVault],
+      blockTimestamp: 100n,
+    });
+    const allocation = [
+      {
+        market: {
+          uniqueKey: targetMarketId,
+          loanAsset: { address: loanToken },
+          targetWithdrawUtilization: MathLib.WAD.toString(),
+        },
+      },
+      {
+        market: {
+          uniqueKey: sourceMarketId,
+          loanAsset: { address: loanToken },
+          targetWithdrawUtilization: MathLib.WAD.toString(),
+        },
+      },
+    ];
+    mockApiMarkets(MathLib.WAD, [
+      {
+        uniqueKey: targetMarketId,
+        targetBorrowUtilization: "900000000000000000",
+        publicAllocatorSharedLiquidity: [],
+        supplyingVaults: [{ address: vault, state: { allocation } }],
+      },
+      {
+        uniqueKey: sourceMarketId,
+        targetBorrowUtilization: "900000000000000000",
+        publicAllocatorSharedLiquidity: [],
+        supplyingVaults: [{ address: otherVault, state: { allocation } }],
+      },
+    ]);
+    const planner = vi
+      .spyOn(ReallocationData.prototype, "getMarketPublicReallocations")
+      .mockImplementation(function (this: ReallocationData) {
+        return { data: this, withdrawals: [] };
+      });
+    const loader = new LiquidityLoader(handle.client);
+
+    await Promise.all([
+      loader.fetch(targetMarketId),
+      loader.fetch(sourceMarketId),
+    ]);
+
+    expect(
+      planner.mock.calls.map(([marketId, options]) => [
+        marketId,
+        [...(options?.reallocatableVaults ?? [])],
+      ]),
+    ).toStrictEqual([
+      [targetMarketId, [vault]],
+      [sourceMarketId, [otherVault]],
+    ]);
   });
 
   test("returns a Promise that rejects when the RPC block read is not mocked", async () => {

--- a/packages/liquidity-sdk-viem/src/loader.ts
+++ b/packages/liquidity-sdk-viem/src/loader.ts
@@ -179,32 +179,36 @@ export class LiquidityLoader<chain extends Chain = Chain> {
           ),
         });
 
-        return apiMarkets.map(({ uniqueKey, targetBorrowUtilization }) => {
-          try {
-            // The source-market withdrawal ceiling defaults to 90%
-            // (DEFAULT_WITHDRAWAL_TARGET_UTILIZATION) inside
-            // `getMarketPublicReallocations`; the API's per-market
-            // `targetWithdrawUtilization` is no longer consulted.
-            // Caller `parameters` overrides are forwarded to the planner.
-            const { data: endState, withdrawals } =
-              startState.getMarketPublicReallocations(uniqueKey, {
-                ...parameters,
-                timestamp: block.timestamp + REALLOCATION_SIMULATION_DELAY,
-                enabled: true,
-              });
+        return apiMarkets.map(
+          ({ uniqueKey, targetBorrowUtilization, supplyingVaults }) => {
+            try {
+              // The source-market withdrawal ceiling defaults to 90%
+              // (DEFAULT_WITHDRAWAL_TARGET_UTILIZATION) inside
+              // `getMarketPublicReallocations`; the API's per-market
+              // `targetWithdrawUtilization` is no longer consulted.
+              // Caller `parameters` overrides are forwarded to the planner.
+              const { data: endState, withdrawals } =
+                startState.getMarketPublicReallocations(uniqueKey, {
+                  ...parameters,
+                  timestamp: block.timestamp + REALLOCATION_SIMULATION_DELAY,
+                  enabled: true,
+                  reallocatableVaults:
+                    supplyingVaults?.map(({ address }) => address) ?? [],
+                });
 
-            return {
-              startState,
-              endState,
-              withdrawals,
-              targetBorrowUtilization,
-            };
-          } catch (error) {
-            return Error(
-              `An error occurred while simulating reallocations: ${error}`,
-            );
-          }
-        });
+              return {
+                startState,
+                endState,
+                withdrawals,
+                targetBorrowUtilization,
+              };
+            } catch (error) {
+              return Error(
+                `An error occurred while simulating reallocations: ${error}`,
+              );
+            }
+          },
+        );
       },
       { cache: false },
     );


### PR DESCRIPTION
## What

- [SDKS-92](https://app.notion.com/3cfd69939e6d8154918ed1977e18b8d6) limits each target planner to that target's normalized supplying-vault set while retaining the union only for batched reads. **Example:** Concurrent plans for disjoint markets let target A count or withdraw target B's vault liquidity, overstating A's capacity and starving or reverting B.

## Why

Concurrent target planning must not source withdrawals from vaults that are unrelated to the target being fulfilled.
