### PR TITLE
fix(blue-sdk-viem): reject oversized Permit2 allowances

### DIFF
--- a/.changeset/brave-permits-stop.md
+++ b/.changeset/brave-permits-stop.md
@@ -1,0 +1,6 @@
+---
+"@morpho-org/blue-sdk-viem": minor
+"@morpho-org/morpho-sdk": minor
+---
+
+Reject Permit2 allowance values above the uint160 limit instead of silently converting them to unlimited approvals, and expose the typed overflow error through the Morpho SDK facade.

--- a/packages/blue-sdk-viem/src/error.ts
+++ b/packages/blue-sdk-viem/src/error.ts
@@ -1,4 +1,4 @@
-import type { Address, ChainId } from "@morpho-org/blue-sdk";
+import { type Address, type ChainId, MathLib } from "@morpho-org/blue-sdk";
 import { BaseError, ContractFunctionRevertedError } from "viem";
 
 /** Thrown when a permit domain targets another chain; consumers should not sign it. */
@@ -40,6 +40,15 @@ export class UnsupportedPermitDomainExtensionsError extends Error {
     );
 
     this.extensions = [...extensions];
+  }
+}
+
+/** Thrown when a finite Permit2 allowance cannot fit in its uint160 field. */
+export class Permit2AllowanceOverflowError extends Error {
+  constructor(public readonly allowance: bigint) {
+    super(
+      `Permit2 allowance "${allowance}" exceeds maximum "${MathLib.MAX_UINT_160}". Reduce the allowance or use the exact maximum for an unlimited approval.`,
+    );
   }
 }
 

--- a/packages/blue-sdk-viem/src/signatures/permit2.ts
+++ b/packages/blue-sdk-viem/src/signatures/permit2.ts
@@ -5,6 +5,7 @@ import {
   MathLib,
 } from "@morpho-org/blue-sdk";
 import type { TypedDataDefinition } from "viem";
