### PR TITLE
fix(evm-simulation): fail closed on incomplete retention evidence

### DIFF
--- a/.changeset/strict-simulations-retain.md
+++ b/.changeset/strict-simulations-retain.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/evm-simulation": patch
+---
+
+Fail closed when bundler metadata or Tenderly retention evidence is incomplete, validate canonical transfer logs, and trust wrapped-native events only from the registered token.

--- a/packages/evm-simulation/AGENTS.md
+++ b/packages/evm-simulation/AGENTS.md
@@ -5,9 +5,9 @@
 - Let `SimulationRevertedError` propagate; a revert belongs to the bundle, not the backend.
 - Keep backend outputs normalized to `RawSimulationResult`; add new backends under `src/simulate/backends/` with colocated parity tests.
 - Encode signature authorizations as `approve(spender, amount ?? maxUint256)` and prepend them to the simulated bundle.
-- Enforce bundler retention by net `(bundler3 address, token)` balance with `DUST_THRESHOLD = 100n`; skip only unknown blue-sdk chains.
+- Enforce bundler retention by net `(bundler3 address, token)` balance with `DUST_THRESHOLD = 100n`; reject chains without bundler metadata in the active address registry.
 - Keep all thrown domain errors under `SimulationPackageError`; only `ExternalServiceError` is bypassable by callers.
-- Add chains through caller `SimulationConfig.chains`; the per-chain `ChainSimulationConfig` is a discriminated union enforcing at least one of `tenderlyRpc` or `simulateV1Url`. Confirm blue-sdk bundler addresses intentionally.
+- Add chains through caller `SimulationConfig.chains`; the per-chain `ChainSimulationConfig` is a discriminated union enforcing at least one of `tenderlyRpc` or `simulateV1Url`. Custom chains must also call `registerCustomAddresses` in the same active ESM/CJS module graph before simulation. Confirm blue-sdk bundler addresses intentionally.
 - Keep unit tests colocated as `{module}.test.ts`; put shared unit fixtures in `src/test-helpers/`, which must stay out of published builds. Keep fork tests under `test/` as `*.integration.test.ts`.
 
 ## Continuous Improvement

--- a/packages/evm-simulation/README.md
+++ b/packages/evm-simulation/README.md
@@ -52,6 +52,8 @@ try {
 
 Each chain entry must declare at least one backend — `tenderlyRpc` (primary), `simulateV1Url` (fallback), or both. The type system enforces this.
 
+Custom chains must also register their Morpho deployment with `registerCustomAddresses` in the same active ESM/CJS module graph that runs `simulate`; simulation rejects chains whose bundler retention metadata is unavailable.
+
 ### API surface
 
 All symbols below are re-exported from the package root.

--- a/packages/evm-simulation/package.json
+++ b/packages/evm-simulation/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@morpho-org/blue-sdk": "workspace:^",
-    "@morpho-org/morpho-ts": "workspace:^",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/packages/evm-simulation/src/errors.ts
+++ b/packages/evm-simulation/src/errors.ts
@@ -59,11 +59,11 @@ export class SimulationValidationError extends SimulationPackageError {
   }
 }
 
