### PR TITLE
fix(wdk): bind operations to a stable provider chain context

### DIFF
--- a/.changeset/stable-wdk-chain-context.md
+++ b/.changeset/stable-wdk-chain-context.md
@@ -1,5 +1,5 @@
 ---
-"@morpho-org/wdk-protocol-lending-morpho-evm": patch
+"@morpho-org/wdk-protocol-lending-morpho-evm": minor
 ---
 
-Bind reads, requirements, quotes, and sends to one validated provider-chain generation while preserving configured provider failover.
+Bind reads, requirements, quotes, and sends to one validated provider-chain generation while preserving configured provider failover, and export `ChainIdMismatchError` and `MissingWalletProviderError` for callers handling validation failures.

--- a/.changeset/stable-wdk-chain-context.md
+++ b/.changeset/stable-wdk-chain-context.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/wdk-protocol-lending-morpho-evm": patch
+---
+
+Bind reads, requirements, quotes, and sends to one validated provider-chain generation while preserving configured provider failover.

--- a/.changeset/stable-wdk-chain-context.md
+++ b/.changeset/stable-wdk-chain-context.md
@@ -2,4 +2,4 @@
 "@morpho-org/wdk-protocol-lending-morpho-evm": minor
 ---
 
-Bind reads, requirements, quotes, and sends to one validated provider-chain generation while preserving configured provider failover, and export `ChainIdMismatchError` and `MissingWalletProviderError` for callers handling validation failures.
+Validate reads, requirements, quotes, and sends against the provider chain at operation boundaries, bind ERC-4337 signing to that validated context, and preserve configured provider failover. Export `ChainIdMismatchError` and `MissingWalletProviderError` for callers handling validation failures.

--- a/packages/wdk-protocol-lending-morpho-evm/README.md
+++ b/packages/wdk-protocol-lending-morpho-evm/README.md
@@ -79,6 +79,8 @@ Options:
 
 Built-in presets already carry their expected chain id. If you use `earnVaultAddress`, `borrowMarketParams`, or `borrowMarketId` directly, pass `chainId` so the adapter can fail before building transactions after a browser-wallet chain switch.
 
+ERC-4337 accounts cache chain-bound UserOperation state. After switching the provider network, create a fresh wallet account and `MorphoProtocolEvm` adapter before continuing.
+
 For vault deposits and collateral supply, pass either `amount`, `nativeAmount`, or both. `nativeAmount` follows Morpho SDK semantics and is only valid when the configured vault asset or collateral token is the wrapped native token for the chain.
 
 ## Methods

--- a/packages/wdk-protocol-lending-morpho-evm/README.md
+++ b/packages/wdk-protocol-lending-morpho-evm/README.md
@@ -68,7 +68,7 @@ new MorphoProtocolEvm(account, options)
 
 Options:
 
-- `chainId` (number | bigint): required when using explicit Morpho targets; guards transaction building against wallet chain switches.
+- `chainId` (number | bigint): required when using explicit Morpho targets; validates reads, requirements, quotes, and sends against provider/target chain mismatches and switches.
 - `earnVaultAddress` (string): explicit Morpho vault address.
 - `borrowMarketParams` (object): explicit Morpho Blue market params.
 - `borrowMarketId` (string): explicit market id; market params are fetched on-chain.
@@ -77,7 +77,7 @@ Options:
 - `supportSignature` (boolean): enable SDK permit/permit2 requirements.
 - `supportDeployless` (boolean): enable SDK deployless reads.
 
-Built-in presets already carry their expected chain id. If you use `earnVaultAddress`, `borrowMarketParams`, or `borrowMarketId` directly, pass `chainId` so the adapter can fail before building transactions after a browser-wallet chain switch.
+Built-in presets already carry their expected chain id. If you use `earnVaultAddress`, `borrowMarketParams`, or `borrowMarketId` directly, pass `chainId` so the adapter rejects reads, requirements, quotes, and sends when the provider chain differs from the target or changes mid-operation.
 
 ERC-4337 accounts cache chain-bound UserOperation state. After switching the provider network, create a fresh wallet account and `MorphoProtocolEvm` adapter before continuing.
 

--- a/packages/wdk-protocol-lending-morpho-evm/README.md
+++ b/packages/wdk-protocol-lending-morpho-evm/README.md
@@ -77,9 +77,9 @@ Options:
 - `supportSignature` (boolean): enable SDK permit/permit2 requirements.
 - `supportDeployless` (boolean): enable SDK deployless reads.
 
-Built-in presets already carry their expected chain id. If you use `earnVaultAddress`, `borrowMarketParams`, or `borrowMarketId` directly, pass `chainId` so the adapter rejects mismatches and switches at each adapter-controlled async boundary and immediately before dispatch. ERC-4337 preparation, signing, and broadcast then execute inside one WDK call.
+Built-in presets already carry their expected chain id. If you use `earnVaultAddress`, `borrowMarketParams`, or `borrowMarketId` directly, pass `chainId` so the adapter checks the provider at the start and terminal boundary of each operation. EOA transactions are signed for that chain and verified before broadcast; ERC-4337 preparation, signing, and broadcast execute atomically through WDK with the signing chain bound to the validated context.
 
-ERC-4337 accounts cache chain-bound UserOperation state. After switching the provider network, create a fresh wallet account and `MorphoProtocolEvm` adapter before continuing.
+ERC-4337 accounts cache chain-bound UserOperation state. If an account has already cached another chain, create a fresh wallet account and `MorphoProtocolEvm` adapter before continuing.
 
 For vault deposits and collateral supply, pass either `amount`, `nativeAmount`, or both. `nativeAmount` follows Morpho SDK semantics and is only valid when the configured vault asset or collateral token is the wrapped native token for the chain.
 

--- a/packages/wdk-protocol-lending-morpho-evm/README.md
+++ b/packages/wdk-protocol-lending-morpho-evm/README.md
@@ -77,7 +77,7 @@ Options:
 - `supportSignature` (boolean): enable SDK permit/permit2 requirements.
 - `supportDeployless` (boolean): enable SDK deployless reads.
 
-Built-in presets already carry their expected chain id. If you use `earnVaultAddress`, `borrowMarketParams`, or `borrowMarketId` directly, pass `chainId` so the adapter rejects reads, requirements, quotes, and sends when the provider chain differs from the target or changes mid-operation.
+Built-in presets already carry their expected chain id. If you use `earnVaultAddress`, `borrowMarketParams`, or `borrowMarketId` directly, pass `chainId` so the adapter rejects mismatches and switches at each adapter-controlled async boundary and immediately before dispatch. ERC-4337 preparation, signing, and broadcast then execute inside one WDK call.
 
 ERC-4337 accounts cache chain-bound UserOperation state. After switching the provider network, create a fresh wallet account and `MorphoProtocolEvm` adapter before continuing.
 

--- a/packages/wdk-protocol-lending-morpho-evm/src/errors.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/errors.ts
@@ -1,0 +1,8 @@
+/** Thrown when a WDK wallet account has no usable RPC provider. */
+export class MissingWalletProviderError extends Error {
+  constructor() {
+    super(
+      'The wallet account has no usable provider. Configure "provider" with at least one RPC URL or EIP-1193 provider.',
+    );
+  }
+}

--- a/packages/wdk-protocol-lending-morpho-evm/src/index.test.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/index.test.ts
@@ -1,0 +1,12 @@
+import { ChainIdMismatchError as SdkChainIdMismatchError } from "@morpho-org/morpho-sdk";
+import { expect, test } from "vitest";
+import { MissingWalletProviderError as SourceMissingWalletProviderError } from "./errors.js";
+import { ChainIdMismatchError, MissingWalletProviderError } from "./index.js";
+
+test("re-exports ChainIdMismatchError by identity", () => {
+  expect(ChainIdMismatchError).toBe(SdkChainIdMismatchError);
+});
+
+test("re-exports MissingWalletProviderError by identity", () => {
+  expect(MissingWalletProviderError).toBe(SourceMissingWalletProviderError);
+});

--- a/packages/wdk-protocol-lending-morpho-evm/src/index.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/index.ts
@@ -5,6 +5,7 @@ export type {
   VaultV1Reallocation,
   VaultV2BlueReallocation,
 } from "@morpho-org/morpho-sdk";
+export { ChainIdMismatchError } from "@morpho-org/morpho-sdk";
 export type { TransactionResult } from "@tetherto/wdk-wallet";
 export type {
   BorrowOptions,
@@ -16,6 +17,7 @@ export type {
   WithdrawOptions,
   WithdrawResult,
 } from "@tetherto/wdk-wallet/protocols";
+export { MissingWalletProviderError } from "./errors.js";
 export {
   type Market,
   type MarketPresetKey,

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
@@ -143,7 +143,12 @@ const extendMock = vi.fn().mockReturnValue({
 });
 const createClientMock = vi.fn().mockReturnValue({ extend: extendMock });
 
+const { ChainIdMismatchError } = await vi.importActual<
+  typeof import("@morpho-org/morpho-sdk")
+>("@morpho-org/morpho-sdk");
+
 vi.doMock("@morpho-org/morpho-sdk", () => ({
+  ChainIdMismatchError,
   morphoViemExtension: morphoViemExtensionMock,
 }));
 
@@ -356,8 +361,8 @@ describe.sequential("MorphoProtocolEvm", () => {
         borrowMarketParams: MARKET_PARAMS,
       });
 
-      await expect(protocol.getVaultPosition()).rejects.toThrow(
-        "Morpho target is configured for chain 1, but the connected provider is on chain 8453.",
+      await expect(protocol.getVaultPosition()).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
       );
     });
 
@@ -559,9 +564,7 @@ describe.sequential("MorphoProtocolEvm", () => {
 
       await expect(
         protocol.borrow({ token: TOKEN, amount: 100_000n }),
-      ).rejects.toThrow(
-        "Morpho target is configured for chain 1, but the connected provider is on chain 8453.",
-      );
+      ).rejects.toBeInstanceOf(ChainIdMismatchError);
       expect(fetchMarketMock).not.toHaveBeenCalled();
     });
 
@@ -827,9 +830,58 @@ describe.sequential("MorphoProtocolEvm", () => {
         fee: 12_345n,
       });
     });