+import { Permit2AllowanceOverflowError } from "../error.js";
 
 /** Message fields for Permit2 allowance typed data. */
 export interface Permit2PermitArgs {
@@ -45,6 +46,7 @@ const permit2PermitTypes = {
  * @param args - Permit2 allowance message fields.
  * @param chainId - Chain id whose Permit2 deployment verifies the signature.
  * @returns Typed data ready to pass to a wallet for signing.
+ * @throws {Permit2AllowanceOverflowError} When `args.allowance` exceeds the Permit2 uint160 limit.
  * @example
  * ```ts
  * import { ChainId } from "@morpho-org/blue-sdk";
@@ -66,6 +68,10 @@ export const getPermit2PermitTypedData = (
   args: Permit2PermitArgs,
   chainId: ChainId,
 ): TypedDataDefinition<typeof permit2PermitTypes, "PermitSingle"> => {
+  if (args.allowance > MathLib.MAX_UINT_160) {
+    throw new Permit2AllowanceOverflowError(args.allowance);
+  }
+
   return {
     domain: {
       name: "Permit2",
@@ -76,7 +82,7 @@ export const getPermit2PermitTypedData = (
     message: {
       details: {
         token: args.erc20,
-        amount: MathLib.min(args.allowance, MathLib.MAX_UINT_160),
+        amount: args.allowance,
         // Use an unlimited expiration because it most
         // closely mimics how a standard approval works.
         expiration: MathLib.min(

--- a/packages/blue-sdk-viem/src/signatures/signatures.test.ts
+++ b/packages/blue-sdk-viem/src/signatures/signatures.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@morpho-org/blue-sdk";
 import type { Address } from "viem";
 import { describe, expect, test } from "vitest";
+import { Permit2AllowanceOverflowError } from "../error.js";
 import { getAuthorizationTypedData } from "./manager.js";
 import { getDaiPermitTypedData, getPermitTypedData } from "./permit.js";
 import {
@@ -130,27 +131,45 @@ describe("getDaiPermitTypedData", () => {
 });
 
 describe("getPermit2PermitTypedData", () => {
-  test("clamps allowance and defaults expiration to MAX_UINT_48", () => {
-    const typedData = getPermit2PermitTypedData(
-      {
-        erc20: TOKEN,
-        allowance: MathLib.MAX_UINT_160 + 1n,
-        nonce: 7,
-        deadline: 8n,
-        spender: SPENDER,
-      },
-      ChainId.EthMainnet,
-    );
+  test.each([MathLib.MAX_UINT_160 - 1n, MathLib.MAX_UINT_160])(
+    "preserves supported allowance %s",
+    (allowance) => {
+      const typedData = getPermit2PermitTypedData(
+        {
+          erc20: TOKEN,
+          allowance,
+          nonce: 7,
+          deadline: 8n,
+          spender: SPENDER,
+        },
+        ChainId.EthMainnet,
+      );
 
-    expect(typedData.domain?.verifyingContract).toBe(
-      addressesRegistry[ChainId.EthMainnet].permit2,
-    );
-    expect(typedData.message.details).toEqual({
-      token: TOKEN,
-      amount: MathLib.MAX_UINT_160,
-      expiration: MathLib.MAX_UINT_48,
-      nonce: 7,
-    });
+      expect(typedData.domain?.verifyingContract).toBe(
+        addressesRegistry[ChainId.EthMainnet].permit2,
+      );
+      expect(typedData.message.details).toEqual({
+        token: TOKEN,
+        amount: allowance,
+        expiration: MathLib.MAX_UINT_48,
+        nonce: 7,
+      });
+    },
+  );
+
+  test("error: Permit2AllowanceOverflowError", () => {
+    expect(() =>
+      getPermit2PermitTypedData(
+        {
+          erc20: TOKEN,
+          allowance: MathLib.MAX_UINT_160 + 1n,
+          nonce: 7,
+          deadline: 8n,
+          spender: SPENDER,
+        },
+        ChainId.EthMainnet,
+      ),
+    ).toThrow(Permit2AllowanceOverflowError);
   });
 
   test("preserves finite allowance and expiration", () => {

--- a/packages/morpho-sdk/src/blue/errors.ts
+++ b/packages/morpho-sdk/src/blue/errors.ts
@@ -24,5 +24,6 @@ export {
   InvalidPermitDomainChainIdError,
   InvalidPermitDomainVerifyingContractError,
   isUnknownOfFactoryError,
+  Permit2AllowanceOverflowError,
   UnsupportedPermitDomainExtensionsError,
 } from "@morpho-org/blue-sdk-viem";

--- a/packages/morpho-sdk/src/errors.ts
+++ b/packages/morpho-sdk/src/errors.ts
@@ -41,6 +41,7 @@ export {
   InvalidPermitDomainChainIdError,
   InvalidPermitDomainVerifyingContractError,
   isUnknownOfFactoryError as isBlueUnknownOfFactoryError,
+  Permit2AllowanceOverflowError as BluePermit2AllowanceOverflowError,
   UnsupportedPermitDomainExtensionsError,
 } from "@morpho-org/blue-sdk-viem";
 export {

--- a/packages/morpho-sdk/src/protocolFacades.test.ts
+++ b/packages/morpho-sdk/src/protocolFacades.test.ts
@@ -16,6 +16,7 @@ import {
   InvalidMarketParamsError as RawBlueInvalidMarketParamsError,
   InvalidPermitDomainChainIdError as RawBlueInvalidPermitDomainChainIdError,
   InvalidPermitDomainVerifyingContractError as RawBlueInvalidPermitDomainVerifyingContractError,
+  Permit2AllowanceOverflowError as RawBluePermit2AllowanceOverflowError,
   RegistryValueAlreadyRegisteredError as RawBlueRegistryValueAlreadyRegisteredError,
   UnknownDataError as RawBlueUnknownDataError,
   UnknownFactory as RawBlueUnknownFactory,
@@ -60,6 +61,7 @@ import {
   MidnightMarket,
 } from "@morpho-org/morpho-sdk/entities";
 import {
+  BluePermit2AllowanceOverflowError,
   DivisionByZeroError,
   getBlueUnsupportedVaultV2Adapter,
   InvalidBitLengthError,
@@ -143,6 +145,7 @@ describe("protocol facades", () => {
       RawBlueInvalidPermitDomainVerifyingContractError,
     ],
     [getBlueUnsupportedVaultV2Adapter, rawGetBlueUnsupportedVaultV2Adapter],
+    [BluePermit2AllowanceOverflowError, RawBluePermit2AllowanceOverflowError],
     [isBlueUnknownOfFactoryError, rawIsBlueUnknownOfFactoryError],
     [NegativeValueError, RawNegativeValueError],
     [


### PR DESCRIPTION
## What

- [SDKS-128](https://app.notion.com/3cfd69939e6d8173bf88d570701e64fc) rejects finite Permit2 allowances above `MAX_UINT_160`, preserves exact-max as the caller's explicit unlimited value, and exposes the typed overflow failure through `blue-sdk-viem` and both `morpho-sdk` Blue facades. **Example:** A frontend conversion bug requests a finite allowance just above uint160; silent clamping makes it unlimited, letting a compromised spender pull future deposits.

## Why

An overflowing finite allowance must fail explicitly instead of becoming an unlimited approval.