-/** Chain ID not configured for any simulation method. Not bypassable. */
+/** Chain ID lacks a simulation backend or registered bundler metadata. Not bypassable. */
 export class UnsupportedChainError extends SimulationPackageError {
   readonly code = "UNSUPPORTED_CHAIN";
 
   constructor(public readonly chainId: number) {
-    super(`Chain ${chainId} is not configured for simulation`);
+    super(`Chain ${chainId} is not fully configured for simulation`);
   }
 }

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
@@ -1,4 +1,5 @@
 import {
+  type Address,
   type BlockTag,
   createPublicClient,
   getAddress,
@@ -39,9 +40,10 @@ export async function simulateV1(params: {
   chainId: number;
   transactions: SimulationTransaction[];
   blockNumber?: bigint | BlockTag;
+  wNative?: Address;
   signal?: AbortSignal;
 }): Promise<RawSimulationResult> {
-  const { rpcUrl, transactions, blockNumber, signal } = params;
+  const { rpcUrl, transactions, blockNumber, wNative, signal } = params;
 
   const client = createPublicClient({
     transport: http(rpcUrl, {
@@ -129,7 +131,7 @@ export async function simulateV1(params: {
 
     return {
       calls: rawCalls,
-      assetChanges: toAssetChanges(parseTransfers(rawCalls)),
+      assetChanges: toAssetChanges(parseTransfers(rawCalls, { wNative })),
     };
   } catch (error) {
     if (error instanceof SimulationRevertedError) throw error;

--- a/packages/evm-simulation/src/simulate/backends/tenderly-rpc.test.ts
+++ b/packages/evm-simulation/src/simulate/backends/tenderly-rpc.test.ts
@@ -360,7 +360,7 @@ describe.sequential("simulateTenderlyRpc — single tx", () => {
     expect(tx.value).toBe("0x4d2");
   });
 
-  it("defaults omitted log fields to empty topics and 0x data", async () => {
+  it("rejects incomplete log evidence", async () => {
     const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
       ok: true,
       json: async () =>
@@ -372,17 +372,15 @@ describe.sequential("simulateTenderlyRpc — single tx", () => {
     });
     installFetchMock(fetchMock);
 
-    const result = await simulateTenderlyRpc({
-      config: CONFIG,
-      transactions: [TX1],
-    });
-
-    expect(result.calls[0]!.logs).toEqual([
-      { address: USDC, topics: [], data: "0x" },
-    ]);
+    await expect(
+      simulateTenderlyRpc({
+        config: CONFIG,
+        transactions: [TX1],
+      }),
+    ).rejects.toThrow(ExternalServiceError);
   });
 
-  it("defaults omitted logs array to empty", async () => {
+  it("rejects a successful response without logs", async () => {
     const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
       ok: true,
       json: async () =>
@@ -394,12 +392,12 @@ describe.sequential("simulateTenderlyRpc — single tx", () => {
     });
     installFetchMock(fetchMock);
 
-    const result = await simulateTenderlyRpc({
-      config: CONFIG,
-      transactions: [TX1],
-    });
-
-    expect(result.calls[0]!.logs).toEqual([]);
+    await expect(
+      simulateTenderlyRpc({
+        config: CONFIG,
+        transactions: [TX1],
+      }),
+    ).rejects.toThrow(ExternalServiceError);
   });
 
   it("defaults missing trace output to 0x", async () => {
@@ -410,6 +408,7 @@ describe.sequential("simulateTenderlyRpc — single tx", () => {
           status: true,
           gasUsed: "0x5208",
           logs: [],
+          assetChanges: [],
         }),
     });
     installFetchMock(fetchMock);
@@ -542,6 +541,25 @@ describe.sequential("simulateTenderlyRpc — bundle", () => {
     ).rejects.toThrow(SimulationRevertedError);
   });
 
+  it("preserves a later bundle revert when earlier success evidence is malformed", async () => {
+    const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        envelope([
+          { status: true, gasUsed: "0x5208", logs: [] },
+          { status: false },
+        ]),
+    });
+    installFetchMock(fetchMock);
+
+    await expect(
+      simulateTenderlyRpc({
+        config: CONFIG,
+        transactions: [TX1, TX2],
+      }),
+    ).rejects.toThrow(SimulationRevertedError);
+  });
+
   it("throws ExternalServiceError on non-200 bundle response", async () => {
     const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
       ok: false,
@@ -570,6 +588,18 @@ describe.sequential("simulateTenderlyRpc — errors", () => {
     const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
       ok: true,
       json: async () => envelope(revertResult()),
+    });
+    installFetchMock(fetchMock);
+
+    await expect(
+      simulateTenderlyRpc({ config: CONFIG, transactions: [TX1] }),
+    ).rejects.toThrow(SimulationRevertedError);
+  });
+
+  it("classifies a status=false response as a revert without success fields", async () => {
+    const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+      ok: true,
+      json: async () => envelope({ status: false, gasUsed: "not-hex" }),
     });
     installFetchMock(fetchMock);
 
@@ -771,6 +801,93 @@ describe.sequential("simulateTenderlyRpc — errors", () => {
     await expect(
       simulateTenderlyRpc({ config: CONFIG, transactions: [TX1] }),
     ).rejects.toThrow(ExternalServiceError);
+  });
+
+  it("throws ExternalServiceError when a successful response omits assetChanges", async () => {
+    const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        envelope({
+          status: true,
+          gasUsed: "0x5208",
+          logs: [],
+          trace: [{ output: "0x" }],
+        }),
+    });
+    installFetchMock(fetchMock);
+
+    await expect(
+      simulateTenderlyRpc({ config: CONFIG, transactions: [TX1] }),
+    ).rejects.toThrow(ExternalServiceError);
+  });
+
+  it.each([
+    ["gasUsed", { ...successResult(), gasUsed: `0x${"f".repeat(65)}` }],
+    [
+      "assetChanges.rawAmount",
+      successResult({
+        assetChanges: [
+          assetChange({
+            token: USDC,
+            to: USER,
+            rawAmount: `0x${"f".repeat(65)}` as Hex,
+          }),
+        ],
+      }),
+    ],
+  ])(
+    "throws ExternalServiceError for an oversized %s",
+    async (_field, result) => {
+      const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+        ok: true,
+        json: async () => envelope(result),
+      });
+      installFetchMock(fetchMock);
+
+      await expect(
+        simulateTenderlyRpc({ config: CONFIG, transactions: [TX1] }),
+      ).rejects.toThrow(ExternalServiceError);
+    },
+  );
+
+  it("normalizes mixed-case success addresses", async () => {
+    const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        envelope(
+          successResult({
+            logs: [
+              {
+                raw: {
+                  address: USDC.toLowerCase(),
+                  topics: ["0xaaaa"],
+                  data: "0x",
+                },
+              },
+            ],
+            assetChanges: [
+              assetChange({
+                token: USDC.toLowerCase() as Address,
+                from: USDC.toLowerCase() as Address,
+                to: VAULT,
+                rawAmount: "0x1",
+              }),
+            ],
+          }),
+        ),
+    });
+    installFetchMock(fetchMock);
+
+    const result = await simulateTenderlyRpc({
+      config: CONFIG,
+      transactions: [TX1],
+    });
+
+    expect(result.calls[0]!.logs[0]!.address).toBe(USDC);
+    expect(
+      result.assetChanges.find(({ account }) => account === USDC)?.changes[0]
+        ?.token,
+    ).toBe(USDC);
   });
 
   it("throws ExternalServiceError when a bundle returns an empty array", async () => {

--- a/packages/evm-simulation/src/simulate/backends/tenderly-rpc.ts
+++ b/packages/evm-simulation/src/simulate/backends/tenderly-rpc.ts
@@ -18,7 +18,6 @@ import {
 import type {
   AccountAssetChanges,
   RawCall,
-  RawLog,
   RawSimulationResult,
   SimulationTransaction,
   TenderlyRpcConfig,
@@ -34,10 +33,16 @@ interface TenderlyRpcCall {
   value: Hex;
 }
 
-const addressSchema = z.custom<Address>(
-  (val) => typeof val === "string" && isAddress(val),
-);
+const addressSchema = z
+  .string()
+  .refine((value) => isAddress(value, { strict: false }))
+  .transform((value): Address => getAddress(value.toLowerCase()));
 const hexSchema = z.custom<Hex>((val) => typeof val === "string" && isHex(val));
+const quantitySchema = z.custom<Hex>(
+  (value) =>
+    typeof value === "string" &&
+    /^0x(?:0|[1-9a-fA-F][0-9a-fA-F]{0,63})$/.test(value),
+);
 
 const traceFrameSchema = z
   .object({
@@ -52,11 +57,10 @@ const logSchema = z
     raw: z
       .object({
         address: addressSchema,
-        topics: z.array(hexSchema).optional(),
-        data: hexSchema.optional(),
+        topics: z.array(hexSchema),
+        data: hexSchema,
       })
-      .passthrough()
-      .optional(),
+      .passthrough(),
   })
   .passthrough();
 
@@ -71,23 +75,27 @@ const assetChangeSchema = z
       .passthrough(),
     from: addressSchema.optional(),
     to: addressSchema.optional(),
-    rawAmount: hexSchema,
+    rawAmount: quantitySchema,
   })
   .passthrough();
 
-const simResultSchema = z
+const successResultSchema = z
   .object({
-    status: z.boolean(),
-    gasUsed: hexSchema,
-    logs: z.array(logSchema).optional(),
+    status: z.literal(true),
+    gasUsed: quantitySchema,
+    logs: z.array(logSchema),
     trace: z.array(traceFrameSchema).optional(),
-    assetChanges: z.array(assetChangeSchema).optional(),
+    assetChanges: z.array(assetChangeSchema),
     error: z.string().optional(),
     errorMessage: z.string().optional(),
   })
   .passthrough();
 
-type SimResult = z.infer<typeof simResultSchema>;
+const failureResultSchema = z
+  .object({ status: z.literal(false) })
+  .passthrough();
+
+type SimResult = z.infer<typeof successResultSchema>;
 
 const rpcErrorSchema = z
   .object({
@@ -103,8 +111,8 @@ function rpcEnvelope<T extends z.ZodTypeAny>(result: T) {
     .passthrough();
 }
 
-const singleEnvelope = rpcEnvelope(simResultSchema);
-const bundleEnvelope = rpcEnvelope(z.array(simResultSchema).min(1));
+const singleEnvelope = rpcEnvelope(z.unknown());
+const bundleEnvelope = rpcEnvelope(z.array(z.unknown()).min(1));
 
 /**
  * Simulate one or more transactions via Tenderly's Node Web3 Gateway.
@@ -150,7 +158,9 @@ export async function simulateTenderlyRpc(params: {
         params: [buildCall(firstTx), block, stateOverrides],
         signal,
       });
-      const result = unwrapResult(singleEnvelope.parse(json));
+      const rawResult = unwrapResult(singleEnvelope.parse(json));
+      throwIfReverted(rawResult);
+      const result = successResultSchema.parse(rawResult);
       return {
         calls: [toRawCall(result)],
         assetChanges: toAssetChanges([result]),
@@ -163,7 +173,11 @@ export async function simulateTenderlyRpc(params: {
       params: [transactions.map(buildCall), block, stateOverrides],
       signal,
     });
-    const results = unwrapResult(bundleEnvelope.parse(json));
+    const rawResults = unwrapResult(bundleEnvelope.parse(json));
+    for (const rawResult of rawResults) throwIfReverted(rawResult);
+    const results = rawResults.map((result) =>
+      successResultSchema.parse(result),
+    );
     return {
       calls: results.map(toRawCall),
       assetChanges: toAssetChanges(results),
@@ -241,31 +255,38 @@ function encodeBlock(blockNumber?: bigint | BlockTag): string {
     : blockNumber;
 }
 
-function toRawCall(data: SimResult): RawCall {
-  if (data.status !== true) {
-    // Tenderly RPC surfaces the revert reason on the trace frame; the
-    // top-level fields are checked as a defensive fallback.
-    const traceError = data.trace?.find((f) => f.errorReason || f.error);
-    const message =
-      traceError?.errorReason ||
+function throwIfReverted(result: unknown): void {
+  if (!failureResultSchema.safeParse(result).success) return;
+
+  const details = z
+    .object({
+      trace: z.array(traceFrameSchema).optional(),
+      error: z.string().optional(),
+      errorMessage: z.string().optional(),
+    })
+    .passthrough()
+    .safeParse(result);
+  const traceError = details.success
+    ? details.data.trace?.find((frame) => frame.errorReason || frame.error)
+    : undefined;
+  const message = details.success
+    ? traceError?.errorReason ||
       traceError?.error ||
-      data.errorMessage ||
-      data.error ||
-      "Transaction simulation reverted";
-    throw new SimulationRevertedError(message, data);
-  }
-  const logs: RawLog[] = [];
-  for (const log of data.logs ?? []) {
-    if (log.raw) {
-      logs.push({
-        address: log.raw.address,
-        topics: log.raw.topics ?? [],
-        data: log.raw.data ?? "0x",
-      });
-    }
-  }
+      details.data.errorMessage ||
+      details.data.error ||
+      "Transaction simulation reverted"
+    : "Transaction simulation reverted";
+
+  throw new SimulationRevertedError(message, result);
+}
+
+function toRawCall(data: SimResult): RawCall {
   return {
-    logs,
+    logs: data.logs.map(({ raw }) => ({
+      address: raw.address,
+      topics: raw.topics,
+      data: raw.data,
+    })),
     status: true,
     returnData: data.trace?.[0]?.output ?? "0x",
     gasUsed: BigInt(data.gasUsed),
@@ -280,7 +301,7 @@ function toRawCall(data: SimResult): RawCall {
 function toAssetChanges(results: SimResult[]): AccountAssetChanges[] {
   const entries: AssetChangeEntry[] = [];
   for (const result of results) {
-    for (const change of result.assetChanges ?? []) {
+    for (const change of result.assetChanges) {
       const amount = BigInt(change.rawAmount);
       const token = change.assetInfo.contractAddress
         ? getAddress(change.assetInfo.contractAddress)

--- a/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
@@ -12,10 +12,10 @@ import {
   makeCall,
   padAddress,
 } from "../../test-helpers/index.js";
-import type { RawLog } from "../../types.js";
+import type { RawLog, SimulationLogger } from "../../types.js";
 import {
   DEPOSIT_TOPIC,
-  parseTransfers,
+  parseTransfers as parseRawTransfers,
   TRANSFER_TOPIC,
   WITHDRAWAL_TOPIC,
 } from "./transfers.js";
@@ -25,6 +25,11 @@ const WETH: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const DAI: Address = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const USER: Address = "0x1111111111111111111111111111111111111111";
 const VAULT: Address = "0x2222222222222222222222222222222222222222";
+
+const parseTransfers = (
+  calls: Parameters<typeof parseRawTransfers>[0],
+  logger?: SimulationLogger,
+) => parseRawTransfers(calls, { logger, wNative: WETH });
 
 describe("parseTransfers", () => {
   it("parses a standard ERC20 Transfer", () => {
@@ -195,6 +200,99 @@ describe("parseTransfers", () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.from).toBe(zeroAddress);
     expect(result[0]!.to).toBe(getAddress(USER));
+  });
+
+  it("ignores Deposit events from unregistered tokens", () => {
+    const amount = 1_000n;
+    const logs: RawLog[] = [
+      {
+        address: DAI,
+        topics: [DEPOSIT_TOPIC, padAddress(USER)],
+        data: encodeUint256(amount),
+      },
+    ];
+
+    expect(parseRawTransfers([makeCall(logs)], { wNative: WETH })).toEqual([]);
+  });
+
+  it("ignores wrapped-native events when no token is registered", () => {
+    const amount = 1_000n;
+    const logs: RawLog[] = [
+      {
+        address: WETH,
+        topics: [DEPOSIT_TOPIC, padAddress(USER)],
+        data: encodeUint256(amount),
+      },
+    ];
+
+    expect(parseRawTransfers([makeCall(logs)])).toEqual([]);
+  });
+
+  it("rejects wrapped-native events with extra topics", () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const logs: RawLog[] = [
+      {
+        address: WETH,
+        topics: [DEPOSIT_TOPIC, padAddress(USER), padAddress(VAULT)],
+        data: encodeUint256(1n),
+      },
+      {
+        address: WETH,
+        topics: [WITHDRAWAL_TOPIC, padAddress(USER), padAddress(VAULT)],
+        data: encodeUint256(2n),
+      },
+    ];
+
+    expect(parseTransfers([makeCall(logs)], logger)).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("normalizes mixed-case event data before wrapped-native deduplication", () => {
+    const upperHex = (value: Hex): Hex =>
+      `0x${value.slice(2).toUpperCase()}` as Hex;
+    const amount = BigInt(`0x${"ab".repeat(32)}`);
+    const data = upperHex(encodeUint256(amount));
+    const logs: RawLog[] = [
+      {
+        address: WETH.toLowerCase() as Address,
+        topics: [upperHex(DEPOSIT_TOPIC), upperHex(padAddress(USER))],
+        data,
+      },
+      {
+        address: WETH,
+        topics: [
+          upperHex(TRANSFER_TOPIC),
+          `0x${"0".repeat(64)}` as Hex,
+          padAddress(USER),
+        ],
+        data: data.toLowerCase() as Hex,
+      },
+    ];
+
+    expect(parseTransfers([makeCall(logs)])).toEqual([
+      expect.objectContaining({ token: WETH, amount }),
+    ]);
+  });
+
+  it("rejects non-canonical uint256 data and indexed addresses", () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const signedData = `0x${"0".repeat(62)}-1` as Hex;
+    const nonZeroPadding = `0x${"1".repeat(24)}${USER.slice(2)}` as Hex;
+    const logs: RawLog[] = [
+      {
+        address: USDC,
+        topics: [TRANSFER_TOPIC, padAddress(USER), padAddress(VAULT)],
+        data: signedData,
+      },
+      {
+        address: USDC,
+        topics: [TRANSFER_TOPIC, nonZeroPadding, padAddress(VAULT)],
+        data: encodeUint256(1n),
+      },
+    ];
+
+    expect(parseTransfers([makeCall(logs)], logger)).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 
   it("handles multi-token flows", () => {

--- a/packages/evm-simulation/src/simulate/parsing/transfers.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.ts
@@ -24,9 +24,6 @@ export const WITHDRAWAL_TOPIC =
 export const DEPOSIT_TOPIC =
   "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c";
 
-const TOPIC_HEX_LENGTH = 66; // "0x" + 32 bytes
-const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
-
 /**
  * Parse raw EVM logs into individual Transfer events.
  *
@@ -34,10 +31,10 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  * with the index of the originating call.
  *
  * **Supported event types:** ERC20 `Transfer(from, to, amount)` and WETH9
- * `Deposit(to, amount)` / `Withdrawal(from, amount)`. WETH9 mint/burn Transfer
- * events paired with their Deposit/Withdrawal are deduplicated. ERC721 and
- * ERC1155 transfer events are **not** parsed — consumers with NFT flows will
- * see an incomplete transfer list.
+ * `Deposit(to, amount)` / `Withdrawal(from, amount)` from the registered
+ * wrapped-native token. Its paired mint/burn Transfer events are deduplicated.
+ * ERC721 and ERC1155 transfer events are **not** parsed — consumers with NFT
+ * flows will see an incomplete transfer list.
  *
  * **Native ETH (`eth_simulateV1` + `traceTransfers`).** When the backend runs
  * `eth_simulateV1` with `traceTransfers` enabled, native-ETH moves — including
@@ -48,7 +45,8 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  * backends. Tenderly does not emit these synthetic logs (it derives native ETH
  * separately), so this path is inert there.
  *
- * **WETH9 dedup assumption — canonical atomic emission.** Dedup is scoped to
+ * **WETH9 dedup assumption — canonical atomic emission.** Dedup for the
+ * registered wrapped-native token is scoped to
  * the same tx: a zero-address `Transfer` is suppressed only if its paired
  * `Deposit`/`Withdrawal` appears in the same `calls[txIdx].logs` slice. This
  * is correct for canonical WETH9, which always emits the `Deposit`/
@@ -57,10 +55,9 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  * that splits these emissions across two txs in the same bundle would leave
  * a phantom zero-address `Transfer` in the parsed output, which can be summed
  * by `assertNoBundlerRetention` and produce a false `BlacklistViolationError`.
- * When a zero-address `Transfer` misses same-tx dedup *and* its token has
- * emitted a `Deposit`/`Withdrawal` somewhere else in the bundle (i.e. it
- * looks wnative-shaped), the parser emits a `warn` so the assumption break
- * is observable before it reaches retention. None of `morpho-sdk`'s currently
+ * When its zero-address `Transfer` misses same-tx dedup, the parser emits a
+ * `warn` so the assumption break is observable before it reaches retention.
+ * None of `morpho-sdk`'s currently
  * supported chains require cross-tx dedup; the assumption is rechecked when
  * onboarding a new chain (see `evm-simulation/CLAUDE.md`).
  *
@@ -69,30 +66,38 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  *
  * Output is sorted canonically by token, from, to, amount for determinism.
  * `txIdx` is attached but does not influence sort order.
+ *
+ * @param calls - Per-transaction call results to parse.
+ * @param options - Registered wrapped-native metadata and optional logger.
+ * @returns Canonically sorted transfers with their originating transaction index.
  */
 export function parseTransfers(
   calls: readonly RawCall[],
-  logger?: SimulationLogger,
+  options: {
+    readonly wNative?: Address;
+    readonly logger?: SimulationLogger;
+  } = {},
 ): Transfer[] {
   const transfers: Transfer[] = [];
-
-  // Tokens that emit `Deposit` or `Withdrawal` somewhere in the bundle look
-  // wnative-shaped. If a zero-address `Transfer` for one of these tokens
-  // misses same-tx dedup, the contract is likely emitting non-canonically
-  // (split across txs) and a phantom transfer would leak into retention.
-  const wnativeShapedTokens = collectWnativeShapedTokens(calls);
+  const { logger } = options;
+  const wNative = options.wNative?.toLowerCase();
 
   for (let txIdx = 0; txIdx < calls.length; txIdx++) {
     const logs = calls[txIdx]!.logs;
     for (const log of logs) {
       try {
-        const topic0 = log.topics[0];
+        const topic0 = log.topics[0]?.toLowerCase();
         if (topic0 === undefined) continue;
 
         switch (topic0) {
           case WITHDRAWAL_TOPIC: {
+            if (log.address.toLowerCase() !== wNative) continue;
             const fromTopic = log.topics[1];
-            if (!isTopicHex(fromTopic) || !isUint256Hex(log.data)) {
+            if (
+              log.topics.length !== 2 ||
+              !isTopicHex(fromTopic) ||
+              !isUint256Hex(log.data)
+            ) {
               warnMalformed(
                 logger,
                 log,
@@ -101,8 +106,8 @@ export function parseTransfers(
               continue;
             }
             transfers.push({
-              token: getAddress(log.address),
-              from: getAddress(`0x${fromTopic.slice(26)}`),
+              token: getAddress(log.address.toLowerCase()),
+              from: getAddress(`0x${fromTopic.slice(26).toLowerCase()}`),
               to: zeroAddress,
               amount: BigInt(log.data),
               txIdx,
@@ -111,8 +116,13 @@ export function parseTransfers(
           }
 
           case DEPOSIT_TOPIC: {
+            if (log.address.toLowerCase() !== wNative) continue;
             const toTopic = log.topics[1];
-            if (!isTopicHex(toTopic) || !isUint256Hex(log.data)) {
+            if (
+              log.topics.length !== 2 ||
+              !isTopicHex(toTopic) ||
+              !isUint256Hex(log.data)
+            ) {
               warnMalformed(
                 logger,
                 log,
@@ -121,9 +131,9 @@ export function parseTransfers(
               continue;
             }
             transfers.push({
-              token: getAddress(log.address),
+              token: getAddress(log.address.toLowerCase()),
               from: zeroAddress,
-              to: getAddress(`0x${toTopic.slice(26)}`),
+              to: getAddress(`0x${toTopic.slice(26).toLowerCase()}`),
               amount: BigInt(log.data),
               txIdx,
             });
@@ -153,42 +163,44 @@ export function parseTransfers(
 
             // WETH9 unwrap dedup: Transfer to zero paired with a Withdrawal of
             // equal amount in the SAME tx.
-            if (toTopic === zeroHash) {
+            if (
+              log.address.toLowerCase() === wNative &&
+              toTopic.toLowerCase() === zeroHash
+            ) {
               const paired = logs.some(
                 (other) =>
-                  other.topics[0] === WITHDRAWAL_TOPIC &&
-                  other.address === log.address &&
-                  other.data === log.data &&
+                  other.topics[0]?.toLowerCase() === WITHDRAWAL_TOPIC &&
+                  other.address.toLowerCase() === log.address.toLowerCase() &&
+                  other.data.toLowerCase() === log.data.toLowerCase() &&
                   other.topics.length === 2 &&
-                  other.topics[1] === fromTopic,
+                  other.topics[1]?.toLowerCase() === fromTopic.toLowerCase(),
               );
               if (paired) continue;
-              if (wnativeShapedTokens.has(log.address.toLowerCase())) {
-                warnNonCanonicalWnative(logger, log, "burn", txIdx);
-              }
+              warnNonCanonicalWnative(logger, log, "burn", txIdx);
             }
 
             // WETH9 wrap dedup: Transfer from zero paired with a Deposit of
             // equal amount in the SAME tx.
-            if (fromTopic === zeroHash) {
+            if (
+              log.address.toLowerCase() === wNative &&
+              fromTopic.toLowerCase() === zeroHash
+            ) {
               const paired = logs.some(
                 (other) =>
-                  other.topics[0] === DEPOSIT_TOPIC &&
-                  other.address === log.address &&
-                  other.data === log.data &&
+                  other.topics[0]?.toLowerCase() === DEPOSIT_TOPIC &&
+                  other.address.toLowerCase() === log.address.toLowerCase() &&
+                  other.data.toLowerCase() === log.data.toLowerCase() &&
                   other.topics.length === 2 &&
-                  other.topics[1] === toTopic,
+                  other.topics[1]?.toLowerCase() === toTopic.toLowerCase(),
               );
               if (paired) continue;
-              if (wnativeShapedTokens.has(log.address.toLowerCase())) {
-                warnNonCanonicalWnative(logger, log, "mint", txIdx);
-              }
+              warnNonCanonicalWnative(logger, log, "mint", txIdx);
             }
 
             transfers.push({
               token: normalizeTransferToken(log.address),
-              from: getAddress(`0x${fromTopic.slice(26)}`),
-              to: getAddress(`0x${toTopic.slice(26)}`),
+              from: getAddress(`0x${fromTopic.slice(26).toLowerCase()}`),
+              to: getAddress(`0x${toTopic.slice(26).toLowerCase()}`),
               amount: BigInt(log.data),
               txIdx,
             });
@@ -224,15 +236,15 @@ export function parseTransfers(
 function normalizeTransferToken(address: Hex): Address {
   return address.toLowerCase() === ethAddress
     ? ethAddress
-    : getAddress(address);
+    : getAddress(address.toLowerCase());
 }
 
 function isTopicHex(value: Hex | undefined): value is Hex {
-  return typeof value === "string" && value.length === TOPIC_HEX_LENGTH;
+  return typeof value === "string" && /^0x0{24}[0-9a-fA-F]{40}$/.test(value);
 }
 
 function isUint256Hex(value: Hex | undefined): value is Hex {
-  return typeof value === "string" && value.length === UINT256_HEX_LENGTH;
+  return typeof value === "string" && /^0x[0-9a-fA-F]{64}$/.test(value);
 }
 
 // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
@@ -246,26 +258,6 @@ function warnMalformed(
     topics: log.topics,
     reason,
   });
-}
-
-/**
- * Collect token addresses (lowercased) that emit `Deposit` or `Withdrawal`
- * anywhere in the bundle. Used to detect when a zero-address `Transfer` that
- * misses same-tx dedup is on a wnative-shaped contract — a strong signal
- * that the contract is emitting non-canonically and a phantom transfer is
- * about to leak into bundler retention.
- */
-function collectWnativeShapedTokens(calls: readonly RawCall[]): Set<string> {
-  const set = new Set<string>();
-  for (const c of calls) {
-    for (const l of c.logs) {
-      const t0 = l.topics[0];
-      if (t0 === WITHDRAWAL_TOPIC || t0 === DEPOSIT_TOPIC) {
-        set.add(l.address.toLowerCase());
-      }
-    }
-  }
-  return set;
 }
 
 // biome-ignore lint/complexity/useMaxParams: structured warn with full context

--- a/packages/evm-simulation/src/simulate/pipeline/bundler-retention.test.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/bundler-retention.test.ts
@@ -24,10 +24,16 @@ vi.mock("@morpho-org/blue-sdk", async (importOriginal) => {
   };
 });
 
-import { BlacklistViolationError } from "../../errors.js";
+import {
+  BlacklistViolationError,
+  UnsupportedChainError,
+} from "../../errors.js";
 import { makeCall, makeTransferLog } from "../../test-helpers/index.js";
 import { parseTransfers } from "../parsing/transfers.js";
-import { assertNoBundlerRetention } from "./bundler-retention.js";
+import {
+  assertNoBundlerRetention,
+  resolveBundlerRetentionMetadata,
+} from "./bundler-retention.js";
 
 const USER: Address = "0x1111111111111111111111111111111111111111";
 const VAULT: Address = "0x2222222222222222222222222222222222222222";
@@ -35,6 +41,7 @@ const DAI: Address = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const USDC: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 // Pulled from blue-sdk so tests exercise the real Set membership check.
 const BUNDLER = getAddress(getChainAddresses(1).bundler3.bundler3) as Address;
+const metadata = resolveBundlerRetentionMetadata(1);
 
 // Synthetic chainIds owned by exactly one case each — see chainAddressOverrides.
 const NO_BUNDLER_CHAIN_ID = 1_000_001;
@@ -61,7 +68,7 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
@@ -72,73 +79,47 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
   it("does not throw for empty transfers", () => {
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers: [], assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers: [], assetChanges: [] }),
     ).not.toThrow();
   });
 
-  it("does not throw for unsupported chain (no blacklist)", () => {
-    const transfers = parseTransfers([
-      makeCall([
-        makeTransferLog({
-          token: USDC,
-          from: USER,
-          to: VAULT,
-          amount: 1000000n,
-        }),
-      ]),
-    ]);
-    expect(() =>
-      assertNoBundlerRetention({
-        chainId: 999999,
-        transfers,
-        assetChanges: [],
-      }),
-    ).not.toThrow();
+  it("rejects unsupported chains", () => {
+    expect(() => resolveBundlerRetentionMetadata(999999)).toThrow(
+      UnsupportedChainError,
+    );
   });
 
-  it("warns and skips when blue-sdk knows the chain but has no bundler3 config", () => {
-    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-
-    expect(() =>
-      assertNoBundlerRetention({
-        chainId: NO_BUNDLER_CHAIN_ID,
-        transfers: [],
-        assetChanges: [],
-        logger,
-      }),
-    ).not.toThrow();
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Chain known to blue-sdk but has no bundler3 config, retention check skipped",
-      { chainId: NO_BUNDLER_CHAIN_ID },
+  it("rejects known chains without bundler3 metadata", () => {
+    expect(() => resolveBundlerRetentionMetadata(NO_BUNDLER_CHAIN_ID)).toThrow(
+      UnsupportedChainError,
     );
   });
 
   it("propagates unexpected SDK errors instead of swallowing them", () => {
-    const transfers = parseTransfers([
-      makeCall([
-        makeTransferLog({
-          token: USDC,
-          from: USER,
-          to: VAULT,
-          amount: 1000000n,
-        }),
-      ]),
-    ]);
+    expect(() => resolveBundlerRetentionMetadata(SDK_ERROR_CHAIN_ID)).toThrow(
+      "unexpected SDK bug",
+    );
+  });
 
+  it("matches bundler addresses case-insensitively", () => {
     expect(() =>
       assertNoBundlerRetention({
-        chainId: SDK_ERROR_CHAIN_ID,
-        transfers,
-        assetChanges: [],
+        metadata,
+        transfers: [],
+        assetChanges: [
+          {
+            account: BUNDLER.toLowerCase() as Address,
+            changes: [{ token: ethAddress, diff: 1_000n }],
+          },
+        ],
       }),
-    ).toThrow("unexpected SDK bug");
+    ).toThrow(BlacklistViolationError);
   });
 
   it("does not throw when bundler passes tokens through (net zero)", () => {
@@ -159,7 +140,7 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
@@ -175,7 +156,7 @@ describe("assertNoBundlerRetention", () => {
       ]),
     ]);
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] }),
     ).toThrow(BlacklistViolationError);
   });
 
@@ -198,7 +179,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
     // Net retention: 500000 > DUST_THRESHOLD (100)
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] }),
     ).toThrow(BlacklistViolationError);
   });
 
@@ -216,7 +197,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
     // Net retention: 50 <= DUST_THRESHOLD (100)
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] }),
     ).not.toThrow();
   });
 
@@ -238,7 +219,7 @@ describe("assertNoBundlerRetention", () => {
 
     expect(() =>
       assertNoBundlerRetention({
-        chainId: 1,
+        metadata,
         transfers,
         assetChanges: [],
         logger,
@@ -285,7 +266,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
 
     try {
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] });
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] });
       expect.fail("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(BlacklistViolationError);
@@ -305,7 +286,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
 
     try {
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] });
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] });
       expect.fail("should have thrown");
     } catch (err) {
       const changes = (err as BlacklistViolationError).assetChanges ?? [];
@@ -329,7 +310,7 @@ describe("assertNoBundlerRetention", () => {
     // Before the fix this resolved instead of throwing (finding 1440).
     expect(() =>
       assertNoBundlerRetention({
-        chainId: 1,
+        metadata,
         transfers: [],
         assetChanges: [
           { account: BUNDLER, changes: [{ token: ethAddress, diff: ONE_ETH }] },
@@ -346,7 +327,7 @@ describe("assertNoBundlerRetention", () => {
     ];
     try {
       assertNoBundlerRetention({
-        chainId: 1,
+        metadata,
         transfers,
         assetChanges: [
           { account: BUNDLER, changes: [{ token: ethAddress, diff: ONE_ETH }] },
@@ -370,14 +351,14 @@ describe("assertNoBundlerRetention", () => {
       { token: ethAddress, from: USER, to: BUNDLER, amount: ONE_ETH, txIdx: 0 },
     ];
     expect(() =>
-      assertNoBundlerRetention({ chainId: 1, transfers, assetChanges: [] }),
+      assertNoBundlerRetention({ metadata, transfers, assetChanges: [] }),
     ).toThrow(BlacklistViolationError);
   });
 
   it("behavior: does not throw when native ETH passes through the bundler (net zero)", () => {
     expect(() =>
       assertNoBundlerRetention({
-        chainId: 1,
+        metadata,
         transfers: [],
         assetChanges: [
           { account: BUNDLER, changes: [{ token: ethAddress, diff: 0n }] },
@@ -389,7 +370,7 @@ describe("assertNoBundlerRetention", () => {
   it("behavior: does not throw for native ETH retention below dust threshold", () => {
     expect(() =>
       assertNoBundlerRetention({
-        chainId: 1,
+        metadata,
         transfers: [],
         assetChanges: [
           { account: BUNDLER, changes: [{ token: ethAddress, diff: 50n }] },
@@ -401,7 +382,7 @@ describe("assertNoBundlerRetention", () => {
   it("behavior: ignores native ETH assetChanges for non-bundler accounts", () => {
     expect(() =>
       assertNoBundlerRetention({
-        chainId: 1,
+        metadata,
         transfers: [],
         assetChanges: [
           { account: VAULT, changes: [{ token: ethAddress, diff: ONE_ETH }] },
@@ -424,7 +405,7 @@ describe("assertNoBundlerRetention", () => {
     ]);
     try {
       assertNoBundlerRetention({
-        chainId: 1,
+        metadata,
         transfers,
         assetChanges: [
           { account: BUNDLER, changes: [{ token: ethAddress, diff: ONE_ETH }] },

--- a/packages/evm-simulation/src/simulate/pipeline/bundler-retention.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/bundler-retention.ts
@@ -2,9 +2,11 @@ import {
   getChainAddresses,
   UnsupportedChainIdError,
 } from "@morpho-org/blue-sdk";
-import { isDefined } from "@morpho-org/morpho-ts";
 import { type Address, ethAddress, getAddress } from "viem";
-import { BlacklistViolationError } from "../../errors.js";
+import {
+  BlacklistViolationError,
+  UnsupportedChainError,
+} from "../../errors.js";
 import type {
   AccountAssetChanges,
   SimulationLogger,
@@ -28,43 +30,54 @@ interface BundlerEntry {
   netChange: bigint;
 }
 
-function getBundlerAddresses(
+interface BundlerRetentionMetadata {
+  readonly bundlerAddresses: ReadonlySet<Address>;
+  readonly wNative?: Address;
+}
+
+/**
+ * Resolves the chain metadata required to enforce bundler retention.
+ *
+ * @param chainId - Chain whose registered bundler addresses are required.
+ * @returns One immutable metadata snapshot for parsing and retention checks.
+ * @throws {UnsupportedChainError} when the active registry has no bundler metadata for the chain.
+ * @internal
+ */
+export function resolveBundlerRetentionMetadata(
   chainId: number,
-  logger?: SimulationLogger,
-): Set<Address> {
+): BundlerRetentionMetadata {
   try {
     const addresses = getChainAddresses(chainId);
     if (!addresses.bundler3) {
-      // blue-sdk knows the chain but didn't catalog a bundler3 for it.
-      // Treat the same as UnsupportedChainIdError — retention check skipped.
-      logger?.warn(
-        "Chain known to blue-sdk but has no bundler3 config, retention check skipped",
-        {
-          chainId,
-        },
-      );
-      return new Set();
+      throw new UnsupportedChainError(chainId);
     }
-    return new Set(
+
+    const bundlerAddresses = new Set(
       Object.values(addresses.bundler3)
-        .filter(isDefined)
-        .map((addr) => getAddress(addr)),
+        .filter((address) => address !== undefined)
+        .map((address) => getAddress(address.toLowerCase())),
     );
+    if (bundlerAddresses.size === 0) {
+      throw new UnsupportedChainError(chainId);
+    }
+
+    return {
+      bundlerAddresses,
+      wNative:
+        addresses.wNative == null
+          ? undefined
+          : getAddress(addresses.wNative.toLowerCase()),
+    };
   } catch (error) {
     if (error instanceof UnsupportedChainIdError) {
-      // Loud warn: this disables a "never bypassable" check for the chain.
-      // Consumers relying on the guarantee must handle this signal.
-      logger?.warn("Chain not supported by blue-sdk, retention check skipped", {
-        chainId,
-      });
-      return new Set();
+      throw new UnsupportedChainError(chainId);
     }
     throw error;
   }
 }
 
 interface AssertNoBundlerRetentionParams {
-  chainId: number;
+  metadata: BundlerRetentionMetadata;
   transfers: Transfer[];
   assetChanges: readonly AccountAssetChanges[];
   logger?: SimulationLogger;
@@ -99,9 +112,8 @@ interface AssertNoBundlerRetentionParams {
 export function assertNoBundlerRetention(
   params: AssertNoBundlerRetentionParams,
 ): void {
-  const { chainId, transfers, assetChanges, logger } = params;
-  const bundlerAddresses = getBundlerAddresses(chainId, logger);
-  if (bundlerAddresses.size === 0) return;
+  const { metadata, transfers, assetChanges, logger } = params;
+  const { bundlerAddresses } = metadata;
 
   // Map keyed by (bundler, token) → structured entry. Avoids string parse-back.
   const flow = new Map<string, BundlerEntry>();
@@ -126,11 +138,12 @@ export function assertNoBundlerRetention(
   // does not re-add the same native move on `eth_simulateV1`.
   const nativeFromAssetChanges = new Set<string>();
   for (const { account, changes } of assetChanges) {
-    if (!bundlerAddresses.has(account)) continue;
+    const normalizedAccount = getAddress(account.toLowerCase());
+    if (!bundlerAddresses.has(normalizedAccount)) continue;
     for (const change of changes) {
-      if (change.token !== ethAddress) continue;
-      recordFlow(account, ethAddress, change.diff);
-      nativeFromAssetChanges.add(account.toLowerCase());
+      if (change.token.toLowerCase() !== ethAddress) continue;
+      recordFlow(normalizedAccount, ethAddress, change.diff);
+      nativeFromAssetChanges.add(normalizedAccount.toLowerCase());
     }
   }
 
@@ -139,12 +152,15 @@ export function assertNoBundlerRetention(
   // is absent from `nativeFromAssetChanges`, so native is never summed on top
   // of the `assetChanges` value already recorded for that address.
   const usesAssetChangeNative = (t: Transfer, addr: Address): boolean =>
-    t.token === ethAddress && nativeFromAssetChanges.has(addr.toLowerCase());
+    t.token.toLowerCase() === ethAddress &&
+    nativeFromAssetChanges.has(addr.toLowerCase());
   for (const t of transfers) {
-    if (bundlerAddresses.has(t.to) && !usesAssetChangeNative(t, t.to))
-      recordFlow(t.to, t.token, t.amount);
-    if (bundlerAddresses.has(t.from) && !usesAssetChangeNative(t, t.from))
-      recordFlow(t.from, t.token, -t.amount);
+    const to = getAddress(t.to.toLowerCase());
+    const from = getAddress(t.from.toLowerCase());
+    if (bundlerAddresses.has(to) && !usesAssetChangeNative(t, to))
+      recordFlow(to, t.token, t.amount);
+    if (bundlerAddresses.has(from) && !usesAssetChangeNative(t, from))
+      recordFlow(from, t.token, -t.amount);
   }
 
   const entries = [...flow.values()];

--- a/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
@@ -1,4 +1,4 @@
-import type { BlockTag } from "viem";
+import type { Address, BlockTag } from "viem";
 import { ExternalServiceError, UnsupportedChainError } from "../../errors.js";
 import type {
   RawSimulationResult,
@@ -43,8 +43,9 @@ export async function executeSimulation(params: {
   chainId: number;
   transactions: SimulationTransaction[];
   blockNumber?: bigint | BlockTag;
+  wNative?: Address;
 }): Promise<RawSimulationResult> {
-  const { config, chainId, transactions, blockNumber } = params;
+  const { config, chainId, transactions, blockNumber, wNative } = params;
   const chain = resolveChain(config, chainId);
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
@@ -80,6 +81,7 @@ export async function executeSimulation(params: {
         chainId,
         transactions,
         blockNumber,
+        wNative,
         signal: AbortSignal.timeout(fallbackBudget),
       });
     }
@@ -95,6 +97,7 @@ export async function executeSimulation(params: {
     chainId,
     transactions,
     blockNumber,
+    wNative,
     signal: AbortSignal.timeout(timeoutMs),
   });
 }

--- a/packages/evm-simulation/src/simulate/pipeline/index.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/index.ts
@@ -1,4 +1,7 @@
 export { buildSimulationTxs } from "./build-simulation-txs.js";
-export { assertNoBundlerRetention } from "./bundler-retention.js";
+export {
+  assertNoBundlerRetention,
+  resolveBundlerRetentionMetadata,
+} from "./bundler-retention.js";
 export { executeSimulation } from "./execute-simulation.js";
 export { validateInput } from "./validate-input.js";

--- a/packages/evm-simulation/src/simulate/simulate.test.ts
+++ b/packages/evm-simulation/src/simulate/simulate.test.ts
@@ -8,7 +8,11 @@ import {
   SimulationValidationError,
   UnsupportedChainError,
 } from "../errors.js";
-import { makeTransferLog } from "../test-helpers/index.js";
+import {
+  encodeUint256,
+  makeTransferLog,
+  padAddress,
+} from "../test-helpers/index.js";
 import type {
   AccountAssetChanges,
   RawLog,
@@ -19,6 +23,7 @@ import type {
 } from "../types.js";
 import type { simulateV1 } from "./backends/eth-simulate-v1.js";
 import type { simulateTenderlyRpc } from "./backends/tenderly-rpc.js";
+import { WITHDRAWAL_TOPIC } from "./parsing/transfers.js";
 import { simulate } from "./simulate.js";
 
 const mockTenderlyRpc = vi.fn<typeof simulateTenderlyRpc>();
@@ -228,6 +233,24 @@ describe.sequential("simulate — success", () => {
     );
   });
 
+  it("does not let lookalike Withdrawal logs cancel bundler retention", async () => {
+    const bundler = getChainAddresses(1).bundler3.bundler3;
+    const amount = 1_000_000n;
+    const logs: RawLog[] = [
+      makeTransferLog({ token: USDC, from: USER, to: bundler, amount }),
+      {
+        address: USDC,
+        topics: [WITHDRAWAL_TOPIC, padAddress(bundler)],
+        data: encodeUint256(amount),
+      },
+    ];
+    mockTenderlyRpc.mockResolvedValueOnce(makeSuccessResult(logs));
+
+    await expect(simulate(makeConfig(), makeParams())).rejects.toThrow(
+      BlacklistViolationError,
+    );
+  });
+
   it("throws BlacklistViolationError end-to-end when Tenderly reports native ETH retention via assetChanges only (finding 1440)", async () => {
     // Tenderly derives native ETH into assetChanges and emits no transfer log.
     // With logs empty, only assetChanges carries the retained ETH — the guard
@@ -398,7 +421,9 @@ describe.sequential("simulate — backend fallback", () => {
     const result = await simulate(makeConfig(), makeParams());
 
     expect(result.transfers).toHaveLength(1);
-    expect(mockSimulateV1).toHaveBeenCalled();
+    expect(mockSimulateV1).toHaveBeenCalledWith(
+      expect.objectContaining({ wNative: getChainAddresses(1).wNative }),
+    );
   });
 
   it("falls back successfully when Tenderly times out within budget", async () => {
@@ -470,6 +495,24 @@ describe.sequential("simulate — validation", () => {
     await expect(
       simulate(makeConfig(), makeParams({ chainId: 999999 })),
     ).rejects.toThrow(UnsupportedChainError);
+  });
+
+  it("rejects configured chains without registered retention metadata before execution", async () => {
+    const chainId = 999999;
+
+    await expect(
+      simulate(
+        {
+          chains: new Map([
+            [chainId, { simulateV1Url: "http://unregistered.local" }],
+          ]),
+        },
+        makeParams({ chainId }),
+      ),
+    ).rejects.toThrow(UnsupportedChainError);
+
+    expect(mockTenderlyRpc).not.toHaveBeenCalled();
+    expect(mockSimulateV1).not.toHaveBeenCalled();
   });
 
   it("throws SimulationValidationError for zero-address token in signature auth", async () => {

--- a/packages/evm-simulation/src/simulate/simulate.ts
+++ b/packages/evm-simulation/src/simulate/simulate.ts
@@ -10,6 +10,7 @@ import {
   assertNoBundlerRetention,
   buildSimulationTxs,
   executeSimulation,
+  resolveBundlerRetentionMetadata,
   validateInput,
 } from "./pipeline/index.js";
 
@@ -42,7 +43,7 @@ import {
  * @param params.blockNumber - Optional pinned block number or `BlockTag`. Defaults to `latest`.
  * @throws {SimulationValidationError} for invalid input (mixed senders, bad addresses,
  *   empty transactions, malformed authorizations).
- * @throws {UnsupportedChainError} when the chain is not configured for any backend.
+ * @throws {UnsupportedChainError} when the chain lacks a backend or registered bundler metadata.
  * @throws {SimulationRevertedError} when the bundle reverts on either backend.
  * @throws {BlacklistViolationError} when the simulation leaves value retained by
  *   a `bundler3` address beyond the dust threshold.
@@ -79,6 +80,7 @@ export async function simulate(
   params: SimulateParams,
 ): Promise<SimulationResult> {
   validateInput(params);
+  const retentionMetadata = resolveBundlerRetentionMetadata(params.chainId);
 
   const simulationTxs = buildSimulationTxs(params);
   const result = await executeSimulation({
@@ -86,6 +88,7 @@ export async function simulate(
     chainId: params.chainId,
     transactions: simulationTxs,
     blockNumber: params.blockNumber,
+    wNative: retentionMetadata.wNative,
   });
   if (result.calls.length !== simulationTxs.length) {
     throw new ExternalServiceError(
@@ -93,10 +96,13 @@ export async function simulate(
     );
   }
 
-  const transfers = parseTransfers(result.calls, config.logger);
+  const transfers = parseTransfers(result.calls, {
+    wNative: retentionMetadata.wNative,
+    logger: config.logger,
+  });
 
   assertNoBundlerRetention({
-    chainId: params.chainId,
+    metadata: retentionMetadata,
     transfers,
     assetChanges: result.assetChanges,
     logger: config.logger,

--- a/packages/evm-simulation/src/types.ts
+++ b/packages/evm-simulation/src/types.ts
@@ -34,7 +34,9 @@ export type ChainSimulationConfig =
  *
  * Every chain entry must declare at least one backend (Tenderly RPC primary,
  * `eth_simulateV1` fallback, or both). Calling `simulate` for a `chainId`
- * missing from `chains` throws `UnsupportedChainError`.
+ * missing from `chains` throws `UnsupportedChainError`. Custom Morpho chains
+ * must also be registered through `registerCustomAddresses` in the same active
+ * module graph before simulation.
  */
 export interface SimulationConfig {
   /** Per-chain simulation capabilities. */

--- a/packages/evm-simulation/test/simulate/backends/eth-simulate-v1.integration.test.ts
+++ b/packages/evm-simulation/test/simulate/backends/eth-simulate-v1.integration.test.ts
@@ -103,6 +103,7 @@ describe.sequential("simulateV1 — assetChanges on a mainnet fork", () => {
     const result = await simulateV1({
       rpcUrl: client.transport.url!,
       chainId: mainnet.id,
+      wNative: WETH,
       transactions: [
         {
           from: client.account.address,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
       '@morpho-org/blue-sdk':
         specifier: workspace:^
         version: link:../blue-sdk
-      '@morpho-org/morpho-ts':
-        specifier: workspace:^
-        version: link:../morpho-ts
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## What

- [SDKS-5](https://app.notion.com/3cfd69939e6d811e8511e36195e83c0b) requires registered Bundler retention metadata before backend execution. **Example:** A Next.js UI registers a custom L2 in its ESM bundle while a CommonJS simulation worker loads another registry instance; the worker otherwise approves a route that leaves USDC in Bundler3.
- [SDKS-41](https://app.notion.com/3cfd69939e6d8136a9e0d95895b41f1a) rejects oversized Tenderly asset-change amounts instead of truncating them to uint256. **Example:** A gateway returns a 65-hex-digit outbound amount that cancels a real Bundler3 inflow in net accounting, so the frontend enables Submit while funds remain stranded.
- [SDKS-49](https://app.notion.com/3cfd69939e6d81388750fca2a0723e10) preserves execution reverts instead of reclassifying them as fallback-eligible service failures. **Example:** Tenderly reports a slippage revert without optional success fields; a fallback at a lagging block succeeds and the UI sends a transaction guaranteed to revert and burn gas.
- [SDKS-73](https://app.notion.com/3cfd69939e6d8187a7d7c19f5fe8e3c6) accepts only canonical uint256 event data. **Example:** A malformed RPC proxy returns 66-character negative decimal log data; length-only parsing treats it as an outflow that cancels real retained tokens.
- [SDKS-76](https://app.notion.com/3cfd69939e6d8198a5bad01b47ce860f) accepts only canonical indexed address topics. **Example:** A token emits a forged outbound Transfer topic with nonzero padding but a Bundler3 address suffix; tail slicing aliases it to Bundler3 and cancels a real inflow.
- [SDKS-80](https://app.notion.com/3cfd69939e6d81699216d5fcd6a19b5e) fails closed when the configured chain has no registered Bundler retention metadata. **Example:** A wallet adds a new L2 RPC but omits deployment registration; simulation otherwise returns green when its route strands funds in that chain's Bundler3.
- [SDKS-111](https://app.notion.com/3cfd69939e6d81fb862cce7e3daa2688) normalizes address and event-signature case before comparisons. **Example:** An RPC proxy uppercases valid hex topics; transfers into Bundler3 disappear from accounting and a retaining route looks safe.
- [SDKS-120](https://app.notion.com/3cfd69939e6d81ceb9fad848fb858268) requires successful Tenderly responses to include asset-change evidence. **Example:** Tenderly returns `status: true` but omits `assetChanges`; retained native ETH emits no ERC-20 log, so a checkout UI incorrectly enables execution.
- [SDKS-147](https://app.notion.com/3cfd69939e6d819c9d71dbf3120d1d1d) recognizes Deposit and Withdrawal events only from the registered wrapped-native token, and ignores those events on registered chains without one. **Example:** A malicious token emits a WETH-shaped Withdrawal beside a real transfer of itself into Bundler3; the fake outflow otherwise nets retention to zero while its balance remains.

## Why

Incomplete registry state, malformed backend evidence, and lookalike token logs must fail closed rather than disable or cancel retained-value detection.