+
+    test("snapshots native value before resolving chain state", async () => {
+      const observedChain = Promise.withResolvers<number>();
+      mockGetChainId.mockImplementationOnce(() => observedChain.promise);
+      account.sendTransaction = vi
+        .fn()
+        .mockResolvedValue({ hash: "dummy-supply-hash", fee: 12_345n });
+      const options = { token: TOKEN, nativeAmount: 100_000n };
+
+      const result = protocol.supply(options);
+      options.nativeAmount = 200_000n;
+      observedChain.resolve(1);
+      await result;
+
+      expect(vaultV2Entity.deposit).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 0n, nativeAmount: 100_000n }),
+      );
+    });
   });
 
   describe("read methods", () => {
+    test("preserves provider-array failover attempts", async () => {
+      const attempts: string[] = [];
+      const providers = ["A", "B"].map((label) => ({
+        request: vi.fn(async () => {
+          attempts.push(label);
+          throw new Error(label);
+        }),
+      }));
+      const fallbackAccount = new WalletAccountReadOnlyEvm(ADDRESS, {
+        provider: providers,
+        retries: 3,
+        chainId: 1,
+      });
+      fallbackAccount.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+      const fallbackProtocol = new MorphoProtocolEvm(fallbackAccount, {
+        chainId: 1,
+        borrowMarketParams: MARKET_PARAMS,
+      });
+
+      await fallbackProtocol.getMarketPosition();
+
+      const clientConfig = createClientMock.mock.calls[0]?.[0] as {
+        transport: viem.Transport;
+      };
+      const transport = clientConfig.transport({ retryCount: 0 });
+      await expect(
+        transport.request({ method: "eth_chainId" }),
+      ).rejects.toThrow();
+      expect(attempts).toEqual(["A", "B", "A", "B"]);
+    });
+
     test("should return vault position data", async () => {
       const result = await protocol.getVaultPosition();
 
@@ -864,10 +916,288 @@ describe.sequential("MorphoProtocolEvm", () => {
 
       mockGetChainId.mockResolvedValue(8453);
 
-      await expect(protocol.getMarketPosition()).rejects.toThrow(
-        "Morpho target is configured for chain 1, but the connected provider is on chain 8453.",
+      await expect(protocol.getMarketPosition()).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
       );
       expect(blueMock).toHaveBeenCalledTimes(1);
+
+      mockGetChainId.mockResolvedValue(1);
+      await protocol.getMarketPosition();
+      expect(blueMock).toHaveBeenCalledTimes(2);
+      expect(morphoViemExtensionMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("shares one context across same-chain operations completing out of order", async () => {
+      const first = Promise.withResolvers<number>();
+      const second = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+
+      const firstPosition = protocol.getMarketPosition();
+      const secondPosition = protocol.getMarketPosition();
+      second.resolve(1);
+      await expect(secondPosition).resolves.toEqual(
+        expect.objectContaining({ marketId: expect.any(String) }),
+      );
+      first.resolve(1);
+      await expect(firstPosition).resolves.toEqual(
+        expect.objectContaining({ marketId: expect.any(String) }),
+      );
+    });
+
+    test("waits for a newer same-chain observation when the older resolves first", async () => {
+      const first = Promise.withResolvers<number>();
+      const second = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+
+      const firstPosition = protocol.getMarketPosition();
+      const secondPosition = protocol.getMarketPosition();
+      first.resolve(1);
+      second.resolve(1);
+
+      await expect(firstPosition).resolves.toEqual(
+        expect.objectContaining({ marketId: expect.any(String) }),
+      );
+      await expect(secondPosition).resolves.toEqual(
+        expect.objectContaining({ marketId: expect.any(String) }),
+      );
+    });
+
+    test("rejects conflicting chain observations completing out of order", async () => {
+      const first = Promise.withResolvers<number>();
+      const second = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+
+      const firstPosition = protocol.getMarketPosition();
+      const secondPosition = protocol.getMarketPosition();
+      second.resolve(8453);
+      await expect(secondPosition).rejects.toBeInstanceOf(ChainIdMismatchError);
+      first.resolve(1);
+      await expect(firstPosition).rejects.toBeInstanceOf(ChainIdMismatchError);
+    });
+
+    test("rejects dispatch while a newer chain observation is pending", async () => {
+      const dispatchChain = Promise.withResolvers<number>();
+      const newerChain = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockImplementationOnce(() => dispatchChain.promise)
+        .mockImplementationOnce(() => newerChain.promise);
+      account.sendTransaction = vi.fn();
+
+      const supply = protocol.supply({ token: TOKEN, nativeAmount: 100_000n });
+      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(3));
+      const position = protocol.getMarketPosition();
+      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(4));
+
+      dispatchChain.resolve(1);
+      await Promise.resolve();
+      expect(account.sendTransaction).not.toHaveBeenCalled();
+
+      newerChain.resolve(8453);
+      await expect(supply).rejects.toBeInstanceOf(ChainIdMismatchError);
+      await expect(position).rejects.toBeInstanceOf(ChainIdMismatchError);
+    });
+
+    test("does not cache market data resolved after a chain switch", async () => {
+      const fetchedMarket = Promise.withResolvers<{
+        params: InstanceType<typeof MarketParams>;
+      }>();
+      fetchMarketMock.mockImplementationOnce(() => fetchedMarket.promise);
+      const marketIdProtocol = new MorphoProtocolEvm(account, {
+        chainId: 1,
+        earnVaultAddress: VAULT,
+        borrowMarketId: MARKET_ID,
+      });
+
+      const stalePosition = marketIdProtocol.getMarketPosition();
+      await vi.waitFor(() => expect(fetchMarketMock).toHaveBeenCalledOnce());
+      mockGetChainId.mockResolvedValue(8453);
+      await expect(marketIdProtocol.getVaultPosition()).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
+      );
+      fetchedMarket.resolve({ params: new MarketParams(MARKET_PARAMS) });
+      await expect(stalePosition).rejects.toBeInstanceOf(ChainIdMismatchError);
+
+      mockGetChainId.mockResolvedValue(1);
+      await marketIdProtocol.getMarketPosition();
+      expect(fetchMarketMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("invalidates same-chain caches after an observed switch away and back", async () => {
+      await protocol.getMarketPosition();
+      const priorChainReads = mockGetChainId.mock.calls.length;
+      const switchedChain = Promise.withResolvers<number>();
+      const returnedChain = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockImplementationOnce(() => switchedChain.promise)
+        .mockImplementationOnce(() => returnedChain.promise);
+
+      const switchedPosition = protocol.getMarketPosition();
+      const returnedPosition = protocol.getMarketPosition();
+      await vi.waitFor(() =>
+        expect(mockGetChainId).toHaveBeenCalledTimes(priorChainReads + 2),
+      );
+      returnedChain.resolve(1);
+      await expect(returnedPosition).resolves.toEqual(
+        expect.objectContaining({ marketId: expect.any(String) }),
+      );
+      switchedChain.resolve(8453);
+      await expect(switchedPosition).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
+      );
+
+      const cachedEntities = blueMock.mock.calls.length;
+      await protocol.getMarketPosition();
+      expect(blueMock).toHaveBeenCalledTimes(cachedEntities + 1);
+    });
+
+    test("rechecks the chain immediately before native-value dispatch", async () => {
+      mockGetChainId
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(8453);
+      account.sendTransaction = vi.fn();
+
+      await expect(
+        protocol.supply({ token: TOKEN, nativeAmount: 100_000n }),
+      ).rejects.toBeInstanceOf(ChainIdMismatchError);
+      expect(account.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    test("rejects a quote when its completion crosses chains", async () => {
+      mockGetChainId
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(8453);
+      account.quoteSendTransaction = vi
+        .fn()
+        .mockResolvedValue({ fee: 12_345n });
+
+      await expect(
+        protocol.quoteSupply({ token: TOKEN, amount: 100_000n }),
+      ).rejects.toBeInstanceOf(ChainIdMismatchError);
+    });
+
+    test("rejects requirements resolved after another operation observes a switch", async () => {
+      const requirementResult =
+        Promise.withResolvers<{ action: { type: string } }[]>();
+      supplyAction.getRequirements.mockImplementationOnce(
+        () => requirementResult.promise,
+      );
+      const requirements = protocol.getSupplyRequirements({
+        token: TOKEN,
+        amount: 100_000n,
+      });
+      await vi.waitFor(() =>
+        expect(supplyAction.getRequirements).toHaveBeenCalledOnce(),
+      );
+
+      mockGetChainId.mockResolvedValue(8453);
+      await expect(protocol.getMarketPosition()).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
+      );
+      requirementResult.resolve([{ action: { type: "erc20Approval" } }]);
+      await expect(requirements).rejects.toBeInstanceOf(ChainIdMismatchError);
+    });
+
+    test("shares one chain context across account-data reads", async () => {
+      const vaultChain = Promise.withResolvers<number>();
+      const marketChain = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockResolvedValueOnce(1)
+        .mockImplementationOnce(() => vaultChain.promise)
+        .mockImplementationOnce(() => marketChain.promise);
+
+      const accountData = protocol.getAccountData();
+      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(3));
+      vaultChain.resolve(1);
+      marketChain.resolve(1);
+
+      await expect(accountData).resolves.toEqual(
+        expect.objectContaining({
+          vaultAddress: VAULT,
+          marketId: new MarketParams(MARKET_PARAMS).id,
+        }),
+      );
+    });
+  });
+
+  describe("erc-4337 chain binding", () => {
+    test("rejects a cached account chain before resolving entities", async () => {
+      const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
+        chainId: 8453,
+        provider: "https://dummy-rpc-url.com",
+        bundlerUrl: "https://dummy-bundler-url.com",
+        safeModulesVersion: "0.3.0",
+        isSponsored: false,
+        useNativeCoins: true,
+      });
+      erc4337Account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+      (erc4337Account as unknown as { _chainId: bigint | undefined })._chainId =
+        1n;
+      mockGetChainId.mockResolvedValue(8453);
+      const erc4337Protocol = new MorphoProtocolEvm(erc4337Account, {
+        chainId: 8453,
+        borrowMarketParams: MARKET_PARAMS,
+      });
+
+      await expect(erc4337Protocol.getMarketPosition()).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
+      );
+      expect(blueMock).not.toHaveBeenCalled();
+    });
+
+    test("requires a fresh account after an observed chain switch", async () => {
+      const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
+        chainId: 1,
+        provider: "https://dummy-rpc-url.com",
+        bundlerUrl: "https://dummy-bundler-url.com",
+        safeModulesVersion: "0.3.0",
+        isSponsored: false,
+        useNativeCoins: true,
+      });
+      erc4337Account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+      (erc4337Account as unknown as { _chainId: bigint | undefined })._chainId =
+        1n;
+      const erc4337Protocol = new MorphoProtocolEvm(erc4337Account, {
+        chainId: 1,
+        borrowMarketParams: MARKET_PARAMS,
+      });
+
+      await erc4337Protocol.getMarketPosition();
+      mockGetChainId.mockResolvedValue(8453);
+      await expect(erc4337Protocol.getMarketPosition()).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
+      );
+      mockGetChainId.mockResolvedValue(1);
+      await expect(erc4337Protocol.getMarketPosition()).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
+      );
+
+      const freshAccount = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
+        chainId: 1,
+        provider: "https://dummy-rpc-url.com",
+        bundlerUrl: "https://dummy-bundler-url.com",
+        safeModulesVersion: "0.3.0",
+        isSponsored: false,
+        useNativeCoins: true,
+      });
+      freshAccount.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+      const freshProtocol = new MorphoProtocolEvm(freshAccount, {
+        chainId: 1,
+        borrowMarketParams: MARKET_PARAMS,
+      });
+      await expect(freshProtocol.getMarketPosition()).resolves.toEqual(
+        expect.objectContaining({ marketId: expect.any(String) }),
+      );
     });
   });
 

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
@@ -1126,7 +1126,7 @@ describe.sequential("MorphoProtocolEvm", () => {
   });
 
   describe("erc-4337", () => {
-    test("should use the validated balance client, snapshot config, and send a signed erc-4337 operation", async () => {
+    test("should use the validated balance client and atomically send a cache-proof erc-4337 operation", async () => {
       // biome-ignore lint/suspicious/noShadow: test-local account shadowing the suite default
       const account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
         chainId: 1,
@@ -1182,10 +1182,11 @@ describe.sequential("MorphoProtocolEvm", () => {
         functionName: "balanceOf",
         args: [ADDRESS],
       });
-      const operationConfig = vi.mocked(account.quoteSendTransaction).mock
+      const operationConfig = vi.mocked(account.sendTransaction).mock
         .calls[0]?.[1];
       expect(operationConfig).toEqual({
         paymasterToken: { address: TOKEN },
+        nonceKey: 0n,
       });
       expect(operationConfig).not.toBe(config);
       expect(
@@ -1193,20 +1194,17 @@ describe.sequential("MorphoProtocolEvm", () => {
           "paymasterToken" in operationConfig &&
           operationConfig.paymasterToken,
       ).not.toBe(config.paymasterToken);
-      expect(account.signTransaction).toHaveBeenCalledWith(
-        SUPPLY_TX,
-        operationConfig,
-      );
+      expect(account.quoteSendTransaction).not.toHaveBeenCalled();
+      expect(account.signTransaction).not.toHaveBeenCalled();
       expect(account.sendTransaction).toHaveBeenCalledWith(
-        signed,
+        SUPPLY_TX,
         operationConfig,
       );
       expect(result).toEqual({
         hash: "dummy-user-operation-hash",
-        fee: 12_345n,
+        fee: 99_999n,
       });
 
-      vi.mocked(account.quoteSendTransaction).mockClear();
       const quoteConfig = { useNativeCoins: true as const };
       await expect(
         protocol.quoteBorrow({ token: TOKEN, amount: 100_000n }, quoteConfig),
@@ -1218,18 +1216,44 @@ describe.sequential("MorphoProtocolEvm", () => {
         quoteConfig,
       );
       expect(forwardedQuoteConfig).not.toBe(quoteConfig);
-
-      mockGetChainId.mockResolvedValue(1);
-      vi.mocked(account.sendTransaction).mockClear();
-      vi.mocked(account.signTransaction).mockImplementationOnce(async () => {
-        mockGetChainId.mockResolvedValue(8453);
-        return signed;
-      });
-      await expect(
-        protocol.supply({ token: TOKEN, amount: 100_000n }),
-      ).rejects.toBeInstanceOf(ChainIdMismatchError);
-      expect(account.sendTransaction).not.toHaveBeenCalled();
     });
+
+    test.each([
+      ["parallel", { parallel: true }],
+      ["custom nonce", { nonceKey: "morpho" }],
+    ])(
+      "behavior: preserves an account-level %s lane",
+      async (_name, nonceConfig) => {
+        // biome-ignore lint/suspicious/noShadow: test-local account shadowing the suite default
+        const account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
+          chainId: 1,
+          provider: "https://dummy-rpc-url.com",
+          bundlerUrl: "https://dummy-bundler-url.com",
+          safeModulesVersion: "0.3.0",
+          isSponsored: false,
+          useNativeCoins: true,
+          ...nonceConfig,
+        });
+        account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+        readContractMock.mockResolvedValue(100_000n);
+        account.sendTransaction = vi.fn().mockResolvedValue({
+          hash: "dummy-user-operation-hash",
+          fee: 99_999n,
+        });
+        // biome-ignore lint/suspicious/noShadow: test-local protocol shadowing the suite default
+        const protocol = new MorphoProtocolEvm(account, {
+          chainId: 1,
+          earnVaultAddress: VAULT,
+        });
+
+        await protocol.supply({ token: TOKEN, amount: 100_000n });
+
+        expect(account.sendTransaction).toHaveBeenCalledWith(
+          SUPPLY_TX,
+          undefined,
+        );
+      },
+    );
 
     test("snapshots native value before resolving chain state", async () => {
       const observedChain = Promise.withResolvers<number>();

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
@@ -3,8 +3,11 @@ import type {
   VaultReallocation,
   VaultV2BlueReallocation,
 } from "@morpho-org/morpho-sdk";
+import { createMockClient } from "@morpho-org/test/mock";
 import * as viem from "viem";
+import { mainnet } from "viem/chains";
 import { beforeEach, describe, expect, expectTypeOf, test, vi } from "vitest";
+import { MissingWalletProviderError } from "./errors.js";
 import type {
   MorphoBorrowOptions,
   MorphoBorrowWithVaultV2ReallocationsOptions,
@@ -58,6 +61,13 @@ const WITHDRAW_COLLATERAL_TX = {
   to: "0x0000000000000000000000000000000000000006",
   value: 0n,
   data: "0x06",
+};
+const POPULATED_TRANSACTION = {
+  chainId: 1,
+  gasLimit: 1n,
+  nonce: 0,
+  maxFeePerGas: 12_345n,
+  maxPriorityFeePerGas: 1n,
 };
 
 const vaultData = {
@@ -130,18 +140,33 @@ const morphoNamespaceMock = {
 const morphoExtendMock = vi
   .fn()
   .mockReturnValue({ morpho: morphoNamespaceMock });
-const morphoViemExtensionMock = vi.fn().mockReturnValue("morpho-extension");
+const morphoViemExtensionMock = vi.fn<(...args: unknown[]) => unknown>(
+  () => "morpho-extension",
+);
 const fetchMarketMock = vi.fn();
 const mockGetChainId = vi.fn().mockResolvedValue(1);
 const readContractMock = vi.fn().mockResolvedValue(123n);
+const prepareTransactionRequestMock = vi.fn().mockResolvedValue({
+  gas: 1n,
+  nonce: 0,
+  maxFeePerGas: 12_345n,
+  maxPriorityFeePerGas: 1n,
+});
+const sendRawTransactionMock = vi
+  .fn()
+  .mockResolvedValue("dummy-transaction-hash");
 const extendMock = vi.fn().mockReturnValue({
   account: { address: ADDRESS },
   chain: { id: 1 },
   getChainId: mockGetChainId,
   readContract: readContractMock,
+  prepareTransactionRequest: prepareTransactionRequestMock,
+  sendRawTransaction: sendRawTransactionMock,
   extend: morphoExtendMock,
 });
-const createClientMock = vi.fn().mockReturnValue({ extend: extendMock });
+const createClientMock = vi.fn<(parameters: unknown) => unknown>(() => ({
+  extend: extendMock,
+}));
 
 const { ChainIdMismatchError } = await vi.importActual<
   typeof import("@morpho-org/morpho-sdk")
@@ -181,11 +206,22 @@ describe.sequential("MorphoProtocolEvm", () => {
     });
     mockGetChainId.mockResolvedValue(1);
     readContractMock.mockResolvedValue(123n);
+    prepareTransactionRequestMock.mockReset().mockResolvedValue({
+      gas: 1n,
+      nonce: 0,
+      maxFeePerGas: 12_345n,
+      maxPriorityFeePerGas: 1n,
+    });
+    sendRawTransactionMock
+      .mockReset()
+      .mockResolvedValue("dummy-transaction-hash");
 
     account = new WalletAccountEvm(SEED, "0'/0/0", {
       provider: "https://dummy-rpc-url.com",
     });
     account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+    account.quoteSendTransaction = vi.fn().mockResolvedValue({ fee: 12_345n });
+    vi.spyOn(account, "signTransaction");
     protocol = new MorphoProtocolEvm(account, {
       chainId: 1,
       earnVaultAddress: VAULT,
@@ -196,9 +232,6 @@ describe.sequential("MorphoProtocolEvm", () => {
   describe("supply", () => {
     test("should build a vault deposit with morpho-sdk and send it", async () => {
       account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-supply-hash", fee: 12_345n });
 
       const result = await protocol.supply({ token: TOKEN, amount: 100_000n });
 
@@ -217,21 +250,152 @@ describe.sequential("MorphoProtocolEvm", () => {
         vaultData,
         slippageTolerance: undefined,
       });
-      expect(account.sendTransaction).toHaveBeenCalledWith(SUPPLY_TX);
-      expect(result).toEqual({ hash: "dummy-supply-hash", fee: 12_345n });
+      expect(account.signTransaction).toHaveBeenCalledWith({
+        ...SUPPLY_TX,
+        ...POPULATED_TRANSACTION,
+      });
+      expect(result).toEqual({
+        hash: "dummy-transaction-hash",
+        fee: 12_345n,
+      });
+    });
+
+    test("uses real viem transport actions for legacy EOA preparation and broadcast", async () => {
+      const handle = createMockClient(mainnet);
+      const hash =
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      handle.request.mockImplementation(async ({ method }) => {
+        if (method === "eth_chainId") return "0x1";
+        if (method === "eth_fillTransaction") {
+          return {
+            tx: {
+              chainId: "0x1",
+              from: ADDRESS,
+              to: SUPPLY_TX.to,
+              input: SUPPLY_TX.data,
+              value: "0x0",
+              gas: "0x5208",
+              gasPrice: "0x3",
+              nonce: "0x0",
+              type: "0x0",
+            },
+          };
+        }
+        if (method === "eth_sendRawTransaction") return hash;
+        throw new Error(`Unhandled RPC ${method}`);
+      });
+      const transportAccount = new WalletAccountEvm(SEED, "0'/0/0", {
+        provider: {
+          request: ({ method, params }) =>
+            handle.request({
+              method,
+              params: Array.isArray(params) ? params : undefined,
+            }),
+        },
+      });
+      transportAccount.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
+      transportAccount.quoteSendTransaction = vi
+        .fn()
+        .mockResolvedValue({ fee: 12_345n });
+      const signTransaction = vi.spyOn(transportAccount, "signTransaction");
+      const transportProtocol = new MorphoProtocolEvm(transportAccount, {
+        chainId: 1,
+        earnVaultAddress: VAULT,
+        borrowMarketParams: MARKET_PARAMS,
+      });
+
+      await createClientMock.withImplementation(
+        (parameters) =>
+          viem.createClient(
+            parameters as Parameters<typeof viem.createClient>[0],
+          ),
+        () =>
+          morphoViemExtensionMock.withImplementation(
+            () => () => ({ morpho: morphoNamespaceMock }),
+            async () => {
+              await expect(
+                transportProtocol.supply({
+                  token: TOKEN,
+                  amount: 100_000n,
+                }),
+              ).resolves.toEqual({ hash, fee: 12_345n });
+            },
+          ),
+      );
+
+      expect(signTransaction).toHaveBeenCalledWith({
+        ...SUPPLY_TX,
+        chainId: 1,
+        gasLimit: 21_000n,
+        gasPrice: 3n,
+        nonce: 0,
+      });
+      expect(handle.request.mock.calls.map(([call]) => call.method)).toEqual(
+        expect.arrayContaining([
+          "eth_chainId",
+          "eth_fillTransaction",
+          "eth_sendRawTransaction",
+        ]),
+      );
     });
 
     test("should return supply requirements from morpho-sdk", async () => {
+      const observedChain = Promise.withResolvers<number>();
+      mockGetChainId.mockImplementationOnce(() => observedChain.promise);
+      const options = { token: TOKEN, amount: 100_000n };
       const requirementOptions = { useSimplePermit: true };
-      const requirements = await protocol.getSupplyRequirements(
-        { token: TOKEN, amount: 100_000n },
+      const pending = protocol.getSupplyRequirements(
+        options,
         requirementOptions,
       );
+      options.amount = 200_000n;
+      requirementOptions.useSimplePermit = false;
+      observedChain.resolve(1);
+      const requirements = await pending;
 
       expect(requirements).toEqual([{ action: { type: "erc20Approval" } }]);
-      expect(supplyAction.getRequirements).toHaveBeenCalledWith(
-        requirementOptions,
+      expect(vaultV2Entity.deposit).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 100_000n }),
       );
+      expect(supplyAction.getRequirements).toHaveBeenCalledWith({
+        useSimplePermit: true,
+      });
+    });
+
+    test("rejects a signer result bound to another chain", async () => {
+      account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
+      const wrongChainTransaction = await account.signTransaction({
+        ...SUPPLY_TX,
+        ...POPULATED_TRANSACTION,
+        chainId: 8453,
+      });
+      vi.mocked(account.signTransaction)
+        .mockClear()
+        .mockResolvedValueOnce(wrongChainTransaction);
+
+      await expect(
+        protocol.supply({ token: TOKEN, amount: 100_000n }),
+      ).rejects.toBeInstanceOf(ChainIdMismatchError);
+      expect(sendRawTransactionMock).not.toHaveBeenCalled();
+    });
+
+    test("rejects an EOA provider switch after signing", async () => {
+      account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
+      const signedTransaction = await account.signTransaction({
+        ...SUPPLY_TX,
+        ...POPULATED_TRANSACTION,
+      });
+      vi.mocked(account.signTransaction)
+        .mockClear()
+        .mockImplementationOnce(async () => {
+          mockGetChainId.mockResolvedValue(8453);
+          return signedTransaction;
+        });
+
+      await expect(
+        protocol.supply({ token: TOKEN, amount: 100_000n }),
+      ).rejects.toBeInstanceOf(ChainIdMismatchError);
+      expect(sendRawTransactionMock).not.toHaveBeenCalled();
     });
 
     test("should use vaultV2 when an explicit vault is configured", async () => {
@@ -243,9 +407,6 @@ describe.sequential("MorphoProtocolEvm", () => {
       });
 
       account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-supply-hash", fee: 12_345n });
 
       await protocol.supply({ token: TOKEN, amount: 100_000n });
 
@@ -277,6 +438,7 @@ describe.sequential("MorphoProtocolEvm", () => {
         chainId: 1,
         earnVaultAddress: VAULT as string,
         borrowMarketParams: mutableParams,
+        metadata: { origin: "before" },
       };
       // biome-ignore lint/suspicious/noShadow: test-local protocol shadowing the suite default
       const protocol = new MorphoProtocolEvm(
@@ -287,15 +449,16 @@ describe.sequential("MorphoProtocolEvm", () => {
       );
       options.earnVaultAddress = "0x0000000000000000000000000000000000000001";
       mutableParams.loanToken = COLLATERAL;
+      options.metadata.origin = "after";
 
       account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-supply-hash", fee: 12_345n });
 
       await protocol.supply({ token: TOKEN, amount: 100_000n });
 
       expect(vaultV2Mock).toHaveBeenCalledWith(VAULT, 1);
+      expect(morphoViemExtensionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: { origin: "before" } }),
+      );
       expect(vaultV2Entity.deposit).toHaveBeenCalledWith(
         expect.objectContaining({
           amount: 100_000n,
@@ -310,9 +473,6 @@ describe.sequential("MorphoProtocolEvm", () => {
       });
 
       account.getTokenBalance = vi.fn();
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-supply-hash", fee: 12_345n });
 
       await protocol.supply({ token: COLLATERAL, nativeAmount: 100_000n });
 
@@ -343,9 +503,6 @@ describe.sequential("MorphoProtocolEvm", () => {
       });
 
       account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-supply-hash", fee: 12_345n });
 
       await protocol.supply({ token: TOKEN, amount: 100_000n });
 
@@ -415,7 +572,7 @@ describe.sequential("MorphoProtocolEvm", () => {
     });
   });
 
-  describe("quoteSupply", () => {
+  describe("quotes", () => {
     test("should quote a vault deposit transaction", async () => {
       account.quoteSendTransaction = vi
         .fn()
@@ -429,14 +586,75 @@ describe.sequential("MorphoProtocolEvm", () => {
       expect(account.quoteSendTransaction).toHaveBeenCalledWith(SUPPLY_TX);
       expect(result).toEqual({ fee: 12_345n });
     });
+
+    test.each([
+      {
+        name: "quoteWithdraw",
+        quote: () => protocol.quoteWithdraw({ token: TOKEN, amount: 100_000n }),
+        transaction: WITHDRAW_TX,
+      },
+      {
+        name: "quoteBorrow",
+        quote: () => protocol.quoteBorrow({ token: TOKEN, amount: 100_000n }),
+        transaction: BORROW_TX,
+      },
+      {
+        name: "quoteRepay",
+        quote: () => protocol.quoteRepay({ token: TOKEN, amount: 100_000n }),
+        transaction: REPAY_TX,
+      },
+      {
+        name: "quoteSupplyCollateral",
+        quote: () =>
+          protocol.quoteSupplyCollateral({
+            token: COLLATERAL,
+            amount: 100_000n,
+          }),
+        transaction: SUPPLY_COLLATERAL_TX,
+      },
+      {
+        name: "quoteWithdrawCollateral",
+        quote: () =>
+          protocol.quoteWithdrawCollateral({
+            token: COLLATERAL,
+            amount: 100_000n,
+          }),
+        transaction: WITHDRAW_COLLATERAL_TX,
+      },
+    ])(
+      "should route $name through the WDK quote API",
+      async ({ quote, transaction }) => {
+        account.quoteSendTransaction = vi
+          .fn()
+          .mockResolvedValue({ fee: 12_345n });
+
+        await expect(quote()).resolves.toEqual({ fee: 12_345n });
+
+        expect(account.quoteSendTransaction).toHaveBeenCalledWith(transaction);
+      },
+    );
+
+    test("snapshots collateral-withdraw quote options", async () => {
+      const observedChain = Promise.withResolvers<number>();
+      mockGetChainId.mockImplementationOnce(() => observedChain.promise);
+      account.quoteSendTransaction = vi
+        .fn()
+        .mockResolvedValue({ fee: 12_345n });
+      const options = { token: COLLATERAL, amount: 100_000n };
+
+      const pending = protocol.quoteWithdrawCollateral(options);
+      options.amount = 200_000n;
+      observedChain.resolve(1);
+      await pending;
+
+      expect(marketEntity.withdrawCollateral).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 100_000n }),
+      );
+    });
   });
 
   describe("withdraw", () => {
     test("should build a vault withdraw with morpho-sdk and send it", async () => {
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-withdraw-hash", fee: 12_345n });
-
       const result = await protocol.withdraw({
         token: TOKEN,
         amount: 100_000n,
@@ -446,8 +664,14 @@ describe.sequential("MorphoProtocolEvm", () => {
         amount: 100_000n,
         userAddress: ADDRESS,
       });
-      expect(account.sendTransaction).toHaveBeenCalledWith(WITHDRAW_TX);
-      expect(result).toEqual({ hash: "dummy-withdraw-hash", fee: 12_345n });
+      expect(account.signTransaction).toHaveBeenCalledWith({
+        ...WITHDRAW_TX,
+        ...POPULATED_TRANSACTION,
+      });
+      expect(result).toEqual({
+        hash: "dummy-transaction-hash",
+        fee: 12_345n,
+      });
     });
 
     test("should throw if 'to' is not the wallet address", async () => {
@@ -459,6 +683,21 @@ describe.sequential("MorphoProtocolEvm", () => {
         }),
       ).rejects.toThrow(
         "'to' must equal the wallet account address for Morpho vault withdrawals.",
+      );
+    });
+
+    test("snapshots withdraw options before resolving chain state", async () => {
+      const observedChain = Promise.withResolvers<number>();
+      mockGetChainId.mockImplementationOnce(() => observedChain.promise);
+      const options = { token: TOKEN, amount: 100_000n };
+
+      const pending = protocol.withdraw(options);
+      options.amount = 200_000n;
+      observedChain.resolve(1);
+      await pending;
+
+      expect(vaultV2Entity.withdraw).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 100_000n }),
       );
     });
   });
@@ -474,10 +713,6 @@ describe.sequential("MorphoProtocolEvm", () => {
     });
 
     test("should build a market borrow with morpho-sdk and send it", async () => {
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-borrow-hash", fee: 12_345n });
-
       const result = await protocol.borrow({ token: TOKEN, amount: 100_000n });
 
       expect(blueMock).toHaveBeenCalledWith(
@@ -495,8 +730,14 @@ describe.sequential("MorphoProtocolEvm", () => {
         slippageTolerance: undefined,
         reallocations: undefined,
       });
-      expect(account.sendTransaction).toHaveBeenCalledWith(BORROW_TX);
-      expect(result).toEqual({ hash: "dummy-borrow-hash", fee: 12_345n });
+      expect(account.signTransaction).toHaveBeenCalledWith({
+        ...BORROW_TX,
+        ...POPULATED_TRANSACTION,
+      });
+      expect(result).toEqual({
+        hash: "dummy-transaction-hash",
+        fee: 12_345n,
+      });
     });
 
     test("should forward Vault V2 BluePublicAllocator reallocations", async () => {
@@ -509,10 +750,6 @@ describe.sequential("MorphoProtocolEvm", () => {
         assets: 50_000n,
         penalty: 1n,
       } satisfies VaultV2BlueReallocation;
-
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-v2-borrow-hash", fee: 12_345n });
 
       await protocol.borrow({
         token: TOKEN,
@@ -529,6 +766,114 @@ describe.sequential("MorphoProtocolEvm", () => {
       });
     });
 
+    test("snapshots borrow inputs before resolving chain state", async () => {
+      const observedChain = Promise.withResolvers<number>();
+      mockGetChainId.mockImplementationOnce(() => observedChain.promise);
+      const adapter = "0x0000000000000000000000000000000000000020";
+      const sourceMarketParams = new MarketParams({
+        ...MARKET_PARAMS,
+        collateralToken: VAULT,
+      });
+      const reallocation = {
+        vault: VAULT,
+        from: {
+          type: "market",
+          adapter: COLLATERAL,
+          marketParams: sourceMarketParams,
+        },
+        to: { adapter: adapter as `0x${string}` },
+        assets: 50_000n,
+        penalty: 1n,
+      } satisfies VaultV2BlueReallocation;
+      const requirementSignature = {
+        args: {
+          owner: ADDRESS,
+          authorized: adapter,
+          isAuthorized: true,
+          nonce: 1n,
+          deadline: 2n,
+          signature: "0x01",
+        },
+        action: {
+          type: "authorization",
+          args: { authorized: adapter, isAuthorized: true, deadline: 2n },
+        },
+      } satisfies RequirementSignature;
+      const options = {
+        token: TOKEN,
+        amount: 100_000n,
+        reallocations: [reallocation],
+        requirementSignature,
+      } satisfies MorphoBorrowWithVaultV2ReallocationsOptions;
+
+      const pending = protocol.borrow(options);
+      options.amount = 200_000n;
+      reallocation.assets = 75_000n;
+      reallocation.to.adapter = TOKEN;
+      Object.assign(sourceMarketParams, { collateralToken: TOKEN });
+      requirementSignature.args.deadline = 3n;
+      requirementSignature.action.args.deadline = 3n;
+      observedChain.resolve(1);
+      await pending;
+
+      expect(marketEntity.borrow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 100_000n,
+          reallocations: [
+            expect.objectContaining({
+              assets: 50_000n,
+              from: expect.objectContaining({
+                type: "market",
+                marketParams: expect.objectContaining({
+                  collateralToken: VAULT,
+                }),
+              }),
+              to: { adapter },
+            }),
+          ],
+        }),
+      );
+      const forwardedSignature = borrowAction.buildTx.mock.calls[0]?.[0]?.[0];
+      expect(forwardedSignature).not.toBe(requirementSignature);
+      expect(forwardedSignature).toEqual(
+        expect.objectContaining({
+          args: expect.objectContaining({ deadline: 2n }),
+          action: expect.objectContaining({
+            args: expect.objectContaining({ deadline: 2n }),
+          }),
+        }),
+      );
+    });
+
+    test("snapshots Vault V1 reallocation withdrawals", async () => {
+      const observedChain = Promise.withResolvers<number>();
+      mockGetChainId.mockImplementationOnce(() => observedChain.promise);
+      const withdrawal = {
+        marketParams: new MarketParams(MARKET_PARAMS),
+        amount: 50_000n,
+      };
+      const options = {
+        token: TOKEN,
+        amount: 100_000n,
+        reallocations: [{ vault: VAULT, fee: 1n, withdrawals: [withdrawal] }],
+      } satisfies MorphoBorrowOptions;
+
+      const pending = protocol.getBorrowRequirements(options);
+      withdrawal.amount = 75_000n;
+      observedChain.resolve(1);
+      await pending;
+
+      expect(marketEntity.borrow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reallocations: [
+            expect.objectContaining({
+              withdrawals: [expect.objectContaining({ amount: 50_000n })],
+            }),
+          ],
+        }),
+      );
+    });
+
     test("should fetch market params when only borrowMarketId is configured", async () => {
       // biome-ignore lint/suspicious/noShadow: test-local protocol shadowing the suite default
       const protocol = new MorphoProtocolEvm(account, {
@@ -536,10 +881,6 @@ describe.sequential("MorphoProtocolEvm", () => {
         earnVaultAddress: VAULT,
         borrowMarketId: MARKET_ID,
       });
-
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-borrow-hash", fee: 12_345n });
 
       await protocol.borrow({ token: TOKEN, amount: 100_000n });
 
@@ -614,19 +955,12 @@ describe.sequential("MorphoProtocolEvm", () => {
     });
 
     test("should build the borrow without signatures by default", async () => {
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-borrow-hash", fee: 12_345n });
-
       await protocol.borrow({ token: TOKEN, amount: 100_000n });
 
       expect(borrowAction.buildTx).toHaveBeenCalledWith(undefined);
     });
 
     test("should fold a signed authorization into the bundle when provided", async () => {
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-borrow-hash", fee: 12_345n });
       const requirementSignature = {
         action: { type: "authorization" },
       } as unknown as RequirementSignature;
@@ -637,7 +971,11 @@ describe.sequential("MorphoProtocolEvm", () => {
         requirementSignature,
       });
 
-      expect(borrowAction.buildTx).toHaveBeenCalledWith([requirementSignature]);
+      expect(borrowAction.buildTx).toHaveBeenCalledWith([
+        expect.objectContaining({
+          action: expect.objectContaining({ type: "authorization" }),
+        }),
+      ]);
     });
 
     test("should throw if 'onBehalfOf' differs from the wallet address", async () => {
@@ -666,10 +1004,6 @@ describe.sequential("MorphoProtocolEvm", () => {
 
   describe("repay", () => {
     test("should build a max repay by shares with morpho-sdk", async () => {
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-repay-hash", fee: 12_345n });
-
       const result = await protocol.repay({ token: TOKEN, amount: "max" });
 
       expect(marketEntity.repay).toHaveBeenCalledWith({
@@ -678,15 +1012,18 @@ describe.sequential("MorphoProtocolEvm", () => {
         positionData,
         slippageTolerance: undefined,
       });
-      expect(account.sendTransaction).toHaveBeenCalledWith(REPAY_TX);
-      expect(result).toEqual({ hash: "dummy-repay-hash", fee: 12_345n });
+      expect(account.signTransaction).toHaveBeenCalledWith({
+        ...REPAY_TX,
+        ...POPULATED_TRANSACTION,
+      });
+      expect(result).toEqual({
+        hash: "dummy-transaction-hash",
+        fee: 12_345n,
+      });
     });
 
     test("should build an asset repay with morpho-sdk after balance check", async () => {
       account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-repay-hash", fee: 12_345n });
 
       await protocol.repay({ token: TOKEN, amount: 100_000n });
 
@@ -716,9 +1053,6 @@ describe.sequential("MorphoProtocolEvm", () => {
   describe("collateral", () => {
     test("should build a supply collateral transaction with morpho-sdk", async () => {
       account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-collateral-hash", fee: 12_345n });
 
       const result = await protocol.supplyCollateral({
         token: COLLATERAL,
@@ -730,17 +1064,18 @@ describe.sequential("MorphoProtocolEvm", () => {
         nativeAmount: undefined,
         userAddress: ADDRESS,
       });
-      expect(account.sendTransaction).toHaveBeenCalledWith(
-        SUPPLY_COLLATERAL_TX,
-      );
-      expect(result).toEqual({ hash: "dummy-collateral-hash", fee: 12_345n });
+      expect(account.signTransaction).toHaveBeenCalledWith({
+        ...SUPPLY_COLLATERAL_TX,
+        ...POPULATED_TRANSACTION,
+      });
+      expect(result).toEqual({
+        hash: "dummy-transaction-hash",
+        fee: 12_345n,
+      });
     });
 
     test("should build a native-only supply collateral transaction", async () => {
       account.getTokenBalance = vi.fn();
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-collateral-hash", fee: 12_345n });
 
       await protocol.supplyCollateral({
         token: COLLATERAL,
@@ -756,11 +1091,6 @@ describe.sequential("MorphoProtocolEvm", () => {
     });
 
     test("should build a withdraw collateral transaction with morpho-sdk", async () => {
-      account.sendTransaction = vi.fn().mockResolvedValue({
-        hash: "dummy-withdraw-collateral-hash",
-        fee: 12_345n,
-      });
-
       const result = await protocol.withdrawCollateral({
         token: COLLATERAL,
         amount: 100_000n,
@@ -771,11 +1101,12 @@ describe.sequential("MorphoProtocolEvm", () => {
         userAddress: ADDRESS,
         positionData,
       });
-      expect(account.sendTransaction).toHaveBeenCalledWith(
-        WITHDRAW_COLLATERAL_TX,
-      );
+      expect(account.signTransaction).toHaveBeenCalledWith({
+        ...WITHDRAW_COLLATERAL_TX,
+        ...POPULATED_TRANSACTION,
+      });
       expect(result).toEqual({
-        hash: "dummy-withdraw-collateral-hash",
+        hash: "dummy-transaction-hash",
         fee: 12_345n,
       });
     });
@@ -795,7 +1126,7 @@ describe.sequential("MorphoProtocolEvm", () => {
   });
 
   describe("erc-4337", () => {
-    test("should send through an erc-4337 account with config", async () => {
+    test("should use the validated balance client, snapshot config, and send a signed erc-4337 operation", async () => {
       // biome-ignore lint/suspicious/noShadow: test-local account shadowing the suite default
       const account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
         chainId: 1,
@@ -807,9 +1138,17 @@ describe.sequential("MorphoProtocolEvm", () => {
       });
       account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
       account.getTokenBalance = vi.fn().mockResolvedValue(100_000n);
+      readContractMock.mockResolvedValueOnce(0n);
+      account.quoteSendTransaction = vi
+        .fn()
+        .mockResolvedValue({ fee: 12_345n });
+      const signed = { signature: "0x01" } as unknown as Awaited<
+        ReturnType<typeof account.signTransaction>
+      >;
+      account.signTransaction = vi.fn().mockResolvedValue(signed);
       account.sendTransaction = vi
         .fn()
-        .mockResolvedValue({ hash: "dummy-user-operation-hash", fee: 12_345n });
+        .mockResolvedValue({ hash: "dummy-user-operation-hash", fee: 99_999n });
 
       // biome-ignore lint/suspicious/noShadow: test-local protocol shadowing the suite default
       const protocol = new MorphoProtocolEvm(account, {
@@ -818,25 +1157,83 @@ describe.sequential("MorphoProtocolEvm", () => {
         borrowMarketParams: MARKET_PARAMS,
       });
 
+      await expect(
+        protocol.supply({ token: TOKEN, amount: 100_000n }),
+      ).rejects.toBeInstanceOf(Error);
+      expect(account.getTokenBalance).not.toHaveBeenCalled();
+      expect(account.quoteSendTransaction).not.toHaveBeenCalled();
+
+      readContractMock.mockResolvedValue(100_000n);
+      const observedChain = Promise.withResolvers<number>();
+      mockGetChainId.mockImplementationOnce(() => observedChain.promise);
       const config = { paymasterToken: { address: TOKEN } };
-      const result = await protocol.supply(
+      const pending = protocol.supply(
         { token: TOKEN, amount: 100_000n },
         config,
       );
+      config.paymasterToken.address = COLLATERAL;
+      observedChain.resolve(1);
+      const result = await pending;
 
-      expect(account.sendTransaction).toHaveBeenCalledWith(SUPPLY_TX, config);
+      expect(account.getTokenBalance).not.toHaveBeenCalled();
+      expect(readContractMock).toHaveBeenCalledWith({
+        address: TOKEN,
+        abi: viem.erc20Abi,
+        functionName: "balanceOf",
+        args: [ADDRESS],
+      });
+      const operationConfig = vi.mocked(account.quoteSendTransaction).mock
+        .calls[0]?.[1];
+      expect(operationConfig).toEqual({
+        paymasterToken: { address: TOKEN },
+      });
+      expect(operationConfig).not.toBe(config);
+      expect(
+        operationConfig !== undefined &&
+          "paymasterToken" in operationConfig &&
+          operationConfig.paymasterToken,
+      ).not.toBe(config.paymasterToken);
+      expect(account.signTransaction).toHaveBeenCalledWith(
+        SUPPLY_TX,
+        operationConfig,
+      );
+      expect(account.sendTransaction).toHaveBeenCalledWith(
+        signed,
+        operationConfig,
+      );
       expect(result).toEqual({
         hash: "dummy-user-operation-hash",
         fee: 12_345n,
       });
+
+      vi.mocked(account.quoteSendTransaction).mockClear();
+      const quoteConfig = { useNativeCoins: true as const };
+      await expect(
+        protocol.quoteBorrow({ token: TOKEN, amount: 100_000n }, quoteConfig),
+      ).resolves.toEqual({ fee: 12_345n });
+      const forwardedQuoteConfig = vi.mocked(account.quoteSendTransaction).mock
+        .calls[0]?.[1];
+      expect(account.quoteSendTransaction).toHaveBeenCalledWith(
+        BORROW_TX,
+        quoteConfig,
+      );
+      expect(forwardedQuoteConfig).not.toBe(quoteConfig);
+
+      mockGetChainId.mockResolvedValue(1);
+      vi.mocked(account.sendTransaction).mockClear();
+      vi.mocked(account.signTransaction).mockImplementationOnce(async () => {
+        mockGetChainId.mockResolvedValue(8453);
+        return signed;
+      });
+      await expect(
+        protocol.supply({ token: TOKEN, amount: 100_000n }),
+      ).rejects.toBeInstanceOf(ChainIdMismatchError);
+      expect(account.sendTransaction).not.toHaveBeenCalled();
     });
 
     test("snapshots native value before resolving chain state", async () => {
       const observedChain = Promise.withResolvers<number>();
       mockGetChainId.mockImplementationOnce(() => observedChain.promise);
-      account.sendTransaction = vi
-        .fn()
-        .mockResolvedValue({ hash: "dummy-supply-hash", fee: 12_345n });
       const options = { token: TOKEN, nativeAmount: 100_000n };
 
       const result = protocol.supply(options);
@@ -851,17 +1248,27 @@ describe.sequential("MorphoProtocolEvm", () => {
   });
 
   describe("read methods", () => {
-    test("preserves provider-array failover attempts", async () => {
+    test("tracks the provider selected by WDK failover", async () => {
       const attempts: string[] = [];
-      const providers = ["A", "B"].map((label) => ({
-        request: vi.fn(async () => {
-          attempts.push(label);
-          throw new Error(label);
-        }),
-      }));
+      const providers = [
+        {
+          request: vi.fn(async ({ method }: { method: string }) => {
+            attempts.push(`A:${method}`);
+            if (method === "eth_blockNumber") throw new Error("A down");
+            return method === "eth_chainId" ? "0x1" : "0x0";
+          }),
+        },
+        {
+          request: vi.fn(async ({ method }: { method: string }) => {
+            attempts.push(`B:${method}`);
+            if (method === "eth_chainId") return "0x2105";
+            return method === "eth_blockNumber" ? "0x1" : "0x0";
+          }),
+        },
+      ];
       const fallbackAccount = new WalletAccountReadOnlyEvm(ADDRESS, {
         provider: providers,
-        retries: 3,
+        retries: 1,
         chainId: 1,
       });
       fallbackAccount.getAddress = vi.fn().mockResolvedValue(ADDRESS);
@@ -872,14 +1279,24 @@ describe.sequential("MorphoProtocolEvm", () => {
 
       await fallbackProtocol.getMarketPosition();
 
+      const accountProvider = Reflect.get(fallbackAccount, "_provider") as {
+        send(method: string, params: readonly unknown[]): Promise<unknown>;
+      };
+      await accountProvider.send("eth_blockNumber", []);
       const clientConfig = createClientMock.mock.calls[0]?.[0] as {
         transport: viem.Transport;
       };
       const transport = clientConfig.transport({ retryCount: 0 });
-      await expect(
-        transport.request({ method: "eth_chainId" }),
-      ).rejects.toThrow();
-      expect(attempts).toEqual(["A", "B", "A", "B"]);
+      await expect(transport.request({ method: "eth_chainId" })).resolves.toBe(
+        "0x2105",
+      );
+      expect(attempts).toEqual([
+        "A:eth_chainId",
+        "A:eth_blockNumber",
+        "B:eth_chainId",
+        "B:eth_blockNumber",
+        "B:eth_chainId",
+      ]);
     });
 
     test("should return vault position data", async () => {
@@ -989,8 +1406,6 @@ describe.sequential("MorphoProtocolEvm", () => {
         .mockResolvedValueOnce(1)
         .mockImplementationOnce(() => dispatchChain.promise)
         .mockImplementationOnce(() => newerChain.promise);
-      account.sendTransaction = vi.fn();
-
       const supply = protocol.supply({ token: TOKEN, nativeAmount: 100_000n });
       await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(3));
       const position = protocol.getMarketPosition();
@@ -998,7 +1413,7 @@ describe.sequential("MorphoProtocolEvm", () => {
 
       dispatchChain.resolve(1);
       await Promise.resolve();
-      expect(account.sendTransaction).not.toHaveBeenCalled();
+      expect(sendRawTransactionMock).not.toHaveBeenCalled();
 
       newerChain.resolve(8453);
       await expect(supply).rejects.toBeInstanceOf(ChainIdMismatchError);
@@ -1063,15 +1478,13 @@ describe.sequential("MorphoProtocolEvm", () => {
         .mockResolvedValueOnce(1)
         .mockResolvedValueOnce(1)
         .mockResolvedValueOnce(8453);
-      account.sendTransaction = vi.fn();
-
       await expect(
         protocol.supply({ token: TOKEN, nativeAmount: 100_000n }),
       ).rejects.toBeInstanceOf(ChainIdMismatchError);
-      expect(account.sendTransaction).not.toHaveBeenCalled();
+      expect(sendRawTransactionMock).not.toHaveBeenCalled();
     });
 
-    test("rejects a quote when its completion crosses chains", async () => {
+    test("rejects a market quote when its completion crosses chains", async () => {
       mockGetChainId
         .mockResolvedValueOnce(1)
         .mockResolvedValueOnce(1)
@@ -1082,7 +1495,7 @@ describe.sequential("MorphoProtocolEvm", () => {
         .mockResolvedValue({ fee: 12_345n });
 
       await expect(
-        protocol.quoteSupply({ token: TOKEN, amount: 100_000n }),
+        protocol.quoteBorrow({ token: TOKEN, amount: 100_000n }),
       ).rejects.toBeInstanceOf(ChainIdMismatchError);
     });
 
@@ -1131,6 +1544,66 @@ describe.sequential("MorphoProtocolEvm", () => {
   });
 
   describe("erc-4337 chain binding", () => {
+    test("preserves the invalid chain across out-of-order provider requests", async () => {
+      const first = Promise.withResolvers<number>();
+      const second = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+      const handle = createMockClient(mainnet);
+      handle.request.mockImplementation(async ({ method }) => {
+        if (method === "eth_chainId") {
+          const chainId = await mockGetChainId();
+          return `0x${chainId.toString(16)}`;
+        }
+        throw new Error(`Unhandled RPC ${method}`);
+      });
+      const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
+        chainId: 1,
+        provider: {
+          request: ({ method, params }) =>
+            handle.request({
+              method,
+              params: Array.isArray(params) ? params : undefined,
+            }),
+        },
+        bundlerUrl: "https://dummy-bundler-url.com",
+        safeModulesVersion: "0.3.0",
+        isSponsored: false,
+        useNativeCoins: true,
+      });
+      erc4337Account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+      const erc4337Protocol = new MorphoProtocolEvm(erc4337Account, {
+        chainId: 1,
+        borrowMarketParams: MARKET_PARAMS,
+      });
+
+      await createClientMock.withImplementation(
+        (parameters) =>
+          viem.createClient(
+            parameters as Parameters<typeof viem.createClient>[0],
+          ),
+        async () => {
+          const firstPosition = erc4337Protocol.getMarketPosition();
+          const secondPosition = erc4337Protocol.getMarketPosition();
+          second.resolve(8453);
+          await expect(secondPosition).rejects.toBeInstanceOf(
+            ChainIdMismatchError,
+          );
+          first.resolve(1);
+          await expect(firstPosition).rejects.toBeInstanceOf(
+            ChainIdMismatchError,
+          );
+        },
+      );
+
+      expect(handle.request.mock.calls.map(([call]) => call.method)).toEqual([
+        "eth_chainId",
+        "eth_chainId",
+      ]);
+      expect(Reflect.get(erc4337Protocol, "_erc4337InvalidChainId")).toBe(8453);
+    });
+
     test("rejects a cached account chain before resolving entities", async () => {
       const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
         chainId: 8453,
@@ -1202,6 +1675,16 @@ describe.sequential("MorphoProtocolEvm", () => {
   });
 
   describe("read-only accounts", () => {
+    test("error: MissingWalletProviderError", () => {
+      const providerlessAccount = new WalletAccountEvm(SEED, "0'/0/0", {
+        provider: [],
+      });
+
+      expect(() => new MorphoProtocolEvm(providerlessAccount)).toThrow(
+        MissingWalletProviderError,
+      );
+    });
+
     test("should reject write methods", async () => {
       // biome-ignore lint/suspicious/noShadow: test-local account shadowing the suite default
       const account = new WalletAccountReadOnlyEvm(ADDRESS, {

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.test.ts
@@ -1218,6 +1218,133 @@ describe.sequential("MorphoProtocolEvm", () => {
       expect(forwardedQuoteConfig).not.toBe(quoteConfig);
     });
 
+    test("binds WDK's signing chain without splitting atomic dispatch", async () => {
+      // biome-ignore lint/suspicious/noShadow: test-local account shadowing the suite default
+      const account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
+        chainId: 1,
+        provider: "https://dummy-rpc-url.com",
+        bundlerUrl: "https://dummy-bundler-url.com",
+        safeModulesVersion: "0.3.0",
+        isSponsored: false,
+        useNativeCoins: true,
+      });
+      account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+      readContractMock.mockResolvedValue(100_000n);
+      let signingChainId: bigint | undefined;
+      account.sendTransaction = vi.fn(async function (this: object) {
+        (account as unknown as { _chainId: bigint | undefined })._chainId =
+          8453n;
+        const getChainId = Reflect.get(
+          this,
+          "_getChainId",
+        ) as () => Promise<bigint>;
+        signingChainId = await getChainId.call(this);
+        return { hash: "dummy-user-operation-hash", fee: 777n };
+      });
+      // biome-ignore lint/suspicious/noShadow: test-local protocol shadowing the suite default
+      const protocol = new MorphoProtocolEvm(account, {
+        chainId: 1,
+        earnVaultAddress: VAULT,
+      });
+
+      await expect(
+        protocol.supply(
+          { token: TOKEN, amount: 100_000n },
+          { paymasterToken: { address: TOKEN } },
+        ),
+      ).resolves.toEqual({ hash: "dummy-user-operation-hash", fee: 777n });
+
+      expect(signingChainId).toBe(1n);
+      expect(account.sendTransaction).toHaveBeenCalledWith(SUPPLY_TX, {
+        paymasterToken: { address: TOKEN },
+        nonceKey: 0n,
+      });
+    });
+
+    test("behavior: bypasses WDK's transaction-only quote cache", async () => {
+      const provider = {
+        request: vi.fn(async ({ method }: { method: string }) => {
+          if (method === "eth_chainId") return "0x1";
+          if (method === "eth_call") return "0x0";
+          throw new Error(`Unhandled RPC ${method}`);
+        }),
+      };
+      const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
+        chainId: 1,
+        provider,
+        bundlerUrl: "https://dummy-bundler-url.com",
+        safeModulesVersion: "0.3.0",
+        isSponsored: false,
+        useNativeCoins: true,
+      });
+      erc4337Account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
+      readContractMock.mockResolvedValue(100_000n);
+
+      const internals = erc4337Account as unknown as {
+        _buildUserOperation: (...args: unknown[]) => Promise<unknown>;
+        _sendUserOperation: (...args: unknown[]) => Promise<string>;
+      };
+      const smartAccount = {
+        entrypointAddress: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+        accountAddress: ADDRESS,
+      };
+      const cachedUserOp = {
+        nonce: 0n,
+        callGasLimit: 1n,
+        verificationGasLimit: 1n,
+        preVerificationGas: 1n,
+        maxFeePerGas: 100n,
+      };
+      const buildUserOperation = vi
+        .spyOn(internals, "_buildUserOperation")
+        .mockResolvedValueOnce({
+          userOp: cachedUserOp,
+          smartAccount,
+          chainId: 1n,
+          mode: "native",
+        })
+        .mockResolvedValueOnce({
+          userOp: { ...cachedUserOp, maxFeePerGas: 200n },
+          smartAccount,
+          chainId: 1n,
+          mode: "native",
+        });
+      vi.spyOn(internals, "_sendUserOperation").mockResolvedValue(
+        "dummy-user-operation-hash",
+      );
+      const sendTransaction = vi.spyOn(erc4337Account, "sendTransaction");
+      const erc4337Protocol = new MorphoProtocolEvm(erc4337Account, {
+        chainId: 1,
+        earnVaultAddress: VAULT,
+      });
+
+      await expect(
+        erc4337Protocol.quoteSupply(
+          { token: TOKEN, amount: 100_000n },
+          { transactionMaxFee: 400n },
+        ),
+      ).resolves.toEqual({ fee: 360n });
+      await expect(
+        erc4337Protocol.supply(
+          { token: TOKEN, amount: 100_000n },
+          { transactionMaxFee: 1_000n },
+        ),
+      ).resolves.toEqual({
+        hash: "dummy-user-operation-hash",
+        fee: 720n,
+      });
+
+      expect(sendTransaction).toHaveBeenCalledWith(SUPPLY_TX, {
+        transactionMaxFee: 1_000n,
+        nonceKey: 0n,
+      });
+      expect(buildUserOperation).toHaveBeenCalledTimes(2);
+      expect(buildUserOperation.mock.calls[1]?.[1]).toEqual(
+        expect.objectContaining({ transactionMaxFee: 1_000n, nonceKey: 0n }),
+      );
+      expect(buildUserOperation.mock.calls[1]?.[2]).toEqual({ nonce: 0n });
+    });
+
     test.each([
       ["parallel", { parallel: true }],
       ["custom nonce", { nonceKey: "morpho" }],
@@ -1351,9 +1478,10 @@ describe.sequential("MorphoProtocolEvm", () => {
       });
     });
 
-    test("should invalidate chain-bound caches when the provider chain changes", async () => {
+    test("reuses same-chain clients after the provider returns", async () => {
       await protocol.getMarketPosition();
       expect(blueMock).toHaveBeenCalledWith(expect.any(Object), 1);
+      expect(morphoViemExtensionMock).toHaveBeenCalledOnce();
 
       mockGetChainId.mockResolvedValue(8453);
 
@@ -1365,10 +1493,10 @@ describe.sequential("MorphoProtocolEvm", () => {
       mockGetChainId.mockResolvedValue(1);
       await protocol.getMarketPosition();
       expect(blueMock).toHaveBeenCalledTimes(2);
-      expect(morphoViemExtensionMock).toHaveBeenCalledTimes(2);
+      expect(morphoViemExtensionMock).toHaveBeenCalledOnce();
     });
 
-    test("shares one context across same-chain operations completing out of order", async () => {
+    test("serializes concurrent chain observations by invocation order", async () => {
       const first = Promise.withResolvers<number>();
       const second = Promise.withResolvers<number>();
       mockGetChainId
@@ -1378,70 +1506,29 @@ describe.sequential("MorphoProtocolEvm", () => {
       const firstPosition = protocol.getMarketPosition();
       const secondPosition = protocol.getMarketPosition();
       second.resolve(1);
-      await expect(secondPosition).resolves.toEqual(
-        expect.objectContaining({ marketId: expect.any(String) }),
-      );
+      await expect(
+        Promise.race([
+          secondPosition.then(() => "settled"),
+          Promise.resolve("pending"),
+        ]),
+      ).resolves.toBe("pending");
       first.resolve(1);
-      await expect(firstPosition).resolves.toEqual(
+      await expect(
+        Promise.all([firstPosition, secondPosition]),
+      ).resolves.toEqual([
         expect.objectContaining({ marketId: expect.any(String) }),
-      );
+        expect.objectContaining({ marketId: expect.any(String) }),
+      ]);
     });
 
-    test("waits for a newer same-chain observation when the older resolves first", async () => {
-      const first = Promise.withResolvers<number>();
-      const second = Promise.withResolvers<number>();
-      mockGetChainId
-        .mockImplementationOnce(() => first.promise)
-        .mockImplementationOnce(() => second.promise);
+    test("recovers after a failed chain observation", async () => {
+      const providerError = new Error("provider unavailable");
+      mockGetChainId.mockRejectedValueOnce(providerError);
 
-      const firstPosition = protocol.getMarketPosition();
-      const secondPosition = protocol.getMarketPosition();
-      first.resolve(1);
-      second.resolve(1);
-
-      await expect(firstPosition).resolves.toEqual(
+      await expect(protocol.getMarketPosition()).rejects.toBe(providerError);
+      await expect(protocol.getMarketPosition()).resolves.toEqual(
         expect.objectContaining({ marketId: expect.any(String) }),
       );
-      await expect(secondPosition).resolves.toEqual(
-        expect.objectContaining({ marketId: expect.any(String) }),
-      );
-    });
-
-    test("rejects conflicting chain observations completing out of order", async () => {
-      const first = Promise.withResolvers<number>();
-      const second = Promise.withResolvers<number>();
-      mockGetChainId
-        .mockImplementationOnce(() => first.promise)
-        .mockImplementationOnce(() => second.promise);
-
-      const firstPosition = protocol.getMarketPosition();
-      const secondPosition = protocol.getMarketPosition();
-      second.resolve(8453);
-      await expect(secondPosition).rejects.toBeInstanceOf(ChainIdMismatchError);
-      first.resolve(1);
-      await expect(firstPosition).rejects.toBeInstanceOf(ChainIdMismatchError);
-    });
-
-    test("rejects dispatch while a newer chain observation is pending", async () => {
-      const dispatchChain = Promise.withResolvers<number>();
-      const newerChain = Promise.withResolvers<number>();
-      mockGetChainId
-        .mockResolvedValueOnce(1)
-        .mockResolvedValueOnce(1)
-        .mockImplementationOnce(() => dispatchChain.promise)
-        .mockImplementationOnce(() => newerChain.promise);
-      const supply = protocol.supply({ token: TOKEN, nativeAmount: 100_000n });
-      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(3));
-      const position = protocol.getMarketPosition();
-      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(4));
-
-      dispatchChain.resolve(1);
-      await Promise.resolve();
-      expect(sendRawTransactionMock).not.toHaveBeenCalled();
-
-      newerChain.resolve(8453);
-      await expect(supply).rejects.toBeInstanceOf(ChainIdMismatchError);
-      await expect(position).rejects.toBeInstanceOf(ChainIdMismatchError);
     });
 
     test("does not cache market data resolved after a chain switch", async () => {
@@ -1469,51 +1556,45 @@ describe.sequential("MorphoProtocolEvm", () => {
       expect(fetchMarketMock).toHaveBeenCalledTimes(2);
     });
 
-    test("invalidates same-chain caches after an observed switch away and back", async () => {
-      await protocol.getMarketPosition();
-      const priorChainReads = mockGetChainId.mock.calls.length;
-      const switchedChain = Promise.withResolvers<number>();
-      const returnedChain = Promise.withResolvers<number>();
-      mockGetChainId
-        .mockImplementationOnce(() => switchedChain.promise)
-        .mockImplementationOnce(() => returnedChain.promise);
-
-      const switchedPosition = protocol.getMarketPosition();
-      const returnedPosition = protocol.getMarketPosition();
-      await vi.waitFor(() =>
-        expect(mockGetChainId).toHaveBeenCalledTimes(priorChainReads + 2),
-      );
-      returnedChain.resolve(1);
-      await expect(returnedPosition).resolves.toEqual(
-        expect.objectContaining({ marketId: expect.any(String) }),
-      );
-      switchedChain.resolve(8453);
-      await expect(switchedPosition).rejects.toBeInstanceOf(
-        ChainIdMismatchError,
-      );
-
-      const cachedEntities = blueMock.mock.calls.length;
-      await protocol.getMarketPosition();
-      expect(blueMock).toHaveBeenCalledTimes(cachedEntities + 1);
-    });
-
     test("rechecks the chain immediately before native-value dispatch", async () => {
-      mockGetChainId
-        .mockResolvedValueOnce(1)
-        .mockResolvedValueOnce(1)
-        .mockResolvedValueOnce(8453);
+      mockGetChainId.mockResolvedValueOnce(1).mockResolvedValueOnce(8453);
       await expect(
         protocol.supply({ token: TOKEN, nativeAmount: 100_000n }),
       ).rejects.toBeInstanceOf(ChainIdMismatchError);
       expect(sendRawTransactionMock).not.toHaveBeenCalled();
     });
 
-    test("rejects a market quote when its completion crosses chains", async () => {
+    test("waits for an older chain observation before dispatch", async () => {
+      const balance = Promise.withResolvers<bigint>();
+      account.getTokenBalance = vi.fn(() => balance.promise);
+      const supply = protocol.supply({ token: TOKEN, amount: 100_000n });
+      await vi.waitFor(() =>
+        expect(account.getTokenBalance).toHaveBeenCalled(),
+      );
+
+      const switchedChain = Promise.withResolvers<number>();
+      const terminalChain = Promise.withResolvers<number>();
       mockGetChainId
-        .mockResolvedValueOnce(1)
-        .mockResolvedValueOnce(1)
-        .mockResolvedValueOnce(1)
-        .mockResolvedValueOnce(8453);
+        .mockImplementationOnce(() => switchedChain.promise)
+        .mockImplementationOnce(() => terminalChain.promise);
+      const switchedPosition = protocol.getMarketPosition();
+      balance.resolve(100_000n);
+      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(3));
+
+      terminalChain.resolve(1);
+      await Promise.resolve();
+      expect(sendRawTransactionMock).not.toHaveBeenCalled();
+
+      switchedChain.resolve(8453);
+      await expect(switchedPosition).rejects.toBeInstanceOf(
+        ChainIdMismatchError,
+      );
+      await expect(supply).rejects.toBeInstanceOf(ChainIdMismatchError);
+      expect(sendRawTransactionMock).not.toHaveBeenCalled();
+    });
+
+    test("rejects a market quote when its completion crosses chains", async () => {
+      mockGetChainId.mockResolvedValueOnce(1).mockResolvedValueOnce(8453);
       account.quoteSendTransaction = vi
         .fn()
         .mockResolvedValue({ fee: 12_345n });
@@ -1523,7 +1604,7 @@ describe.sequential("MorphoProtocolEvm", () => {
       ).rejects.toBeInstanceOf(ChainIdMismatchError);
     });
 
-    test("rejects requirements resolved after another operation observes a switch", async () => {
+    test("rejects an in-flight operation after out-of-order A-B-A observations", async () => {
       const requirementResult =
         Promise.withResolvers<{ action: { type: string } }[]>();
       supplyAction.getRequirements.mockImplementationOnce(
@@ -1537,26 +1618,42 @@ describe.sequential("MorphoProtocolEvm", () => {
         expect(supplyAction.getRequirements).toHaveBeenCalledOnce(),
       );
 
-      mockGetChainId.mockResolvedValue(8453);
-      await expect(protocol.getMarketPosition()).rejects.toBeInstanceOf(
-        ChainIdMismatchError,
+      const olderObservation = Promise.withResolvers<number>();
+      const newerObservation = Promise.withResolvers<number>();
+      mockGetChainId
+        .mockImplementationOnce(() => olderObservation.promise)
+        .mockImplementationOnce(() => newerObservation.promise);
+      const olderPosition = protocol.getMarketPosition();
+      const newerPosition = protocol.getMarketPosition();
+      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(3));
+
+      newerObservation.resolve(1);
+      await expect(
+        Promise.race([
+          newerPosition.then(() => "settled"),
+          Promise.resolve("pending"),
+        ]),
+      ).resolves.toBe("pending");
+      olderObservation.resolve(8453);
+      await expect(olderPosition).rejects.toBeInstanceOf(ChainIdMismatchError);
+      await expect(newerPosition).resolves.toEqual(
+        expect.objectContaining({ marketId: expect.any(String) }),
       );
+
+      mockGetChainId.mockResolvedValue(1);
       requirementResult.resolve([{ action: { type: "erc20Approval" } }]);
       await expect(requirements).rejects.toBeInstanceOf(ChainIdMismatchError);
     });
 
-    test("shares one chain context across account-data reads", async () => {
-      const vaultChain = Promise.withResolvers<number>();
-      const marketChain = Promise.withResolvers<number>();
+    test("checks account-data reads at the operation boundaries", async () => {
+      const finalChain = Promise.withResolvers<number>();
       mockGetChainId
         .mockResolvedValueOnce(1)
-        .mockImplementationOnce(() => vaultChain.promise)
-        .mockImplementationOnce(() => marketChain.promise);
+        .mockImplementationOnce(() => finalChain.promise);
 
       const accountData = protocol.getAccountData();
-      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(3));
-      vaultChain.resolve(1);
-      marketChain.resolve(1);
+      await vi.waitFor(() => expect(mockGetChainId).toHaveBeenCalledTimes(2));
+      finalChain.resolve(1);
 
       await expect(accountData).resolves.toEqual(
         expect.objectContaining({
@@ -1564,70 +1661,11 @@ describe.sequential("MorphoProtocolEvm", () => {
           marketId: new MarketParams(MARKET_PARAMS).id,
         }),
       );
+      expect(mockGetChainId).toHaveBeenCalledTimes(2);
     });
   });
 
   describe("erc-4337 chain binding", () => {
-    test("preserves the invalid chain across out-of-order provider requests", async () => {
-      const first = Promise.withResolvers<number>();
-      const second = Promise.withResolvers<number>();
-      mockGetChainId
-        .mockImplementationOnce(() => first.promise)
-        .mockImplementationOnce(() => second.promise);
-      const handle = createMockClient(mainnet);
-      handle.request.mockImplementation(async ({ method }) => {
-        if (method === "eth_chainId") {
-          const chainId = await mockGetChainId();
-          return `0x${chainId.toString(16)}`;
-        }
-        throw new Error(`Unhandled RPC ${method}`);
-      });
-      const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
-        chainId: 1,
-        provider: {
-          request: ({ method, params }) =>
-            handle.request({
-              method,
-              params: Array.isArray(params) ? params : undefined,
-            }),
-        },
-        bundlerUrl: "https://dummy-bundler-url.com",
-        safeModulesVersion: "0.3.0",
-        isSponsored: false,
-        useNativeCoins: true,
-      });
-      erc4337Account.getAddress = vi.fn().mockResolvedValue(ADDRESS);
-      const erc4337Protocol = new MorphoProtocolEvm(erc4337Account, {
-        chainId: 1,
-        borrowMarketParams: MARKET_PARAMS,
-      });
-
-      await createClientMock.withImplementation(
-        (parameters) =>
-          viem.createClient(
-            parameters as Parameters<typeof viem.createClient>[0],
-          ),
-        async () => {
-          const firstPosition = erc4337Protocol.getMarketPosition();
-          const secondPosition = erc4337Protocol.getMarketPosition();
-          second.resolve(8453);
-          await expect(secondPosition).rejects.toBeInstanceOf(
-            ChainIdMismatchError,
-          );
-          first.resolve(1);
-          await expect(firstPosition).rejects.toBeInstanceOf(
-            ChainIdMismatchError,
-          );
-        },
-      );
-
-      expect(handle.request.mock.calls.map(([call]) => call.method)).toEqual([
-        "eth_chainId",
-        "eth_chainId",
-      ]);
-      expect(Reflect.get(erc4337Protocol, "_erc4337InvalidChainId")).toBe(8453);
-    });
-
     test("rejects a cached account chain before resolving entities", async () => {
       const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
         chainId: 8453,
@@ -1652,7 +1690,7 @@ describe.sequential("MorphoProtocolEvm", () => {
       expect(blueMock).not.toHaveBeenCalled();
     });
 
-    test("requires a fresh account after an observed chain switch", async () => {
+    test("recovers when the provider returns to the configured chain", async () => {
       const erc4337Account = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
         chainId: 1,
         provider: "https://dummy-rpc-url.com",
@@ -1675,24 +1713,7 @@ describe.sequential("MorphoProtocolEvm", () => {
         ChainIdMismatchError,
       );
       mockGetChainId.mockResolvedValue(1);
-      await expect(erc4337Protocol.getMarketPosition()).rejects.toBeInstanceOf(
-        ChainIdMismatchError,
-      );
-
-      const freshAccount = new WalletAccountEvmErc4337(SEED, "0'/0/0", {
-        chainId: 1,
-        provider: "https://dummy-rpc-url.com",
-        bundlerUrl: "https://dummy-bundler-url.com",
-        safeModulesVersion: "0.3.0",
-        isSponsored: false,
-        useNativeCoins: true,
-      });
-      freshAccount.getAddress = vi.fn().mockResolvedValue(ADDRESS);
-      const freshProtocol = new MorphoProtocolEvm(freshAccount, {
-        chainId: 1,
-        borrowMarketParams: MARKET_PARAMS,
-      });
-      await expect(freshProtocol.getMarketPosition()).resolves.toEqual(
+      await expect(erc4337Protocol.getMarketPosition()).resolves.toEqual(
         expect.objectContaining({ marketId: expect.any(String) }),
       );
     });

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
@@ -296,7 +296,8 @@ interface WdkTransaction extends EvmTransaction {
 
 interface ChainContext {
   readonly chainId: number;
-  readonly generation: number;
+  readonly revision: number;
+  readonly previousChainId: number | undefined;
 }
 
 interface PreparedTransaction {
@@ -534,27 +535,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   private readonly _provider: Eip1193Provider;
   private readonly _accountConfiguredChainId: number | undefined;
   private _chainContext: ChainContext | undefined = undefined;
-  private _latestChainObservation:
-    | { readonly chainId: Promise<number> }
-    | undefined = undefined;
-  private _erc4337Context: ChainContext | undefined = undefined;
-  private _erc4337InvalidChainId: number | undefined = undefined;
+  private _latestChainObservation: Promise<ChainContext> | undefined =
+    undefined;
   private _viemClient:
     | {
-        readonly context: ChainContext;
+        readonly chainId: number;
         readonly account: Address;
         readonly value: ViemPublicClient;
       }
     | undefined = undefined;
   private _morphoClient:
     | {
-        readonly context: ChainContext;
+        readonly chainId: number;
         readonly viemClient: ViemPublicClient;
         readonly value: MorphoClientType;
       }
     | undefined = undefined;
   private _marketParams:
-    | { readonly context: ChainContext; readonly value: MarketParams }
+    | { readonly chainId: number; readonly value: MarketParams }
     | undefined = undefined;
 
   /**
@@ -789,10 +787,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const userAddress = await this._getSdkUserAddress(onBehalfOf);
     const vault = await this._getVault(context);
     const accrualVault = await vault.entity.getData();
-    await this._revalidate(context);
 
     if (!isAddressEqual(accrualVault.asset, token as Address)) {
       throw new Error(
@@ -916,7 +913,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._assertOptionalAddress("to", to);
 
     const userAddress = (await this._evmAccount.getAddress()) as Address;
-    this._assertCurrent(context);
     if (to !== undefined && !isAddressEqual(to as Address, userAddress)) {
       throw new Error(
         "'to' must equal the wallet account address for Morpho vault withdrawals.",
@@ -925,7 +921,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
 
     const vault = await this._getVault(context);
     const accrualVault = await vault.entity.getData();
-    await this._revalidate(context);
 
     if (!isAddressEqual(accrualVault.asset, token as Address)) {
       throw new Error(
@@ -1137,7 +1132,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const userAddress = await this._getSdkUserAddress(onBehalfOf);
     const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.loanToken, token as Address)) {
@@ -1147,7 +1142,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     }
 
     const positionData = await market.entity.getPositionData(userAddress);
-    await this._revalidate(context);
 
     return market.entity.borrow({
       amount: normalizedAmount,
@@ -1317,7 +1311,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const userAddress = await this._getSdkUserAddress(onBehalfOf);
     const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.loanToken, token as Address)) {
@@ -1327,7 +1321,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     }
 
     const positionData = await market.entity.getPositionData(userAddress);
-    await this._revalidate(context);
     const repayAmount =
       normalizedAmount === "max"
         ? { shares: positionData.borrowShares }
@@ -1514,7 +1507,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const userAddress = await this._getSdkUserAddress(onBehalfOf);
     const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.collateralToken, token as Address)) {
@@ -1643,7 +1636,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._assertOptionalAddress("to", to);
 
     const userAddress = (await this._evmAccount.getAddress()) as Address;
-    this._assertCurrent(context);
     const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.collateralToken, token as Address)) {
@@ -1659,7 +1651,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     }
 
     const positionData = await market.entity.getPositionData(userAddress);
-    await this._revalidate(context);
 
     return {
       context,
@@ -1700,8 +1691,10 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    */
   async getVaultPosition(account?: string): Promise<VaultPosition> {
     const context = await this._getVaultContext();
+    const position = await this._getVaultPosition(context, account);
+    await this._revalidate(context);
 
-    return await this._getVaultPosition(context, account);
+    return position;
   }
 
   private async _getVaultPosition(
@@ -1713,10 +1706,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     const userAddress =
       (account as Address | undefined) ??
       ((await this._evmAccount.getAddress()) as Address);
-    this._assertCurrent(context);
     const vault = await this._getVault(context);
     const data = await vault.entity.getData();
-    await this._revalidate(context);
     const client = await this._getViemClient(context);
     const shares = await client.readContract({
       address: vault.address,
@@ -1724,7 +1715,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       functionName: "balanceOf",
       args: [userAddress],
     });
-    await this._revalidate(context);
 
     return {
       shares,
@@ -1758,8 +1748,10 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    */
   async getMarketPosition(account?: string): Promise<MarketPosition> {
     const context = await this._getMarketContext();
+    const position = await this._getMarketPosition(context, account);
+    await this._revalidate(context);
 
-    return await this._getMarketPosition(context, account);
+    return position;
   }
 
   private async _getMarketPosition(
@@ -1771,10 +1763,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     const userAddress =
       (account as Address | undefined) ??
       ((await this._evmAccount.getAddress()) as Address);
-    this._assertCurrent(context);
     const market = await this._getMarket(context);
     const position = await market.entity.getPositionData(userAddress);
-    await this._revalidate(context);
 
     return {
       supplyShares: position.supplyShares,
@@ -1860,7 +1850,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }> {
     const target = this._resolveVaultTarget();
     const { address } = target;
-    this._assertCurrent(context);
     this._assertTargetChain(target, context);
     const client = await this._getMorphoClient(context);
     const entity = client.vaultV2(address, context.chainId);
@@ -1874,7 +1863,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }> {
     const params = await this._getMarketParams(context);
     const client = await this._getMorphoClient(context);
-    this._assertCurrent(context);
 
     return {
       params,
@@ -1883,13 +1871,12 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _getMarketParams(context: ChainContext): Promise<MarketParams> {
-    if (this._marketParams?.context === context) {
+    if (this._marketParams?.chainId === context.chainId) {
       return this._marketParams.value;
     }
 
     const target = this._resolveMarketTarget();
 
-    this._assertCurrent(context);
     this._assertTargetChain(target, context);
 
     if ("marketParams" in target) {
@@ -1897,7 +1884,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
         target.marketParams instanceof MarketParams
           ? target.marketParams
           : new MarketParams(target.marketParams);
-      this._marketParams = { context, value };
+      this._marketParams = { chainId: context.chainId, value };
       return value;
     }
 
@@ -1912,7 +1899,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       market.params instanceof MarketParams
         ? market.params
         : new MarketParams(market.params);
-    this._marketParams = { context, value };
+    this._marketParams = { chainId: context.chainId, value };
 
     return value;
   }
@@ -1923,7 +1910,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     const viemClient = await this._getViemClient(context);
 
     if (
-      this._morphoClient?.context !== context ||
+      this._morphoClient?.chainId !== context.chainId ||
       this._morphoClient.viemClient !== viemClient
     ) {
       const value = viemClient.extend(
@@ -1933,7 +1920,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
           metadata: this._options.metadata,
         }),
       ).morpho;
-      this._morphoClient = { context, viemClient, value };
+      this._morphoClient = { chainId: context.chainId, viemClient, value };
     }
 
     return this._morphoClient.value;
@@ -1963,11 +1950,10 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     context: ChainContext,
   ): Promise<ViemPublicClient> {
     const address = (await this._evmAccount.getAddress()) as Address;
-    this._assertCurrent(context);
 
     if (
       this._viemClient &&
-      this._viemClient.context === context &&
+      this._viemClient.chainId === context.chainId &&
       isAddressEqual(this._viemClient.account, address)
     ) {
       return this._viemClient.value;
@@ -1978,60 +1964,39 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       chain: this._getViemChain(context.chainId),
       transport: this._getViemTransport(),
     }).extend(publicActions) as ViemPublicClient;
-    this._viemClient = { context, account: address, value };
+    this._viemClient = { chainId: context.chainId, account: address, value };
 
     return value;
   }
 
   private async _getChainContext(): Promise<ChainContext> {
-    const observation = {
-      chainId: createClient({
-        transport: this._getViemTransport(),
-      })
-        .extend(publicActions)
-        .getChainId()
-        .then(Number),
-    };
+    const observedChain = createClient({ transport: this._getViemTransport() })
+      .extend(publicActions)
+      .getChainId()
+      .then(
+        (chainId) => ({ type: "success" as const, chainId: Number(chainId) }),
+        (error: unknown) => ({ type: "failure" as const, error }),
+      );
+    const previousObservation = this._latestChainObservation;
+    const observation = (async () => {
+      await previousObservation?.catch(() => undefined);
+      const result = await observedChain;
+      if (result.type === "failure") throw result.error;
+
+      const observedChainId = result.chainId;
+      const context =
+        this._chainContext?.chainId === observedChainId
+          ? this._chainContext
+          : Object.freeze({
+              chainId: observedChainId,
+              revision: (this._chainContext?.revision ?? 0) + 1,
+              previousChainId: this._chainContext?.chainId,
+            });
+      this._chainContext = context;
+      return context;
+    })();
     this._latestChainObservation = observation;
-    const chainId = await observation.chainId;
-    let latestObservation = observation;
-    let latestChainId = chainId;
-
-    while (latestObservation !== this._latestChainObservation) {
-      const nextObservation = this._latestChainObservation;
-      if (nextObservation === undefined) break;
-      latestObservation = nextObservation;
-      latestChainId = await nextObservation.chainId;
-    }
-
-    if (latestChainId !== chainId) {
-      this._chainContext = Object.freeze({
-        chainId: latestChainId,
-        generation: (this._chainContext?.generation ?? 0) + 1,
-      });
-      if (this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337) {
-        const expectedChainId =
-          this._erc4337Context?.chainId ??
-          this._accountConfiguredChainId ??
-          latestChainId;
-        this._erc4337InvalidChainId ??=
-          latestChainId !== expectedChainId ? latestChainId : chainId;
-        throw new ChainIdMismatchError(
-          this._erc4337InvalidChainId,
-          expectedChainId,
-        );
-      }
-      throw new ChainIdMismatchError(latestChainId, chainId);
-    }
-
-    const context =
-      this._chainContext?.chainId === latestChainId
-        ? this._chainContext
-        : Object.freeze({
-            chainId: latestChainId,
-            generation: (this._chainContext?.generation ?? 0) + 1,
-          });
-    this._chainContext = context;
+    const context = await observation;
     this._assertErc4337Context(context);
     return context;
   }
@@ -2048,21 +2013,18 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     return context;
   }
 
-  private _assertCurrent(context: ChainContext): void {
-    if (this._chainContext !== context) {
-      throw new ChainIdMismatchError(
-        this._chainContext?.chainId,
-        context.chainId,
-      );
-    }
-
-    this._assertErc4337Context(context);
-  }
-
   private async _revalidate(context: ChainContext): Promise<void> {
     const current = await this._getChainContext();
-    if (current !== context) {
-      throw new ChainIdMismatchError(current.chainId, context.chainId);
+    if (
+      current.chainId !== context.chainId ||
+      current.revision !== context.revision
+    ) {
+      throw new ChainIdMismatchError(
+        current.chainId === context.chainId
+          ? current.previousChainId
+          : current.chainId,
+        context.chainId,
+      );
     }
   }
 
@@ -2073,35 +2035,20 @@ export default class MorphoProtocolEvm extends LendingProtocol {
 
     const cachedChainId: unknown = Reflect.get(this._evmAccount, "_chainId");
     const accountChainId =
-      typeof cachedChainId === "bigint"
-        ? Number(cachedChainId)
-        : this._accountConfiguredChainId;
-    const expectedChainId =
-      this._erc4337Context?.chainId ?? accountChainId ?? context.chainId;
-
-    if (this._erc4337InvalidChainId !== undefined) {
-      throw new ChainIdMismatchError(
-        this._erc4337InvalidChainId,
-        expectedChainId,
-      );
-    }
+      typeof cachedChainId === "bigint" ? Number(cachedChainId) : undefined;
+    const expectedChainId = this._accountConfiguredChainId ?? accountChainId;
 
     if (
-      (accountChainId !== undefined && accountChainId !== expectedChainId) ||
-      context.chainId !== expectedChainId ||
-      (this._erc4337Context !== undefined && this._erc4337Context !== context)
+      expectedChainId !== undefined &&
+      accountChainId !== undefined &&
+      accountChainId !== expectedChainId
     ) {
-      this._erc4337InvalidChainId =
-        accountChainId !== undefined && accountChainId !== expectedChainId
-          ? accountChainId
-          : context.chainId;
-      throw new ChainIdMismatchError(
-        this._erc4337InvalidChainId,
-        expectedChainId,
-      );
+      throw new ChainIdMismatchError(accountChainId, expectedChainId);
     }
 
-    this._erc4337Context = context;
+    if (expectedChainId !== undefined && context.chainId !== expectedChainId) {
+      throw new ChainIdMismatchError(context.chainId, expectedChainId);
+    }
   }
 
   private _resolveVaultTarget(): VaultTarget {
@@ -2252,11 +2199,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _getSdkUserAddress(
-    context: ChainContext,
     onBehalfOf: string | undefined,
   ): Promise<Address> {
     const address = (await this._evmAccount.getAddress()) as Address;
-    this._assertCurrent(context);
 
     if (
       onBehalfOf !== undefined &&
@@ -2278,7 +2223,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     let balance: bigint;
     if (this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337) {
       const client = await this._getViemClient(context);
-      const userAddress = await this._getSdkUserAddress(context, undefined);
+      const userAddress = await this._getSdkUserAddress(undefined);
       balance = await client.readContract({
         address: token,
         abi: erc20Abi,
@@ -2288,7 +2233,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     } else {
       balance = await this._evmAccount.getTokenBalance(token);
     }
-    await this._revalidate(context);
 
     if (balance < amount) {
       throw new Error("Not enough funds to fulfill the operation.");
@@ -2299,8 +2243,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     prepared: PreparedTransaction,
     config?: Erc4337TransactionConfig,
   ): Promise<SupplyResult> {
-    await this._revalidate(prepared.context);
-
     if (this._evmAccount instanceof WalletAccountEvmErc4337) {
       const account = this._evmAccount;
       const walletConfig: unknown = Reflect.get(account, "_config");
@@ -2315,30 +2257,34 @@ export default class MorphoProtocolEvm extends LendingProtocol {
           effectiveConfig.nonceKey !== undefined &&
           effectiveConfig.nonceKey !== null) ||
         ("parallel" in effectiveConfig && effectiveConfig.parallel === true);
+      await this._revalidate(prepared.context);
 
-      if (hasNonceLane) {
-        return await account.sendTransaction(prepared.transaction, config);
-      }
+      // WDK's quote cache omits config; a nonce lane forces a fresh build.
+      const operationConfig = hasNonceLane
+        ? config
+        : { ...config, nonceKey: 0n };
+      // WDK reads this protected hook while signing. Bind it to the validated
+      // context so a provider switch cannot change the signature domain.
+      const chainBoundAccount = new Proxy(account, {
+        // biome-ignore lint/complexity/useMaxParams: standard Proxy trap signature
+        get(target, property, receiver) {
+          return property === "_getChainId"
+            ? async () => BigInt(prepared.context.chainId)
+            : Reflect.get(target, property, receiver);
+        },
+      });
 
-      // WDK's quote cache omits config; its default key-0 nonce lane forces a
-      // fresh, config-bound build instead of consuming a cached operation.
-      const cacheProofConfig: Erc4337TransactionConfig & {
-        readonly nonceKey: bigint;
-      } = { ...config, nonceKey: 0n };
-
-      return await account.sendTransaction(
+      return await chainBoundAccount.sendTransaction(
         prepared.transaction,
-        cacheProofConfig,
+        operationConfig,
       );
     }
     if (this._evmAccount instanceof WalletAccountEvm) {
       const { fee } = await this._evmAccount.quoteSendTransaction(
         prepared.transaction,
       );
-      await this._revalidate(prepared.context);
       const client = await this._getViemClient(prepared.context);
       const address = (await this._evmAccount.getAddress()) as Address;
-      this._assertCurrent(prepared.context);
       const transaction = await client.prepareTransactionRequest({
         account: address,
         chainId: prepared.context.chainId,
@@ -2346,7 +2292,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
         value: prepared.transaction.value,
         data: prepared.transaction.data,
       });
-      await this._revalidate(prepared.context);
       const signed = await this._evmAccount.signTransaction({
         ...prepared.transaction,
         chainId: prepared.context.chainId,
@@ -2380,7 +2325,6 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     prepared: PreparedTransaction,
     config?: Erc4337TransactionConfig,
   ): Promise<{ fee: bigint }> {
-    await this._revalidate(prepared.context);
     const { fee } =
       this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337
         ? await this._evmAccount.quoteSendTransaction(

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
@@ -25,7 +25,10 @@ import type {
   WithdrawResult,
 } from "@tetherto/wdk-wallet/protocols";
 import { LendingProtocol } from "@tetherto/wdk-wallet/protocols";
-import type { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+import type {
+  EvmTransaction,
+  WalletAccountReadOnlyEvm,
+} from "@tetherto/wdk-wallet-evm";
 import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
 import type {
   EvmErc4337WalletNativeCoinsConfig,
@@ -42,17 +45,18 @@ import {
   type Client,
   createClient,
   custom,
+  erc20Abi,
   erc4626Abi,
-  fallback,
-  http,
   isAddress,
   isAddressEqual,
   type PublicActions,
+  parseTransaction,
   publicActions,
   type Transport,
   zeroAddress,
 } from "viem";
 import { arbitrum, base, mainnet, optimism, polygon } from "viem/chains";
+import { MissingWalletProviderError } from "./errors.js";
 import {
   type MarketPresetKey,
   MORPHO_MARKET_PRESETS,
@@ -79,10 +83,13 @@ export interface Eip1193Provider {
   }): Promise<unknown>;
 }
 
-type WdkProviderSource =
-  | string
-  | Eip1193Provider
-  | readonly (string | Eip1193Provider)[];
+type WdkProvider = {
+  request?: Eip1193Provider["request"];
+  send?: (
+    method: string,
+    params: readonly unknown[] | object,
+  ) => Promise<unknown>;
+};
 
 type ViemPublicClient = Client<Transport, Chain> &
   PublicActions<Transport, Chain>;
@@ -249,7 +256,7 @@ export interface MorphoProtocolOptions {
   borrowMarketParams?: InputMarketParams;
   /** Curated target names for Ethereum USDT earn/borrow. */
   presets?: Presets;
-  /** Required when explicit Morpho targets are used; guards against wallet chain switches. */
+  /** Required with explicit Morpho targets; validates reads, requirements, quotes, and sends against chain mismatches and switches. */
   chainId?: number | bigint;
   /** Optional Morpho SDK slippage tolerance in WAD precision. */
   slippageTolerance?: bigint;
@@ -281,7 +288,7 @@ type MarketTarget =
     }
   | { readonly marketId: string; readonly chainId: number | undefined };
 
-interface WdkTransaction {
+interface WdkTransaction extends EvmTransaction {
   to: Address;
   value: bigint;
   data: `0x${string}`;
@@ -361,6 +368,18 @@ interface NormalizedDepositAmounts {
   nativeAmount: bigint | undefined;
 }
 
+function snapshotRequirementSignature(
+  signature: RequirementSignature | undefined,
+): RequirementSignature | undefined {
+  if (signature === undefined) return undefined;
+
+  return {
+    ...signature,
+    args: { ...signature.args },
+    action: { ...signature.action, args: { ...signature.action.args } },
+  } as RequirementSignature;
+}
+
 function normalizeDepositAmounts({
   amount,
   nativeAmount,
@@ -387,6 +406,79 @@ function normalizeDepositAmounts({
   };
 }
 
+function normalizeSupplyOptions(
+  options: MorphoSupplyOptions,
+): MorphoSupplyOptions & NormalizedDepositAmounts {
+  return {
+    ...options,
+    ...normalizeDepositAmounts(options),
+    requirementSignature: snapshotRequirementSignature(
+      options.requirementSignature,
+    ),
+  };
+}
+
+function normalizeWithdrawOptions(
+  options: WithdrawOptions,
+): WithdrawOptions & { amount: bigint } {
+  return { ...options, amount: normalizeAmount(options.amount) };
+}
+
+function normalizeBorrowOptions(options: MorphoBorrowInput): MorphoBorrowInput {
+  return {
+    ...options,
+    amount: normalizeAmount(options.amount),
+    requirementSignature: snapshotRequirementSignature(
+      options.requirementSignature,
+    ),
+    reallocations: options.reallocations?.map((reallocation) => {
+      if ("withdrawals" in reallocation) {
+        return {
+          ...reallocation,
+          withdrawals: reallocation.withdrawals.map((withdrawal) => ({
+            ...withdrawal,
+            marketParams: new MarketParams(withdrawal.marketParams),
+          })),
+        };
+      }
+
+      return {
+        ...reallocation,
+        from:
+          reallocation.from.type === "market"
+            ? {
+                ...reallocation.from,
+                marketParams: new MarketParams(reallocation.from.marketParams),
+              }
+            : { ...reallocation.from },
+        to: { ...reallocation.to },
+      };
+    }),
+  } as MorphoBorrowInput;
+}
+
+function normalizeRepayOptions(
+  options: MorphoRepayOptions,
+): Omit<MorphoRepayOptions, "amount"> & { amount: bigint | "max" } {
+  return {
+    ...options,
+    amount: options.amount === "max" ? "max" : normalizeAmount(options.amount),
+    requirementSignature: snapshotRequirementSignature(
+      options.requirementSignature,
+    ),
+  };
+}
+
+function normalizeTransactionConfig(
+  config: Erc4337TransactionConfig | undefined,
+): Erc4337TransactionConfig | undefined {
+  if (config === undefined) return undefined;
+
+  return "paymasterToken" in config && config.paymasterToken !== undefined
+    ? { ...config, paymasterToken: { ...config.paymasterToken } }
+    : { ...config };
+}
+
 function normalizeOptions(
   options: MorphoProtocolOptions,
 ): NormalizedMorphoProtocolOptions {
@@ -402,6 +494,10 @@ function normalizeOptions(
       options.borrowMarketParams === undefined
         ? undefined
         : Object.freeze({ ...options.borrowMarketParams }),
+    metadata:
+      options.metadata === undefined
+        ? undefined
+        : Object.freeze({ ...options.metadata }),
   };
 
   return Object.freeze(normalized);
@@ -435,8 +531,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    */
   private readonly _evmAccount: MorphoEvmAccount;
   private readonly _options: NormalizedMorphoProtocolOptions;
-  private readonly _providerSource: WdkProviderSource;
-  private readonly _providerRetries: number;
+  private readonly _provider: Eip1193Provider;
   private readonly _accountConfiguredChainId: number | undefined;
   private _chainContext: ChainContext | undefined = undefined;
   private _latestChainObservation:
@@ -472,6 +567,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *
    * @param account - The wallet account to use to interact with the protocol.
    * @param options - The Morpho target configuration.
+   * @throws {MissingWalletProviderError} when the account has no provider or an empty provider list.
    */
   constructor(account: MorphoEvmAccount, options: MorphoProtocolOptions = {}) {
     // `LendingProtocol`'s constructor is overloaded to accept either an
@@ -483,8 +579,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     super(account as ConstructorParameters<typeof LendingProtocol>[0]);
     this._evmAccount = account;
 
-    // wdk-wallet exposes its provider config only through this protected
-    // runtime field. Absorb that unstable boundary as unknown before narrowing.
+    // WDK exposes its provider config and active failover provider only through
+    // protected runtime fields. Absorb that unstable boundary locally.
     const walletConfig: unknown = Reflect.get(account, "_config");
     const config =
       typeof walletConfig === "object" && walletConfig !== null
@@ -494,7 +590,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       "provider" in config ? config.provider : undefined;
 
     if (!provider || (Array.isArray(provider) && provider.length === 0)) {
-      throw new Error("The wallet account must have a provider configured.");
+      throw new MissingWalletProviderError();
     }
 
     const normalizedOptions = normalizeOptions(options);
@@ -502,11 +598,25 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._validateOptions(normalizedOptions);
 
     this._options = normalizedOptions;
-    this._providerSource = Array.isArray(provider)
-      ? (Object.freeze([...provider]) as WdkProviderSource)
-      : (provider as WdkProviderSource);
-    const retries = "retries" in config ? config.retries : undefined;
-    this._providerRetries = typeof retries === "number" ? retries : 3;
+    const accountProvider = Reflect.get(account, "_provider") as WdkProvider;
+    this._provider = {
+      request: (args) => {
+        const currentRequest = accountProvider.request;
+        if (currentRequest !== undefined) {
+          return currentRequest.call(accountProvider, args);
+        }
+
+        const currentSend = accountProvider.send as NonNullable<
+          WdkProvider["send"]
+        >;
+        return currentSend.call(
+          accountProvider,
+          args.method,
+          args.params ?? [],
+        );
+      },
+    };
+
     const accountChainId = "chainId" in config ? config.chainId : undefined;
     this._accountConfiguredChainId =
       typeof accountChainId === "number" ? accountChainId : undefined;
@@ -525,7 +635,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The supply result.
-   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
+   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
+   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
+   *   returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured vault, the account lacks funds, or the transaction fails.
    */
   async supply(
@@ -533,16 +645,13 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<SupplyResult> {
     this._assertWritable("supply(options)");
-    const depositAmounts = normalizeDepositAmounts(options);
-    const operationOptions: MorphoSupplyOptions = {
-      ...options,
-      ...depositAmounts,
-    };
+    const operationOptions = normalizeSupplyOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getVaultContext();
-    if (depositAmounts.amount > 0n) {
+    if (operationOptions.amount > 0n) {
       await this._assertTokenBalance(context, {
         token: operationOptions.token,
-        amount: depositAmounts.amount,
+        amount: operationOptions.amount,
       });
     } else {
       this._assertAddress("token", operationOptions.token);
@@ -550,7 +659,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
 
     const tx = await this._getSupplyTransaction(context, operationOptions);
 
-    return await this._sendTransaction(tx, config);
+    return await this._sendTransaction(tx, operationConfig);
   }
 
   /**
@@ -559,15 +668,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The supply options.
    * @param requirementOptions - Optional Morpho SDK requirement options.
    * @returns Approval/signature requirements.
-   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async getSupplyRequirements(
     options: MorphoSupplyOptions,
     requirementOptions?: RequirementOptions,
   ): Promise<ApprovalOrSignatureRequirement[]> {
+    const operationOptions = normalizeSupplyOptions(options);
+    const operationRequirementOptions =
+      requirementOptions === undefined ? undefined : { ...requirementOptions };
     const context = await this._getVaultContext();
-    const action = await this._getSupplyAction(context, options);
-    const requirements = await action.getRequirements(requirementOptions);
+    const action = await this._getSupplyAction(context, operationOptions);
+    const requirements = await action.getRequirements(
+      operationRequirementOptions,
+    );
     await this._revalidate(context);
 
     return requirements;
@@ -579,16 +694,19 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
-   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async quoteSupply(
     options: MorphoSupplyOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<SupplyResult, "hash">> {
+    const operationOptions = normalizeSupplyOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getVaultContext();
-    const tx = await this._getSupplyTransaction(context, options);
+    const tx = await this._getSupplyTransaction(context, operationOptions);
 
-    return await this._quoteTransaction(tx, config);
+    return await this._quoteTransaction(tx, operationConfig);
   }
 
   private async _getSupplyAction(
@@ -649,7 +767,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The withdraw result.
-   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
+   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
+   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
+   *   returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured vault, or the transaction fails.
    */
   async withdraw(
@@ -657,10 +777,12 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<WithdrawResult> {
     this._assertWritable("withdraw(options)");
+    const operationOptions = normalizeWithdrawOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getVaultContext();
-    const tx = await this._getWithdrawTransaction(context, options);
+    const tx = await this._getWithdrawTransaction(context, operationOptions);
 
-    return await this._sendTransaction(tx, config);
+    return await this._sendTransaction(tx, operationConfig);
   }
 
   /**
@@ -669,16 +791,19 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
-   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async quoteWithdraw(
     options: WithdrawOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<WithdrawResult, "hash">> {
+    const operationOptions = normalizeWithdrawOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getVaultContext();
-    const tx = await this._getWithdrawTransaction(context, options);
+    const tx = await this._getWithdrawTransaction(context, operationOptions);
 
-    return await this._quoteTransaction(tx, config);
+    return await this._quoteTransaction(tx, operationConfig);
   }
 
   private async _getWithdrawTransaction(
@@ -734,7 +859,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The borrow options.
    * @param config - ERC-4337 transaction config override.
    * @returns The borrow result.
-   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
+   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
+   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
+   *   returns a transaction for another chain.
    * @throws {Error} If the options are invalid, GeneralAdapter1 is not authorized, or the transaction fails.
    */
   async borrow(
@@ -742,10 +869,12 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<BorrowResult> {
     this._assertWritable("borrow(options)");
+    const operationOptions = normalizeBorrowOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
-    const tx = await this._getBorrowTransaction(context, options);
+    const tx = await this._getBorrowTransaction(context, operationOptions);
 
-    return await this._sendTransaction(tx, config);
+    return await this._sendTransaction(tx, operationConfig);
   }
 
   /**
@@ -755,7 +884,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns Authorization requirements. When offchain signatures are enabled
    *   (`supportSignature: true`), the authorization may instead be returned as a signable
    *   `RequirementSignatureRequest` to fold into the bundle via `setAuthorizationWithSig`.
-   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   public getBorrowRequirements(
     options: MorphoBorrowOptions,
@@ -768,7 +898,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *   allocator penalty donation. When offchain signatures are enabled (`supportSignature: true`),
    *   the authorization may instead be returned as a signable `RequirementSignatureRequest` to
    *   fold into the bundle via `setAuthorizationWithSig`.
-   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   public getBorrowRequirements(
     options: MorphoBorrowWithVaultV2ReallocationsOptions,
@@ -788,8 +919,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       | RequirementSignatureRequest
     )[]
   > {
+    const operationOptions = normalizeBorrowOptions(options);
     const context = await this._getMarketContext();
-    const action = await this._getBorrowAction(context, options);
+    const action = await this._getBorrowAction(context, operationOptions);
     const requirements = await action.getRequirements();
     await this._revalidate(context);
 
@@ -802,16 +934,19 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The borrow options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
-   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async quoteBorrow(
     options: MorphoBorrowInput,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<BorrowResult, "hash">> {
+    const operationOptions = normalizeBorrowOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
-    const tx = await this._getBorrowTransaction(context, options);
+    const tx = await this._getBorrowTransaction(context, operationOptions);
 
-    return await this._quoteTransaction(tx, config);
+    return await this._quoteTransaction(tx, operationConfig);
   }
 
   private async _getBorrowAction(
@@ -875,7 +1010,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The repay options.
    * @param config - ERC-4337 transaction config override.
    * @returns The repay result.
-   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
+   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
+   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
+   *   returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the account lacks funds, or the transaction fails.
    */
   async repay(
@@ -883,21 +1020,20 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<RepayResult> {
     this._assertWritable("repay(options)");
-    const amount =
-      options.amount === "max" ? "max" : normalizeAmount(options.amount);
-    const operationOptions: MorphoRepayOptions = { ...options, amount };
+    const operationOptions = normalizeRepayOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
 
-    if (amount !== "max") {
+    if (operationOptions.amount !== "max") {
       await this._assertTokenBalance(context, {
         token: operationOptions.token,
-        amount,
+        amount: operationOptions.amount,
       });
     }
 
     const tx = await this._getRepayTransaction(context, operationOptions);
 
-    return await this._sendTransaction(tx, config);
+    return await this._sendTransaction(tx, operationConfig);
   }
 
   /**
@@ -906,15 +1042,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The repay options.
    * @param requirementOptions - Optional Morpho SDK requirement options.
    * @returns Approval/signature requirements.
-   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async getRepayRequirements(
     options: MorphoRepayOptions,
     requirementOptions?: RequirementOptions,
   ): Promise<ApprovalOrSignatureRequirement[]> {
+    const operationOptions = normalizeRepayOptions(options);
+    const operationRequirementOptions =
+      requirementOptions === undefined ? undefined : { ...requirementOptions };
     const context = await this._getMarketContext();
-    const action = await this._getRepayAction(context, options);
-    const requirements = await action.getRequirements(requirementOptions);
+    const action = await this._getRepayAction(context, operationOptions);
+    const requirements = await action.getRequirements(
+      operationRequirementOptions,
+    );
     await this._revalidate(context);
 
     return requirements;
@@ -926,16 +1068,19 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The repay options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
-   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async quoteRepay(
     options: MorphoRepayOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<RepayResult, "hash">> {
+    const operationOptions = normalizeRepayOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
-    const tx = await this._getRepayTransaction(context, options);
+    const tx = await this._getRepayTransaction(context, operationOptions);
 
-    return await this._quoteTransaction(tx, config);
+    return await this._quoteTransaction(tx, operationConfig);
   }
 
   private async _getRepayAction(
@@ -1000,7 +1145,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The supply collateral result.
-   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
+   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
+   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
+   *   returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured market collateral, the account lacks funds, or the transaction fails.
    */
   async supplyCollateral(
@@ -1008,16 +1155,13 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<SupplyResult> {
     this._assertWritable("supplyCollateral(options)");
-    const depositAmounts = normalizeDepositAmounts(options);
-    const operationOptions: MorphoSupplyOptions = {
-      ...options,
-      ...depositAmounts,
-    };
+    const operationOptions = normalizeSupplyOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
-    if (depositAmounts.amount > 0n) {
+    if (operationOptions.amount > 0n) {
       await this._assertTokenBalance(context, {
         token: operationOptions.token,
-        amount: depositAmounts.amount,
+        amount: operationOptions.amount,
       });
     } else {
       this._assertAddress("token", operationOptions.token);
@@ -1028,7 +1172,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       operationOptions,
     );
 
-    return await this._sendTransaction(tx, config);
+    return await this._sendTransaction(tx, operationConfig);
   }
 
   /**
@@ -1037,15 +1181,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral supply options.
    * @param requirementOptions - Optional Morpho SDK requirement options.
    * @returns Approval/signature requirements.
-   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async getSupplyCollateralRequirements(
     options: MorphoSupplyOptions,
     requirementOptions?: RequirementOptions,
   ): Promise<ApprovalOrSignatureRequirement[]> {
+    const operationOptions = normalizeSupplyOptions(options);
+    const operationRequirementOptions =
+      requirementOptions === undefined ? undefined : { ...requirementOptions };
     const context = await this._getMarketContext();
-    const action = await this._getSupplyCollateralAction(context, options);
-    const requirements = await action.getRequirements(requirementOptions);
+    const action = await this._getSupplyCollateralAction(
+      context,
+      operationOptions,
+    );
+    const requirements = await action.getRequirements(
+      operationRequirementOptions,
+    );
     await this._revalidate(context);
 
     return requirements;
@@ -1057,16 +1210,22 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
-   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async quoteSupplyCollateral(
     options: MorphoSupplyOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<SupplyResult, "hash">> {
+    const operationOptions = normalizeSupplyOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
-    const tx = await this._getSupplyCollateralTransaction(context, options);
+    const tx = await this._getSupplyCollateralTransaction(
+      context,
+      operationOptions,
+    );
 
-    return await this._quoteTransaction(tx, config);
+    return await this._quoteTransaction(tx, operationConfig);
   }
 
   private async _getSupplyCollateralAction(
@@ -1117,7 +1276,9 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The withdraw collateral result.
-   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
+   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
+   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
+   *   returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured market collateral, or the transaction fails.
    */
   async withdrawCollateral(
@@ -1125,10 +1286,15 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<WithdrawResult> {
     this._assertWritable("withdrawCollateral(options)");
+    const operationOptions = normalizeWithdrawOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
-    const tx = await this._getWithdrawCollateralTransaction(context, options);
+    const tx = await this._getWithdrawCollateralTransaction(
+      context,
+      operationOptions,
+    );
 
-    return await this._sendTransaction(tx, config);
+    return await this._sendTransaction(tx, operationConfig);
   }
 
   /**
@@ -1137,16 +1303,22 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
-   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async quoteWithdrawCollateral(
     options: WithdrawOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<WithdrawResult, "hash">> {
+    const operationOptions = normalizeWithdrawOptions(options);
+    const operationConfig = normalizeTransactionConfig(config);
     const context = await this._getMarketContext();
-    const tx = await this._getWithdrawCollateralTransaction(context, options);
+    const tx = await this._getWithdrawCollateralTransaction(
+      context,
+      operationOptions,
+    );
 
-    return await this._quoteTransaction(tx, config);
+    return await this._quoteTransaction(tx, operationConfig);
   }
 
   private async _getWithdrawCollateralTransaction(
@@ -1195,7 +1367,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *
    * @param account - If set, returns the vault position for the given address.
    * @returns The vault position.
-   * @throws {ChainIdMismatchError} When the provider changes chains while reading the position.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async getVaultPosition(account?: string): Promise<VaultPosition> {
     const context = await this._getVaultContext();
@@ -1237,7 +1410,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *
    * @param account - If set, returns the market position for the given address.
    * @returns The market position.
-   * @throws {ChainIdMismatchError} When the provider changes chains while reading the position.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async getMarketPosition(account?: string): Promise<MarketPosition> {
     const context = await this._getMarketContext();
@@ -1273,7 +1447,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *
    * @param account - If set, returns the data for the given address.
    * @returns The account data.
-   * @throws {ChainIdMismatchError} When the provider changes chains while reading account data.
+   * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
+   *   with configured target or cached ERC-4337 account context.
    */
   async getAccountData(account?: string): Promise<AccountData> {
     const context = await this._getChainContext();
@@ -1407,29 +1582,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private _getViemTransport(): Transport {
-    if (Array.isArray(this._providerSource)) {
-      const providers = this._providerSource as readonly (
-        | string
-        | Eip1193Provider
-      )[];
-      const attempts = 1 + this._providerRetries;
-      return fallback(
-        Array.from({ length: attempts }, (_, index) => {
-          const provider = providers[index % providers.length] as
-            | string
-            | Eip1193Provider;
-
-          return typeof provider === "string"
-            ? http(provider)
-            : custom(provider);
-        }),
-        { retryCount: 0 },
-      );
-    }
-
-    return typeof this._providerSource === "string"
-      ? http(this._providerSource)
-      : custom(this._providerSource as Eip1193Provider);
+    return custom(this._provider);
   }
 
   private _getViemChain(chainId: number): Chain {
@@ -1442,10 +1595,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
       rpcUrls: {
         default: {
-          http:
-            typeof this._providerSource === "string"
-              ? [this._providerSource]
-              : [],
+          http: [],
         },
       },
     } satisfies Chain;
@@ -1502,7 +1652,16 @@ export default class MorphoProtocolEvm extends LendingProtocol {
         generation: (this._chainContext?.generation ?? 0) + 1,
       });
       if (this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337) {
-        this._erc4337InvalidChainId = chainId;
+        const expectedChainId =
+          this._erc4337Context?.chainId ??
+          this._accountConfiguredChainId ??
+          latestChainId;
+        this._erc4337InvalidChainId ??=
+          latestChainId !== expectedChainId ? latestChainId : chainId;
+        throw new ChainIdMismatchError(
+          this._erc4337InvalidChainId,
+          expectedChainId,
+        );
       }
       throw new ChainIdMismatchError(latestChainId, chainId);
     }
@@ -1758,7 +1917,19 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     { token, amount }: { token: string; amount: bigint },
   ): Promise<void> {
     this._assertAddress("token", token);
-    const balance = await this._evmAccount.getTokenBalance(token);
+    let balance: bigint;
+    if (this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337) {
+      const client = await this._getViemClient(context);
+      const userAddress = await this._getSdkUserAddress(context, undefined);
+      balance = await client.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [userAddress],
+      });
+    } else {
+      balance = await this._evmAccount.getTokenBalance(token);
+    }
     await this._revalidate(context);
 
     if (balance < amount) {
@@ -1773,15 +1944,60 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     await this._revalidate(prepared.context);
 
     if (this._evmAccount instanceof WalletAccountEvmErc4337) {
-      return (await this._evmAccount.sendTransaction(
+      const { fee } = await this._evmAccount.quoteSendTransaction(
         prepared.transaction,
         config,
-      )) as SupplyResult;
+      );
+      await this._revalidate(prepared.context);
+      const signed = await this._evmAccount.signTransaction(
+        prepared.transaction,
+        config,
+      );
+      await this._revalidate(prepared.context);
+
+      const { hash } = await this._evmAccount.sendTransaction(signed, config);
+
+      return { hash, fee };
     }
     if (this._evmAccount instanceof WalletAccountEvm) {
-      return (await this._evmAccount.sendTransaction(
+      const { fee } = await this._evmAccount.quoteSendTransaction(
         prepared.transaction,
-      )) as SupplyResult;
+      );
+      await this._revalidate(prepared.context);
+      const client = await this._getViemClient(prepared.context);
+      const address = (await this._evmAccount.getAddress()) as Address;
+      this._assertCurrent(prepared.context);
+      const transaction = await client.prepareTransactionRequest({
+        account: address,
+        chainId: prepared.context.chainId,
+        to: prepared.transaction.to,
+        value: prepared.transaction.value,
+        data: prepared.transaction.data,
+      });
+      await this._revalidate(prepared.context);
+      const signed = await this._evmAccount.signTransaction({
+        ...prepared.transaction,
+        chainId: prepared.context.chainId,
+        gasLimit: transaction.gas,
+        nonce: transaction.nonce,
+        ...(transaction.gasPrice === undefined
+          ? {
+              maxFeePerGas: transaction.maxFeePerGas,
+              maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+            }
+          : { gasPrice: transaction.gasPrice }),
+      });
+      await this._revalidate(prepared.context);
+      const serializedTransaction = signed as `0x${string}`;
+      const signedChainId = parseTransaction(serializedTransaction).chainId;
+      if (signedChainId !== prepared.context.chainId) {
+        throw new ChainIdMismatchError(signedChainId, prepared.context.chainId);
+      }
+      const hash = await client.sendRawTransaction({
+        serializedTransaction,
+      });
+
+      return { hash, fee };
     }
     throw new Error(
       "The method requires the protocol to be initialized with a non read-only account.",

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
@@ -568,6 +568,20 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param account - The wallet account to use to interact with the protocol.
    * @param options - The Morpho target configuration.
    * @throws {MissingWalletProviderError} when the account has no provider or an empty provider list.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings", borrow: "wsteth" },
+   * });
+   * // morpho satisfies MorphoProtocolEvm
+   * ```
    */
   constructor(account: MorphoEvmAccount, options: MorphoProtocolOptions = {}) {
     // `LendingProtocol`'s constructor is overloaded to accept either an
@@ -635,10 +649,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The supply result.
-   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
-   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
-   *   returns a transaction for another chain.
+   * @throws {ChainIdMismatchError} when the provider chain context changes while preparing the
+   *   operation, conflicts with the configured target or cached ERC-4337 account context, or the
+   *   EOA signer returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured vault, the account lacks funds, or the transaction fails.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings" },
+   * });
+   * const result = await morpho.supply({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // result satisfies SupplyResult
+   * ```
    */
   async supply(
     options: MorphoSupplyOptions,
@@ -670,6 +701,23 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns Approval/signature requirements.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings" },
+   * });
+   * const requirements = await morpho.getSupplyRequirements({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // requirements satisfies ApprovalOrSignatureRequirement[]
+   * ```
    */
   async getSupplyRequirements(
     options: MorphoSupplyOptions,
@@ -696,6 +744,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The fee quote.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings" },
+   * });
+   * const quote = await morpho.quoteSupply({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // quote satisfies Omit<SupplyResult, "hash">
+   * ```
    */
   async quoteSupply(
     options: MorphoSupplyOptions,
@@ -767,10 +833,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The withdraw result.
-   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
-   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
-   *   returns a transaction for another chain.
+   * @throws {ChainIdMismatchError} when the provider chain context changes while preparing the
+   *   operation, conflicts with the configured target or cached ERC-4337 account context, or the
+   *   EOA signer returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured vault, or the transaction fails.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings" },
+   * });
+   * const result = await morpho.withdraw({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // result satisfies WithdrawResult
+   * ```
    */
   async withdraw(
     options: WithdrawOptions,
@@ -793,6 +876,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The fee quote.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings" },
+   * });
+   * const quote = await morpho.quoteWithdraw({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // quote satisfies Omit<WithdrawResult, "hash">
+   * ```
    */
   async quoteWithdraw(
     options: WithdrawOptions,
@@ -859,10 +960,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The borrow options.
    * @param config - ERC-4337 transaction config override.
    * @returns The borrow result.
-   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
-   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
-   *   returns a transaction for another chain.
+   * @throws {ChainIdMismatchError} when the provider chain context changes while preparing the
+   *   operation, conflicts with the configured target or cached ERC-4337 account context, or the
+   *   EOA signer returns a transaction for another chain.
    * @throws {Error} If the options are invalid, GeneralAdapter1 is not authorized, or the transaction fails.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const result = await morpho.borrow({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // result satisfies BorrowResult
+   * ```
    */
   async borrow(
     options: MorphoBorrowInput,
@@ -886,6 +1004,23 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *   `RequirementSignatureRequest` to fold into the bundle via `setAuthorizationWithSig`.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const requirements = await morpho.getBorrowRequirements({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // requirements satisfies (RequirementAuthorization | RequirementSignatureRequest)[]
+   * ```
    */
   public getBorrowRequirements(
     options: MorphoBorrowOptions,
@@ -900,6 +1035,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *   fold into the bundle via `setAuthorizationWithSig`.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm, {
+   *   type MorphoBorrowWithVaultV2ReallocationsOptions,
+   * } from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const options: MorphoBorrowWithVaultV2ReallocationsOptions = {
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   *   reallocations: [],
+   * };
+   * const requirements = await morpho.getBorrowRequirements(options);
+   * // requirements may also include a RequirementApproval
+   * ```
    */
   public getBorrowRequirements(
     options: MorphoBorrowWithVaultV2ReallocationsOptions,
@@ -936,6 +1092,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The fee quote.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const quote = await morpho.quoteBorrow({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // quote satisfies Omit<BorrowResult, "hash">
+   * ```
    */
   async quoteBorrow(
     options: MorphoBorrowInput,
@@ -1010,10 +1184,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The repay options.
    * @param config - ERC-4337 transaction config override.
    * @returns The repay result.
-   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
-   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
-   *   returns a transaction for another chain.
+   * @throws {ChainIdMismatchError} when the provider chain context changes while preparing the
+   *   operation, conflicts with the configured target or cached ERC-4337 account context, or the
+   *   EOA signer returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the account lacks funds, or the transaction fails.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const result = await morpho.repay({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // result satisfies RepayResult
+   * ```
    */
   async repay(
     options: MorphoRepayOptions,
@@ -1044,6 +1235,23 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns Approval/signature requirements.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const requirements = await morpho.getRepayRequirements({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // requirements satisfies ApprovalOrSignatureRequirement[]
+   * ```
    */
   async getRepayRequirements(
     options: MorphoRepayOptions,
@@ -1070,6 +1278,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The fee quote.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const quote = await morpho.quoteRepay({
+   *   token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+   *   amount: 1_000_000n,
+   * });
+   * // quote satisfies Omit<RepayResult, "hash">
+   * ```
    */
   async quoteRepay(
     options: MorphoRepayOptions,
@@ -1145,10 +1371,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The supply collateral result.
-   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
-   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
-   *   returns a transaction for another chain.
+   * @throws {ChainIdMismatchError} when the provider chain context changes while preparing the
+   *   operation, conflicts with the configured target or cached ERC-4337 account context, or the
+   *   EOA signer returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured market collateral, the account lacks funds, or the transaction fails.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const result = await morpho.supplyCollateral({
+   *   token: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+   *   amount: 1_000_000_000_000_000n,
+   * });
+   * // result satisfies SupplyResult
+   * ```
    */
   async supplyCollateral(
     options: MorphoSupplyOptions,
@@ -1183,6 +1426,23 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns Approval/signature requirements.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const requirements = await morpho.getSupplyCollateralRequirements({
+   *   token: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+   *   amount: 1_000_000_000_000_000n,
+   * });
+   * // requirements satisfies ApprovalOrSignatureRequirement[]
+   * ```
    */
   async getSupplyCollateralRequirements(
     options: MorphoSupplyOptions,
@@ -1212,6 +1472,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The fee quote.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const quote = await morpho.quoteSupplyCollateral({
+   *   token: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+   *   amount: 1_000_000_000_000_000n,
+   * });
+   * // quote satisfies Omit<SupplyResult, "hash">
+   * ```
    */
   async quoteSupplyCollateral(
     options: MorphoSupplyOptions,
@@ -1276,10 +1554,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The withdraw collateral result.
-   * @throws {ChainIdMismatchError} when the provider chain context changes mid-operation,
-   *   conflicts with the configured target or cached ERC-4337 account context, or the EOA signer
-   *   returns a transaction for another chain.
+   * @throws {ChainIdMismatchError} when the provider chain context changes while preparing the
+   *   operation, conflicts with the configured target or cached ERC-4337 account context, or the
+   *   EOA signer returns a transaction for another chain.
    * @throws {Error} If the options are invalid, the token does not match the configured market collateral, or the transaction fails.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountEvm(process.env.WALLET_SEED!, "0'/0/0", {
+   *   provider: process.env.MAINNET_RPC_URL!,
+   * });
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const result = await morpho.withdrawCollateral({
+   *   token: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+   *   amount: 1_000_000_000_000_000n,
+   * });
+   * // result satisfies WithdrawResult
+   * ```
    */
   async withdrawCollateral(
     options: WithdrawOptions,
@@ -1305,6 +1600,24 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The fee quote.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const quote = await morpho.quoteWithdrawCollateral({
+   *   token: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+   *   amount: 1_000_000_000_000_000n,
+   * });
+   * // quote satisfies Omit<WithdrawResult, "hash">
+   * ```
    */
   async quoteWithdrawCollateral(
     options: WithdrawOptions,
@@ -1369,6 +1682,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The vault position.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings" },
+   * });
+   * const position = await morpho.getVaultPosition();
+   * // position satisfies VaultPosition
+   * ```
    */
   async getVaultPosition(account?: string): Promise<VaultPosition> {
     const context = await this._getVaultContext();
@@ -1412,6 +1740,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The market position.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { borrow: "wsteth" },
+   * });
+   * const position = await morpho.getMarketPosition();
+   * // position satisfies MarketPosition
+   * ```
    */
   async getMarketPosition(account?: string): Promise<MarketPosition> {
     const context = await this._getMarketContext();
@@ -1449,6 +1792,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns The account data.
    * @throws {ChainIdMismatchError} when provider chain context changes mid-operation or conflicts
    *   with configured target or cached ERC-4337 account context.
+   * @example
+   * ```ts
+   * import MorphoProtocolEvm from "@morpho-org/wdk-protocol-lending-morpho-evm";
+   * import { WalletAccountReadOnlyEvm } from "@tetherto/wdk-wallet-evm";
+   *
+   * const account = new WalletAccountReadOnlyEvm(
+   *   "0x405005C7c4422390F4B334F64Cf20E0b767131d0",
+   *   { provider: process.env.MAINNET_RPC_URL! },
+   * );
+   * const morpho = new MorphoProtocolEvm(account, {
+   *   presets: { earn: "sky-money-usdt-savings", borrow: "wsteth" },
+   * });
+   * const data = await morpho.getAccountData();
+   * // data satisfies AccountData
+   * ```
    */
   async getAccountData(account?: string): Promise<AccountData> {
     const context = await this._getChainContext();
@@ -1944,20 +2302,34 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     await this._revalidate(prepared.context);
 
     if (this._evmAccount instanceof WalletAccountEvmErc4337) {
-      const { fee } = await this._evmAccount.quoteSendTransaction(
-        prepared.transaction,
-        config,
-      );
-      await this._revalidate(prepared.context);
-      const signed = await this._evmAccount.signTransaction(
-        prepared.transaction,
-        config,
-      );
-      await this._revalidate(prepared.context);
+      const account = this._evmAccount;
+      const walletConfig: unknown = Reflect.get(account, "_config");
+      const effectiveConfig = {
+        ...(typeof walletConfig === "object" && walletConfig !== null
+          ? walletConfig
+          : {}),
+        ...config,
+      };
+      const hasNonceLane =
+        ("nonceKey" in effectiveConfig &&
+          effectiveConfig.nonceKey !== undefined &&
+          effectiveConfig.nonceKey !== null) ||
+        ("parallel" in effectiveConfig && effectiveConfig.parallel === true);
 
-      const { hash } = await this._evmAccount.sendTransaction(signed, config);
+      if (hasNonceLane) {
+        return await account.sendTransaction(prepared.transaction, config);
+      }
 
-      return { hash, fee };
+      // WDK's quote cache omits config; its default key-0 nonce lane forces a
+      // fresh, config-bound build instead of consuming a cached operation.
+      const cacheProofConfig: Erc4337TransactionConfig & {
+        readonly nonceKey: bigint;
+      } = { ...config, nonceKey: 0n };
+
+      return await account.sendTransaction(
+        prepared.transaction,
+        cacheProofConfig,
+      );
     }
     if (this._evmAccount instanceof WalletAccountEvm) {
       const { fee } = await this._evmAccount.quoteSendTransaction(

--- a/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
+++ b/packages/wdk-protocol-lending-morpho-evm/src/morpho-protocol-evm.ts
@@ -6,6 +6,7 @@ import {
 import { fetchMarket } from "@morpho-org/blue-sdk-viem";
 import {
   type BlueAuthorizationAction,
+  ChainIdMismatchError,
   type ERC20ApprovalAction,
   type Metadata,
   type MorphoClientType,
@@ -42,6 +43,7 @@ import {
   createClient,
   custom,
   erc4626Abi,
+  fallback,
   http,
   isAddress,
   isAddressEqual,
@@ -80,20 +82,7 @@ export interface Eip1193Provider {
 type WdkProviderSource =
   | string
   | Eip1193Provider
-  | Array<string | Eip1193Provider>;
-
-/**
- * wdk-wallet exposes the construction config (including the provider URL or
- * EIP-1193 provider) via a `protected _config` field on every wallet account
- * class. Reading it here is the package boundary: there is no public accessor,
- * and we need the raw source to construct a viem client bound to the same
- * provider the wallet uses.
- */
-interface WdkWalletWithConfig {
-  readonly _config: {
-    readonly provider?: WdkProviderSource;
-  };
-}
+  | readonly (string | Eip1193Provider)[];
 
 type ViemPublicClient = Client<Transport, Chain> &
   PublicActions<Transport, Chain>;
@@ -298,6 +287,16 @@ interface WdkTransaction {
   data: `0x${string}`;
 }
 
+interface ChainContext {
+  readonly chainId: number;
+  readonly generation: number;
+}
+
+interface PreparedTransaction {
+  readonly context: ChainContext;
+  readonly transaction: WdkTransaction;
+}
+
 const SUPPORTED_CHAINS: Record<number, Chain> = {
   [mainnet.id]: mainnet,
   [base.id]: base,
@@ -437,11 +436,31 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   private readonly _evmAccount: MorphoEvmAccount;
   private readonly _options: NormalizedMorphoProtocolOptions;
   private readonly _providerSource: WdkProviderSource;
-  private _chainId: number | undefined = undefined;
-  private _viemClient: ViemPublicClient | undefined = undefined;
-  private _viemClientAccount: Address | undefined = undefined;
-  private _morphoClient: MorphoClientType | undefined = undefined;
-  private _marketParams: MarketParams | undefined = undefined;
+  private readonly _providerRetries: number;
+  private readonly _accountConfiguredChainId: number | undefined;
+  private _chainContext: ChainContext | undefined = undefined;
+  private _latestChainObservation:
+    | { readonly chainId: Promise<number> }
+    | undefined = undefined;
+  private _erc4337Context: ChainContext | undefined = undefined;
+  private _erc4337InvalidChainId: number | undefined = undefined;
+  private _viemClient:
+    | {
+        readonly context: ChainContext;
+        readonly account: Address;
+        readonly value: ViemPublicClient;
+      }
+    | undefined = undefined;
+  private _morphoClient:
+    | {
+        readonly context: ChainContext;
+        readonly viemClient: ViemPublicClient;
+        readonly value: MorphoClientType;
+      }
+    | undefined = undefined;
+  private _marketParams:
+    | { readonly context: ChainContext; readonly value: MarketParams }
+    | undefined = undefined;
 
   /**
    * Creates a new interface to the Morpho protocol for EVM blockchains.
@@ -464,10 +483,17 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     super(account as ConstructorParameters<typeof LendingProtocol>[0]);
     this._evmAccount = account;
 
-    const provider = (account as unknown as WdkWalletWithConfig)._config
-      ?.provider;
+    // wdk-wallet exposes its provider config only through this protected
+    // runtime field. Absorb that unstable boundary as unknown before narrowing.
+    const walletConfig: unknown = Reflect.get(account, "_config");
+    const config =
+      typeof walletConfig === "object" && walletConfig !== null
+        ? walletConfig
+        : {};
+    const provider: unknown =
+      "provider" in config ? config.provider : undefined;
 
-    if (!provider) {
+    if (!provider || (Array.isArray(provider) && provider.length === 0)) {
       throw new Error("The wallet account must have a provider configured.");
     }
 
@@ -476,7 +502,14 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._validateOptions(normalizedOptions);
 
     this._options = normalizedOptions;
-    this._providerSource = provider;
+    this._providerSource = Array.isArray(provider)
+      ? (Object.freeze([...provider]) as WdkProviderSource)
+      : (provider as WdkProviderSource);
+    const retries = "retries" in config ? config.retries : undefined;
+    this._providerRetries = typeof retries === "number" ? retries : 3;
+    const accountChainId = "chainId" in config ? config.chainId : undefined;
+    this._accountConfiguredChainId =
+      typeof accountChainId === "number" ? accountChainId : undefined;
   }
 
   /**
@@ -492,6 +525,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The supply result.
+   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
    * @throws {Error} If the options are invalid, the token does not match the configured vault, the account lacks funds, or the transaction fails.
    */
   async supply(
@@ -500,13 +534,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   ): Promise<SupplyResult> {
     this._assertWritable("supply(options)");
     const depositAmounts = normalizeDepositAmounts(options);
+    const operationOptions: MorphoSupplyOptions = {
+      ...options,
+      ...depositAmounts,
+    };
+    const context = await this._getVaultContext();
     if (depositAmounts.amount > 0n) {
-      await this._assertTokenBalance(options.token, depositAmounts.amount);
+      await this._assertTokenBalance(context, {
+        token: operationOptions.token,
+        amount: depositAmounts.amount,
+      });
     } else {
-      this._assertAddress("token", options.token);
+      this._assertAddress("token", operationOptions.token);
     }
 
-    const tx = await this._getSupplyTransaction(options, depositAmounts);
+    const tx = await this._getSupplyTransaction(context, operationOptions);
 
     return await this._sendTransaction(tx, config);
   }
@@ -517,14 +559,18 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The supply options.
    * @param requirementOptions - Optional Morpho SDK requirement options.
    * @returns Approval/signature requirements.
+   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
    */
   async getSupplyRequirements(
     options: MorphoSupplyOptions,
     requirementOptions?: RequirementOptions,
   ): Promise<ApprovalOrSignatureRequirement[]> {
-    const action = await this._getSupplyAction(options);
+    const context = await this._getVaultContext();
+    const action = await this._getSupplyAction(context, options);
+    const requirements = await action.getRequirements(requirementOptions);
+    await this._revalidate(context);
 
-    return await action.getRequirements(requirementOptions);
+    return requirements;
   }
 
   /**
@@ -533,17 +579,20 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
+   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
    */
   async quoteSupply(
     options: MorphoSupplyOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<SupplyResult, "hash">> {
-    const tx = await this._getSupplyTransaction(options);
+    const context = await this._getVaultContext();
+    const tx = await this._getSupplyTransaction(context, options);
 
     return await this._quoteTransaction(tx, config);
   }
 
   private async _getSupplyAction(
+    context: ChainContext,
     {
       token,
       amount,
@@ -551,17 +600,15 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       onBehalfOf,
       slippageTolerance,
     }: MorphoSupplyOptions,
-    depositAmounts: NormalizedDepositAmounts = normalizeDepositAmounts({
-      amount,
-      nativeAmount,
-    }),
   ) {
+    const depositAmounts = normalizeDepositAmounts({ amount, nativeAmount });
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(onBehalfOf);
-    const vault = await this._getVault();
+    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const vault = await this._getVault(context);
     const accrualVault = await vault.entity.getData();
+    await this._revalidate(context);
 
     if (!isAddressEqual(accrualVault.asset, token as Address)) {
       throw new Error(
@@ -579,18 +626,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _getSupplyTransaction(
+    context: ChainContext,
     options: MorphoSupplyOptions,
-    depositAmounts?: NormalizedDepositAmounts,
-  ): Promise<WdkTransaction> {
-    const action = await this._getSupplyAction(options, depositAmounts);
+  ): Promise<PreparedTransaction> {
+    const action = await this._getSupplyAction(context, options);
 
-    return toWdkTransaction(
-      action.buildTx(
-        options.requirementSignature
-          ? [options.requirementSignature]
-          : undefined,
+    return {
+      context,
+      transaction: toWdkTransaction(
+        action.buildTx(
+          options.requirementSignature
+            ? [options.requirementSignature]
+            : undefined,
+        ),
       ),
-    );
+    };
   }
 
   /**
@@ -599,6 +649,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The withdraw result.
+   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
    * @throws {Error} If the options are invalid, the token does not match the configured vault, or the transaction fails.
    */
   async withdraw(
@@ -606,8 +657,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<WithdrawResult> {
     this._assertWritable("withdraw(options)");
-
-    const tx = await this._getWithdrawTransaction(options);
+    const context = await this._getVaultContext();
+    const tx = await this._getWithdrawTransaction(context, options);
 
     return await this._sendTransaction(tx, config);
   }
@@ -618,34 +669,37 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
+   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
    */
   async quoteWithdraw(
     options: WithdrawOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<WithdrawResult, "hash">> {
-    const tx = await this._getWithdrawTransaction(options);
+    const context = await this._getVaultContext();
+    const tx = await this._getWithdrawTransaction(context, options);
 
     return await this._quoteTransaction(tx, config);
   }
 
-  private async _getWithdrawTransaction({
-    token,
-    amount,
-    to,
-  }: WithdrawOptions): Promise<WdkTransaction> {
+  private async _getWithdrawTransaction(
+    context: ChainContext,
+    { token, amount, to }: WithdrawOptions,
+  ): Promise<PreparedTransaction> {
     const normalizedAmount = normalizeAmount(amount);
     this._assertAddress("token", token);
     this._assertOptionalAddress("to", to);
 
     const userAddress = (await this._evmAccount.getAddress()) as Address;
+    this._assertCurrent(context);
     if (to !== undefined && !isAddressEqual(to as Address, userAddress)) {
       throw new Error(
         "'to' must equal the wallet account address for Morpho vault withdrawals.",
       );
     }
 
-    const vault = await this._getVault();
+    const vault = await this._getVault(context);
     const accrualVault = await vault.entity.getData();
+    await this._revalidate(context);
 
     if (!isAddressEqual(accrualVault.asset, token as Address)) {
       throw new Error(
@@ -653,14 +707,17 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       );
     }
 
-    return toWdkTransaction(
-      vault.entity
-        .withdraw({
-          amount: normalizedAmount,
-          userAddress,
-        })
-        .buildTx(),
-    );
+    return {
+      context,
+      transaction: toWdkTransaction(
+        vault.entity
+          .withdraw({
+            amount: normalizedAmount,
+            userAddress,
+          })
+          .buildTx(),
+      ),
+    };
   }
 
   /**
@@ -677,6 +734,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The borrow options.
    * @param config - ERC-4337 transaction config override.
    * @returns The borrow result.
+   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
    * @throws {Error} If the options are invalid, GeneralAdapter1 is not authorized, or the transaction fails.
    */
   async borrow(
@@ -684,8 +742,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<BorrowResult> {
     this._assertWritable("borrow(options)");
-
-    const tx = await this._getBorrowTransaction(options);
+    const context = await this._getMarketContext();
+    const tx = await this._getBorrowTransaction(context, options);
 
     return await this._sendTransaction(tx, config);
   }
@@ -697,6 +755,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @returns Authorization requirements. When offchain signatures are enabled
    *   (`supportSignature: true`), the authorization may instead be returned as a signable
    *   `RequirementSignatureRequest` to fold into the bundle via `setAuthorizationWithSig`.
+   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
    */
   public getBorrowRequirements(
     options: MorphoBorrowOptions,
@@ -709,6 +768,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *   allocator penalty donation. When offchain signatures are enabled (`supportSignature: true`),
    *   the authorization may instead be returned as a signable `RequirementSignatureRequest` to
    *   fold into the bundle via `setAuthorizationWithSig`.
+   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
    */
   public getBorrowRequirements(
     options: MorphoBorrowWithVaultV2ReallocationsOptions,
@@ -728,9 +788,12 @@ export default class MorphoProtocolEvm extends LendingProtocol {
       | RequirementSignatureRequest
     )[]
   > {
-    const action = await this._getBorrowAction(options);
+    const context = await this._getMarketContext();
+    const action = await this._getBorrowAction(context, options);
+    const requirements = await action.getRequirements();
+    await this._revalidate(context);
 
-    return await action.getRequirements();
+    return requirements;
   }
 
   /**
@@ -739,29 +802,34 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The borrow options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
+   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
    */
   async quoteBorrow(
     options: MorphoBorrowInput,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<BorrowResult, "hash">> {
-    const tx = await this._getBorrowTransaction(options);
+    const context = await this._getMarketContext();
+    const tx = await this._getBorrowTransaction(context, options);
 
     return await this._quoteTransaction(tx, config);
   }
 
-  private async _getBorrowAction({
-    token,
-    amount,
-    onBehalfOf,
-    slippageTolerance,
-    reallocations,
-  }: MorphoBorrowInput) {
+  private async _getBorrowAction(
+    context: ChainContext,
+    {
+      token,
+      amount,
+      onBehalfOf,
+      slippageTolerance,
+      reallocations,
+    }: MorphoBorrowInput,
+  ) {
     const normalizedAmount = normalizeAmount(amount);
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(onBehalfOf);
-    const market = await this._getMarket();
+    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.loanToken, token as Address)) {
       throw new Error(
@@ -770,6 +838,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     }
 
     const positionData = await market.entity.getPositionData(userAddress);
+    await this._revalidate(context);
 
     return market.entity.borrow({
       amount: normalizedAmount,
@@ -781,17 +850,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _getBorrowTransaction(
+    context: ChainContext,
     options: MorphoBorrowInput,
-  ): Promise<WdkTransaction> {
-    const action = await this._getBorrowAction(options);
+  ): Promise<PreparedTransaction> {
+    const action = await this._getBorrowAction(context, options);
 
-    return toWdkTransaction(
-      action.buildTx(
-        options.requirementSignature
-          ? [options.requirementSignature]
-          : undefined,
+    return {
+      context,
+      transaction: toWdkTransaction(
+        action.buildTx(
+          options.requirementSignature
+            ? [options.requirementSignature]
+            : undefined,
+        ),
       ),
-    );
+    };
   }
 
   /**
@@ -802,6 +875,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The repay options.
    * @param config - ERC-4337 transaction config override.
    * @returns The repay result.
+   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
    * @throws {Error} If the options are invalid, the account lacks funds, or the transaction fails.
    */
   async repay(
@@ -811,12 +885,17 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     this._assertWritable("repay(options)");
     const amount =
       options.amount === "max" ? "max" : normalizeAmount(options.amount);
+    const operationOptions: MorphoRepayOptions = { ...options, amount };
+    const context = await this._getMarketContext();
 
     if (amount !== "max") {
-      await this._assertTokenBalance(options.token, amount);
+      await this._assertTokenBalance(context, {
+        token: operationOptions.token,
+        amount,
+      });
     }
 
-    const tx = await this._getRepayTransaction(options, amount);
+    const tx = await this._getRepayTransaction(context, operationOptions);
 
     return await this._sendTransaction(tx, config);
   }
@@ -827,14 +906,18 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The repay options.
    * @param requirementOptions - Optional Morpho SDK requirement options.
    * @returns Approval/signature requirements.
+   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
    */
   async getRepayRequirements(
     options: MorphoRepayOptions,
     requirementOptions?: RequirementOptions,
   ): Promise<ApprovalOrSignatureRequirement[]> {
-    const action = await this._getRepayAction(options);
+    const context = await this._getMarketContext();
+    const action = await this._getRepayAction(context, options);
+    const requirements = await action.getRequirements(requirementOptions);
+    await this._revalidate(context);
 
-    return await action.getRequirements(requirementOptions);
+    return requirements;
   }
 
   /**
@@ -843,27 +926,28 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The repay options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
+   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
    */
   async quoteRepay(
     options: MorphoRepayOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<RepayResult, "hash">> {
-    const tx = await this._getRepayTransaction(options);
+    const context = await this._getMarketContext();
+    const tx = await this._getRepayTransaction(context, options);
 
     return await this._quoteTransaction(tx, config);
   }
 
   private async _getRepayAction(
+    context: ChainContext,
     { token, amount, onBehalfOf, slippageTolerance }: MorphoRepayOptions,
-    normalizedAmount: "max" | bigint = amount === "max"
-      ? "max"
-      : normalizeAmount(amount),
   ) {
+    const normalizedAmount = amount === "max" ? "max" : normalizeAmount(amount);
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(onBehalfOf);
-    const market = await this._getMarket();
+    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.loanToken, token as Address)) {
       throw new Error(
@@ -872,6 +956,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     }
 
     const positionData = await market.entity.getPositionData(userAddress);
+    await this._revalidate(context);
     const repayAmount =
       normalizedAmount === "max"
         ? { shares: positionData.borrowShares }
@@ -886,18 +971,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _getRepayTransaction(
+    context: ChainContext,
     options: MorphoRepayOptions,
-    amount?: "max" | bigint,
-  ): Promise<WdkTransaction> {
-    const action = await this._getRepayAction(options, amount);
+  ): Promise<PreparedTransaction> {
+    const action = await this._getRepayAction(context, options);
 
-    return toWdkTransaction(
-      action.buildTx(
-        options.requirementSignature
-          ? [options.requirementSignature]
-          : undefined,
+    return {
+      context,
+      transaction: toWdkTransaction(
+        action.buildTx(
+          options.requirementSignature
+            ? [options.requirementSignature]
+            : undefined,
+        ),
       ),
-    );
+    };
   }
 
   /**
@@ -912,6 +1000,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The supply collateral result.
+   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
    * @throws {Error} If the options are invalid, the token does not match the configured market collateral, the account lacks funds, or the transaction fails.
    */
   async supplyCollateral(
@@ -920,15 +1009,23 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   ): Promise<SupplyResult> {
     this._assertWritable("supplyCollateral(options)");
     const depositAmounts = normalizeDepositAmounts(options);
+    const operationOptions: MorphoSupplyOptions = {
+      ...options,
+      ...depositAmounts,
+    };
+    const context = await this._getMarketContext();
     if (depositAmounts.amount > 0n) {
-      await this._assertTokenBalance(options.token, depositAmounts.amount);
+      await this._assertTokenBalance(context, {
+        token: operationOptions.token,
+        amount: depositAmounts.amount,
+      });
     } else {
-      this._assertAddress("token", options.token);
+      this._assertAddress("token", operationOptions.token);
     }
 
     const tx = await this._getSupplyCollateralTransaction(
-      options,
-      depositAmounts,
+      context,
+      operationOptions,
     );
 
     return await this._sendTransaction(tx, config);
@@ -940,14 +1037,18 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral supply options.
    * @param requirementOptions - Optional Morpho SDK requirement options.
    * @returns Approval/signature requirements.
+   * @throws {ChainIdMismatchError} When the provider changes chains while resolving requirements.
    */
   async getSupplyCollateralRequirements(
     options: MorphoSupplyOptions,
     requirementOptions?: RequirementOptions,
   ): Promise<ApprovalOrSignatureRequirement[]> {
-    const action = await this._getSupplyCollateralAction(options);
+    const context = await this._getMarketContext();
+    const action = await this._getSupplyCollateralAction(context, options);
+    const requirements = await action.getRequirements(requirementOptions);
+    await this._revalidate(context);
 
-    return await action.getRequirements(requirementOptions);
+    return requirements;
   }
 
   /**
@@ -956,28 +1057,28 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral supply options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
+   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
    */
   async quoteSupplyCollateral(
     options: MorphoSupplyOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<SupplyResult, "hash">> {
-    const tx = await this._getSupplyCollateralTransaction(options);
+    const context = await this._getMarketContext();
+    const tx = await this._getSupplyCollateralTransaction(context, options);
 
     return await this._quoteTransaction(tx, config);
   }
 
   private async _getSupplyCollateralAction(
+    context: ChainContext,
     { token, amount, nativeAmount, onBehalfOf }: MorphoSupplyOptions,
-    depositAmounts: NormalizedDepositAmounts = normalizeDepositAmounts({
-      amount,
-      nativeAmount,
-    }),
   ) {
+    const depositAmounts = normalizeDepositAmounts({ amount, nativeAmount });
     this._assertAddress("token", token);
     this._assertOptionalAddress("onBehalfOf", onBehalfOf);
 
-    const userAddress = await this._getSdkUserAddress(onBehalfOf);
-    const market = await this._getMarket();
+    const userAddress = await this._getSdkUserAddress(context, onBehalfOf);
+    const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.collateralToken, token as Address)) {
       throw new Error(
@@ -993,21 +1094,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _getSupplyCollateralTransaction(
+    context: ChainContext,
     options: MorphoSupplyOptions,
-    depositAmounts?: NormalizedDepositAmounts,
-  ): Promise<WdkTransaction> {
-    const action = await this._getSupplyCollateralAction(
-      options,
-      depositAmounts,
-    );
+  ): Promise<PreparedTransaction> {
+    const action = await this._getSupplyCollateralAction(context, options);
 
-    return toWdkTransaction(
-      action.buildTx(
-        options.requirementSignature
-          ? [options.requirementSignature]
-          : undefined,
+    return {
+      context,
+      transaction: toWdkTransaction(
+        action.buildTx(
+          options.requirementSignature
+            ? [options.requirementSignature]
+            : undefined,
+        ),
       ),
-    );
+    };
   }
 
   /**
@@ -1016,6 +1117,7 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The withdraw collateral result.
+   * @throws {ChainIdMismatchError} When the provider changes chains before dispatch.
    * @throws {Error} If the options are invalid, the token does not match the configured market collateral, or the transaction fails.
    */
   async withdrawCollateral(
@@ -1023,8 +1125,8 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     config?: Erc4337TransactionConfig,
   ): Promise<WithdrawResult> {
     this._assertWritable("withdrawCollateral(options)");
-
-    const tx = await this._getWithdrawCollateralTransaction(options);
+    const context = await this._getMarketContext();
+    const tx = await this._getWithdrawCollateralTransaction(context, options);
 
     return await this._sendTransaction(tx, config);
   }
@@ -1035,27 +1137,29 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    * @param options - The collateral withdraw options.
    * @param config - ERC-4337 transaction config override.
    * @returns The fee quote.
+   * @throws {ChainIdMismatchError} When the provider changes chains while quoting.
    */
   async quoteWithdrawCollateral(
     options: WithdrawOptions,
     config?: Erc4337TransactionConfig,
   ): Promise<Omit<WithdrawResult, "hash">> {
-    const tx = await this._getWithdrawCollateralTransaction(options);
+    const context = await this._getMarketContext();
+    const tx = await this._getWithdrawCollateralTransaction(context, options);
 
     return await this._quoteTransaction(tx, config);
   }
 
-  private async _getWithdrawCollateralTransaction({
-    token,
-    amount,
-    to,
-  }: WithdrawOptions): Promise<WdkTransaction> {
+  private async _getWithdrawCollateralTransaction(
+    context: ChainContext,
+    { token, amount, to }: WithdrawOptions,
+  ): Promise<PreparedTransaction> {
     const normalizedAmount = normalizeAmount(amount);
     this._assertAddress("token", token);
     this._assertOptionalAddress("to", to);
 
     const userAddress = (await this._evmAccount.getAddress()) as Address;
-    const market = await this._getMarket();
+    this._assertCurrent(context);
+    const market = await this._getMarket(context);
 
     if (!isAddressEqual(market.params.collateralToken, token as Address)) {
       throw new Error(
@@ -1070,16 +1174,20 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     }
 
     const positionData = await market.entity.getPositionData(userAddress);
+    await this._revalidate(context);
 
-    return toWdkTransaction(
-      market.entity
-        .withdrawCollateral({
-          amount: normalizedAmount,
-          userAddress,
-          positionData,
-        })
-        .buildTx(),
-    );
+    return {
+      context,
+      transaction: toWdkTransaction(
+        market.entity
+          .withdrawCollateral({
+            amount: normalizedAmount,
+            userAddress,
+            positionData,
+          })
+          .buildTx(),
+      ),
+    };
   }
 
   /**
@@ -1087,22 +1195,35 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *
    * @param account - If set, returns the vault position for the given address.
    * @returns The vault position.
+   * @throws {ChainIdMismatchError} When the provider changes chains while reading the position.
    */
   async getVaultPosition(account?: string): Promise<VaultPosition> {
+    const context = await this._getVaultContext();
+
+    return await this._getVaultPosition(context, account);
+  }
+
+  private async _getVaultPosition(
+    context: ChainContext,
+    account?: string,
+  ): Promise<VaultPosition> {
     this._assertOptionalAddress("account", account);
 
     const userAddress =
       (account as Address | undefined) ??
       ((await this._evmAccount.getAddress()) as Address);
-    const vault = await this._getVault();
+    this._assertCurrent(context);
+    const vault = await this._getVault(context);
     const data = await vault.entity.getData();
-    const client = await this._getViemClient();
+    await this._revalidate(context);
+    const client = await this._getViemClient(context);
     const shares = await client.readContract({
       address: vault.address,
       abi: erc4626Abi,
       functionName: "balanceOf",
       args: [userAddress],
     });
+    await this._revalidate(context);
 
     return {
       shares,
@@ -1116,15 +1237,27 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *
    * @param account - If set, returns the market position for the given address.
    * @returns The market position.
+   * @throws {ChainIdMismatchError} When the provider changes chains while reading the position.
    */
   async getMarketPosition(account?: string): Promise<MarketPosition> {
+    const context = await this._getMarketContext();
+
+    return await this._getMarketPosition(context, account);
+  }
+
+  private async _getMarketPosition(
+    context: ChainContext,
+    account?: string,
+  ): Promise<MarketPosition> {
     this._assertOptionalAddress("account", account);
 
     const userAddress =
       (account as Address | undefined) ??
       ((await this._evmAccount.getAddress()) as Address);
-    const market = await this._getMarket();
+    this._assertCurrent(context);
+    const market = await this._getMarket(context);
     const position = await market.entity.getPositionData(userAddress);
+    await this._revalidate(context);
 
     return {
       supplyShares: position.supplyShares,
@@ -1140,12 +1273,17 @@ export default class MorphoProtocolEvm extends LendingProtocol {
    *
    * @param account - If set, returns the data for the given address.
    * @returns The account data.
+   * @throws {ChainIdMismatchError} When the provider changes chains while reading account data.
    */
   async getAccountData(account?: string): Promise<AccountData> {
+    const context = await this._getChainContext();
+    this._assertTargetChain(this._resolveVaultTarget(), context);
+    this._assertTargetChain(this._resolveMarketTarget(), context);
     const [vault, market] = await Promise.all([
-      this.getVaultPosition(account),
-      this.getMarketPosition(account),
+      this._getVaultPosition(context, account),
+      this._getMarketPosition(context, account),
     ]);
+    await this._revalidate(context);
 
     return {
       vaultShares: vault.shares,
@@ -1183,82 +1321,112 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     return target.marketId;
   }
 
-  private async _getVault(): Promise<{
+  private async _getVault(context: ChainContext): Promise<{
     address: Address;
     entity: ReturnType<MorphoClientType["vaultV2"]>;
   }> {
     const target = this._resolveVaultTarget();
     const { address } = target;
-    const chainId = await this._getChainId();
-    this._assertTargetChain(target, { chainId, label: "Morpho target" });
-    const client = await this._getMorphoClient();
-    const entity = client.vaultV2(address, chainId);
+    this._assertCurrent(context);
+    this._assertTargetChain(target, context);
+    const client = await this._getMorphoClient(context);
+    const entity = client.vaultV2(address, context.chainId);
 
     return { address, entity };
   }
 
-  private async _getMarket(): Promise<{
+  private async _getMarket(context: ChainContext): Promise<{
     params: MarketParams;
     entity: ReturnType<MorphoClientType["blue"]>;
   }> {
-    const params = await this._getMarketParams();
-    const chainId = await this._getChainId();
-    const client = await this._getMorphoClient();
+    const params = await this._getMarketParams(context);
+    const client = await this._getMorphoClient(context);
+    this._assertCurrent(context);
 
     return {
       params,
-      entity: client.blue(params, chainId),
+      entity: client.blue(params, context.chainId),
     };
   }
 
-  private async _getMarketParams(): Promise<MarketParams> {
-    const chainId = await this._getChainId();
-
-    if (this._marketParams) return this._marketParams;
+  private async _getMarketParams(context: ChainContext): Promise<MarketParams> {
+    if (this._marketParams?.context === context) {
+      return this._marketParams.value;
+    }
 
     const target = this._resolveMarketTarget();
 
-    this._assertTargetChain(target, { chainId, label: "Morpho target" });
+    this._assertCurrent(context);
+    this._assertTargetChain(target, context);
 
     if ("marketParams" in target) {
-      this._marketParams =
+      const value =
         target.marketParams instanceof MarketParams
           ? target.marketParams
           : new MarketParams(target.marketParams);
-      return this._marketParams;
+      this._marketParams = { context, value };
+      return value;
     }
 
-    const client = await this._getViemClient();
+    const client = await this._getViemClient(context);
     const market = await fetchMarket(target.marketId as MarketId, client, {
-      chainId,
+      chainId: context.chainId,
       deployless: this._options.supportDeployless,
     });
+    await this._revalidate(context);
 
-    this._marketParams =
+    const value =
       market.params instanceof MarketParams
         ? market.params
         : new MarketParams(market.params);
+    this._marketParams = { context, value };
 
-    return this._marketParams;
+    return value;
   }
 
-  private async _getMorphoClient(): Promise<MorphoClientType> {
-    const viemClient = await this._getViemClient();
+  private async _getMorphoClient(
+    context: ChainContext,
+  ): Promise<MorphoClientType> {
+    const viemClient = await this._getViemClient(context);
 
-    if (!this._morphoClient) {
-      this._morphoClient = viemClient.extend(
+    if (
+      this._morphoClient?.context !== context ||
+      this._morphoClient.viemClient !== viemClient
+    ) {
+      const value = viemClient.extend(
         morphoViemExtension({
           supportSignature: this._options.supportSignature ?? false,
           supportDeployless: this._options.supportDeployless,
           metadata: this._options.metadata,
         }),
       ).morpho;
+      this._morphoClient = { context, viemClient, value };
     }
 
-    return this._morphoClient;
+    return this._morphoClient.value;
   }
 
   private _getViemTransport(): Transport {
+    if (Array.isArray(this._providerSource)) {
+      const providers = this._providerSource as readonly (
+        | string
+        | Eip1193Provider
+      )[];
+      const attempts = 1 + this._providerRetries;
+      return fallback(
+        Array.from({ length: attempts }, (_, index) => {
+          const provider = providers[index % providers.length] as
+            | string
+            | Eip1193Provider;
+
+          return typeof provider === "string"
+            ? http(provider)
+            : custom(provider);
+        }),
+        { retryCount: 0 },
+      );
+    }
+
     return typeof this._providerSource === "string"
       ? http(this._providerSource)
       : custom(this._providerSource as Eip1193Provider);
@@ -1283,48 +1451,140 @@ export default class MorphoProtocolEvm extends LendingProtocol {
     } satisfies Chain;
   }
 
-  private async _getViemClient(): Promise<ViemPublicClient> {
+  private async _getViemClient(
+    context: ChainContext,
+  ): Promise<ViemPublicClient> {
     const address = (await this._evmAccount.getAddress()) as Address;
-    const chainId = await this._getChainId();
+    this._assertCurrent(context);
 
     if (
       this._viemClient &&
-      this._viemClientAccount &&
-      isAddressEqual(this._viemClientAccount, address)
+      this._viemClient.context === context &&
+      isAddressEqual(this._viemClient.account, address)
     ) {
-      return this._viemClient;
+      return this._viemClient.value;
     }
 
-    this._viemClient = createClient({
+    const value = createClient({
       account: address,
-      chain: this._getViemChain(chainId),
+      chain: this._getViemChain(context.chainId),
       transport: this._getViemTransport(),
     }).extend(publicActions) as ViemPublicClient;
-    this._viemClientAccount = address;
-    this._morphoClient = undefined;
+    this._viemClient = { context, account: address, value };
 
-    return this._viemClient;
+    return value;
   }
 
-  private async _getChainId(): Promise<number> {
-    const currentChainId = Number(
-      await createClient({
+  private async _getChainContext(): Promise<ChainContext> {
+    const observation = {
+      chainId: createClient({
         transport: this._getViemTransport(),
       })
         .extend(publicActions)
-        .getChainId(),
-    );
+        .getChainId()
+        .then(Number),
+    };
+    this._latestChainObservation = observation;
+    const chainId = await observation.chainId;
+    let latestObservation = observation;
+    let latestChainId = chainId;
 
-    if (this._chainId !== undefined && this._chainId !== currentChainId) {
-      this._viemClient = undefined;
-      this._viemClientAccount = undefined;
-      this._morphoClient = undefined;
-      this._marketParams = undefined;
+    while (latestObservation !== this._latestChainObservation) {
+      const nextObservation = this._latestChainObservation;
+      if (nextObservation === undefined) break;
+      latestObservation = nextObservation;
+      latestChainId = await nextObservation.chainId;
     }
 
-    this._chainId = currentChainId;
+    if (latestChainId !== chainId) {
+      this._chainContext = Object.freeze({
+        chainId: latestChainId,
+        generation: (this._chainContext?.generation ?? 0) + 1,
+      });
+      if (this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337) {
+        this._erc4337InvalidChainId = chainId;
+      }
+      throw new ChainIdMismatchError(latestChainId, chainId);
+    }
 
-    return this._chainId;
+    const context =
+      this._chainContext?.chainId === latestChainId
+        ? this._chainContext
+        : Object.freeze({
+            chainId: latestChainId,
+            generation: (this._chainContext?.generation ?? 0) + 1,
+          });
+    this._chainContext = context;
+    this._assertErc4337Context(context);
+    return context;
+  }
+
+  private async _getVaultContext(): Promise<ChainContext> {
+    const context = await this._getChainContext();
+    this._assertTargetChain(this._resolveVaultTarget(), context);
+    return context;
+  }
+
+  private async _getMarketContext(): Promise<ChainContext> {
+    const context = await this._getChainContext();
+    this._assertTargetChain(this._resolveMarketTarget(), context);
+    return context;
+  }
+
+  private _assertCurrent(context: ChainContext): void {
+    if (this._chainContext !== context) {
+      throw new ChainIdMismatchError(
+        this._chainContext?.chainId,
+        context.chainId,
+      );
+    }
+
+    this._assertErc4337Context(context);
+  }
+
+  private async _revalidate(context: ChainContext): Promise<void> {
+    const current = await this._getChainContext();
+    if (current !== context) {
+      throw new ChainIdMismatchError(current.chainId, context.chainId);
+    }
+  }
+
+  private _assertErc4337Context(context: ChainContext): void {
+    if (!(this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337)) {
+      return;
+    }
+
+    const cachedChainId: unknown = Reflect.get(this._evmAccount, "_chainId");
+    const accountChainId =
+      typeof cachedChainId === "bigint"
+        ? Number(cachedChainId)
+        : this._accountConfiguredChainId;
+    const expectedChainId =
+      this._erc4337Context?.chainId ?? accountChainId ?? context.chainId;
+
+    if (this._erc4337InvalidChainId !== undefined) {
+      throw new ChainIdMismatchError(
+        this._erc4337InvalidChainId,
+        expectedChainId,
+      );
+    }
+
+    if (
+      (accountChainId !== undefined && accountChainId !== expectedChainId) ||
+      context.chainId !== expectedChainId ||
+      (this._erc4337Context !== undefined && this._erc4337Context !== context)
+    ) {
+      this._erc4337InvalidChainId =
+        accountChainId !== undefined && accountChainId !== expectedChainId
+          ? accountChainId
+          : context.chainId;
+      throw new ChainIdMismatchError(
+        this._erc4337InvalidChainId,
+        expectedChainId,
+      );
+    }
+
+    this._erc4337Context = context;
   }
 
   private _resolveVaultTarget(): VaultTarget {
@@ -1378,12 +1638,10 @@ export default class MorphoProtocolEvm extends LendingProtocol {
 
   private _assertTargetChain(
     target: { chainId: number | undefined },
-    args: { chainId: number; label: string },
+    context: ChainContext,
   ): void {
-    if (target.chainId !== undefined && target.chainId !== args.chainId) {
-      throw new Error(
-        `${args.label} is configured for chain ${target.chainId}, but the connected provider is on chain ${args.chainId}.`,
-      );
+    if (target.chainId !== undefined && target.chainId !== context.chainId) {
+      throw new ChainIdMismatchError(context.chainId, target.chainId);
     }
   }
 
@@ -1477,9 +1735,11 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _getSdkUserAddress(
+    context: ChainContext,
     onBehalfOf: string | undefined,
   ): Promise<Address> {
     const address = (await this._evmAccount.getAddress()) as Address;
+    this._assertCurrent(context);
 
     if (
       onBehalfOf !== undefined &&
@@ -1494,11 +1754,12 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _assertTokenBalance(
-    token: string,
-    amount: bigint,
+    context: ChainContext,
+    { token, amount }: { token: string; amount: bigint },
   ): Promise<void> {
     this._assertAddress("token", token);
     const balance = await this._evmAccount.getTokenBalance(token);
+    await this._revalidate(context);
 
     if (balance < amount) {
       throw new Error("Not enough funds to fulfill the operation.");
@@ -1506,17 +1767,21 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _sendTransaction(
-    tx: WdkTransaction,
+    prepared: PreparedTransaction,
     config?: Erc4337TransactionConfig,
   ): Promise<SupplyResult> {
+    await this._revalidate(prepared.context);
+
     if (this._evmAccount instanceof WalletAccountEvmErc4337) {
       return (await this._evmAccount.sendTransaction(
-        tx,
+        prepared.transaction,
         config,
       )) as SupplyResult;
     }
     if (this._evmAccount instanceof WalletAccountEvm) {
-      return (await this._evmAccount.sendTransaction(tx)) as SupplyResult;
+      return (await this._evmAccount.sendTransaction(
+        prepared.transaction,
+      )) as SupplyResult;
     }
     throw new Error(
       "The method requires the protocol to be initialized with a non read-only account.",
@@ -1524,13 +1789,18 @@ export default class MorphoProtocolEvm extends LendingProtocol {
   }
 
   private async _quoteTransaction(
-    tx: WdkTransaction,
+    prepared: PreparedTransaction,
     config?: Erc4337TransactionConfig,
   ): Promise<{ fee: bigint }> {
+    await this._revalidate(prepared.context);
     const { fee } =
       this._evmAccount instanceof WalletAccountReadOnlyEvmErc4337
-        ? await this._evmAccount.quoteSendTransaction(tx, config)
-        : await this._evmAccount.quoteSendTransaction(tx);
+        ? await this._evmAccount.quoteSendTransaction(
+            prepared.transaction,
+            config,
+          )
+        : await this._evmAccount.quoteSendTransaction(prepared.transaction);
+    await this._revalidate(prepared.context);
 
     return { fee };
   }


### PR DESCRIPTION
## What

- [SDKS-9](https://app.notion.com/3cfd69939e6d8117839aeacc732b5b7b) preserves configured provider-array failover. **Example:** The primary RPC is rate-limited during a deposit; the frontend continues through its backup instead of losing all Morpho reads and submissions.
- [SDKS-21](https://app.notion.com/3cfd69939e6d813a8a93e22b0bdd822c) prevents concurrent chain probes from mixing chain contexts. **Example:** An Ethereum deposit and portfolio refresh overlap while the user switches to Base; late responses can otherwise send an Ethereum Bundler target and native value on Base.
- [SDKS-24](https://app.notion.com/3cfd69939e6d8111994ed08a077307d4) keeps explicit Blue targets bound to one chain through dispatch. **Example:** A user starts an Ethereum borrow, then switches MetaMask to Base before entity creation; the app can otherwise open unintended Base debt or submit reverting calldata.
- [SDKS-97](https://app.notion.com/3cfd69939e6d819bba38db34e26a41f7) rejects stale market fetches after chain changes. **Example:** A slow Ethereum lookup finishes after a switch to Base; a later borrow can otherwise reuse old-chain market data and target the wrong network.
- [SDKS-107](https://app.notion.com/3cfd69939e6d8170bd74df0d522053eb) requires a fresh ERC-4337 account after a provider chain change. **Example:** A smart-wallet session switches from Ethereum to Base without reload; the app can otherwise sign Base Morpho calldata with Ethereum UserOperation domain, EntryPoint, or bundler context.
- [SDKS-169](https://linear.app/morpho-labs/issue/SDK-452/sdks-169medium-independent-url-transports-can-build-a-morpho) binds reads, signing, and broadcast to the wallet account's validated provider context. **Example:** A load-balanced RPC URL flips from Ethereum to Base between a deposit preview and send; the frontend rejects instead of broadcasting native value to a Base address built from Ethereum state.

## Why

Failover should remain available without allowing delayed old-chain data, targets, values, or UserOperation signatures to cross a chain boundary.
