### PR TITLE
fix(evm-simulation): scope wrapped-native events to registry

### DIFF
--- a/.agents/pr-review-engine/agents/style-conventions.md
+++ b/.agents/pr-review-engine/agents/style-conventions.md
@@ -22,6 +22,7 @@ Per AGENTS.md §8 — mechanical style (Biome enforces what it can; this persona
 - A relative import missing the `.js` suffix (NodeNext) — flag when it would survive Biome but break NodeNext resolution. Architectural impact at the boundary is `module-api-architecture`'s concern; this persona catches the mechanical compliance.
 - A runtime import where `import type { ... }` would do — costs bundle weight, no runtime gain.
 - A local re-declaration of an SDK type (`Address`, `MarketId`, `ChainId`, `BigIntish`) instead of reusing the exported one.
+- A hand-rolled equivalent of a semantic helper exposed by a direct dependency: use viem's `isAddressEqual` for EVM address equality, and use `_try(accessor, ExpectedError)` for optional typed lookups. Require explicit expected errors and preserve the distinction between a caught failure and a successful `undefined` result. Lowercasing remains valid when normalization itself—not equality—is the goal, such as normalized keys or deterministic output.
 - An edit to a generated output (`src/api/sdk.ts`, anything under `lib/`) — change the generated **input** (`graphql/*.gql`) instead.
 
 Per AGENTS.md §7 — changeset relevance (the policy lives in §7; this persona checks the diff matches):
@@ -35,7 +36,7 @@ Per AGENTS.md §7 — changeset relevance (the policy lives in §7; this persona
 ## Severity guidance
 
 - **High** — missing changeset on a behavior-affecting source change in a published package, a missing patch bump for a maintained direct runtime dependent that should publish against the bumped dependency, or a package bump whose downstream maintained internal peer ranges were not updated when required (CI release will undercount, integrators get a surprise).
-- **Medium** — Biome violation surviving `pnpm lint`, missing `.js` suffix, runtime import where type-only would do.
+- **Medium** — Biome violation surviving `pnpm lint`, missing `.js` suffix, runtime import where type-only would do, hand-rolled equivalent of an available semantic helper.
 - **Low** — local re-declaration of an SDK type, JSDoc-only diff without a patch changeset, unnecessary changeset.
 
 ## Out-of-scope reminders (for the sub-agent)

--- a/.changeset/filter-wrapped-native-events.md
+++ b/.changeset/filter-wrapped-native-events.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/evm-simulation": patch
+---
+
+On chains with registered wrapped-native metadata, only interpret WETH9 `Deposit` and `Withdrawal` logs emitted by that token.

--- a/.changeset/filter-wrapped-native-events.md
+++ b/.changeset/filter-wrapped-native-events.md
@@ -2,4 +2,4 @@
 "@morpho-org/evm-simulation": patch
 ---
 
-On chains with registered wrapped-native metadata, only interpret WETH9 `Deposit` and `Withdrawal` logs emitted by that token.
+Use chain registry metadata when parsing WETH9 `Deposit` and `Withdrawal` logs: accept only the registered wrapped-native token, reject them on known tokenless chains, and retain legacy signature-based parsing on unknown custom chains.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ A scannable list of patterns reviewers reject. Most are review-only today (per t
 - Biome owns style: 2-space indent, organized imports, no unused imports or variables.
 - NodeNext module resolution; relative imports include `.js` (`export * from "./market/index.js"`).
 - Type-only imports where possible (`import type { Address } from "viem"`).
+- Reuse semantic helpers exposed by direct dependencies instead of hand-rolling equivalents. When available, use viem's `isAddressEqual` for EVM address equality, and use `_try(accessor, ExpectedError)` for optional typed lookups. Always name the expected errors so unrelated failures propagate, and do not pass an accessor that can legitimately return `undefined` unless successful absence is explicitly tagged (for example with `null`). Lowercasing remains valid when normalization itself—not equality—is the goal, such as normalized map/set keys or deterministic output.
 - Generated code: change generated inputs (`graphql/*.gql`), never edit generated outputs (`src/api/sdk.ts`). Never edit `lib/`.
 - One concern per PR. Tests, JSDoc, and any required semver-relevant changeset land with the change — not as a follow-up.
 

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.test.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.test.ts
@@ -12,8 +12,13 @@ import {
   SimulationRevertedError,
   SimulationValidationError,
 } from "../../errors.js";
-import { makeTransferLog } from "../../test-helpers/index.js";
+import {
+  encodeUint256,
+  makeTransferLog,
+  padAddress,
+} from "../../test-helpers/index.js";
 import type { SimulationTransaction } from "../../types.js";
+import { WITHDRAWAL_TOPIC } from "../parsing/transfers.js";
 import { simulateV1 } from "./eth-simulate-v1.js";
 
 type MockSimulateCalls = (args: SimulateCallsParameters) => Promise<unknown>;
@@ -380,6 +385,34 @@ describe.sequential("simulateV1", () => {
       { account: USER, changes: [{ token: USDC, diff: -1_000_000n }] },
       { account: VAULT, changes: [{ token: USDC, diff: 1_000_000n }] },
     ]);
+  });
+
+  test("behavior: ignores WETH9 events in assetChanges on known tokenless chains", async () => {
+    mockSimulateCalls.mockResolvedValueOnce({
+      results: [
+        {
+          status: "success",
+          gasUsed: 0n,
+          data: "0x" as Hex,
+          logs: [
+            {
+              address: USDC,
+              topics: [WITHDRAWAL_TOPIC, padAddress(USER)],
+              data: encodeUint256(1_000n),
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await simulateV1({
+      rpcUrl: "http://rpc.local",
+      chainId: 1,
+      transactions: [BASIC_TX],
+      wNative: null,
+    });
+
+    expect(result.assetChanges).toEqual([]);
   });
 
   it("nets inbound and outbound transfers of the same token to zero and drops it", async () => {

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
@@ -40,7 +40,7 @@ export async function simulateV1(params: {
   chainId: number;
   transactions: SimulationTransaction[];
   blockNumber?: bigint | BlockTag;
-  wNative?: Address;
+  wNative?: Address | null;
   signal?: AbortSignal;
 }): Promise<RawSimulationResult> {
   const { rpcUrl, transactions, blockNumber, wNative, signal } = params;

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
@@ -1,4 +1,5 @@
 import {
+  type Address,
   type BlockTag,
   createPublicClient,
   getAddress,
@@ -39,9 +40,10 @@ export async function simulateV1(params: {
   chainId: number;
   transactions: SimulationTransaction[];
   blockNumber?: bigint | BlockTag;
+  wNative?: Address;
   signal?: AbortSignal;
 }): Promise<RawSimulationResult> {
-  const { rpcUrl, transactions, blockNumber, signal } = params;
+  const { rpcUrl, transactions, blockNumber, wNative, signal } = params;
 
   const client = createPublicClient({
     transport: http(rpcUrl, {
@@ -129,7 +131,7 @@ export async function simulateV1(params: {
 
     return {
       calls: rawCalls,
-      assetChanges: toAssetChanges(parseTransfers(rawCalls)),
+      assetChanges: toAssetChanges(parseTransfers(rawCalls, { wNative })),
     };
   } catch (error) {
     if (error instanceof SimulationRevertedError) throw error;

--- a/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
@@ -12,10 +12,10 @@ import {
   makeCall,
   padAddress,
 } from "../../test-helpers/index.js";
-import type { RawLog } from "../../types.js";
+import type { RawLog, SimulationLogger } from "../../types.js";
 import {
   DEPOSIT_TOPIC,
-  parseTransfers,
+  parseTransfers as parseRawTransfers,
   TRANSFER_TOPIC,
   WITHDRAWAL_TOPIC,
 } from "./transfers.js";
@@ -25,6 +25,11 @@ const WETH: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const DAI: Address = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const USER: Address = "0x1111111111111111111111111111111111111111";
 const VAULT: Address = "0x2222222222222222222222222222222222222222";
+
+const parseTransfers = (
+  calls: Parameters<typeof parseRawTransfers>[0],
+  logger?: SimulationLogger,
+) => parseRawTransfers(calls, { wNative: WETH, logger });
 
 describe("parseTransfers", () => {
   it("parses a standard ERC20 Transfer", () => {
@@ -195,6 +200,38 @@ describe("parseTransfers", () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.from).toBe(zeroAddress);
     expect(result[0]!.to).toBe(getAddress(USER));
+  });
+
+  test("behavior: ignores WETH9-shaped events from unregistered tokens", () => {
+    const logs: RawLog[] = [
+      {
+        address: DAI,
+        topics: [DEPOSIT_TOPIC, padAddress(USER)],
+        data: encodeUint256(1_000n),
+      },
+    ];
+
+    expect(parseRawTransfers([makeCall(logs)], { wNative: WETH })).toEqual([]);
+  });
+
+  test("behavior: keeps signature-based parsing without registry metadata", () => {
+    const logs: RawLog[] = [
+      {
+        address: DAI,
+        topics: [DEPOSIT_TOPIC, padAddress(USER)],
+        data: encodeUint256(1_000n),
+      },
+    ];
+
+    expect(parseRawTransfers([makeCall(logs)])).toEqual([
+      {
+        token: DAI,
+        from: zeroAddress,
+        to: USER,
+        amount: 1_000n,
+        txIdx: 0,
+      },
+    ]);
   });
 
   it("handles multi-token flows", () => {

--- a/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
@@ -158,7 +158,7 @@ describe("parseTransfers", () => {
         data: encodeUint256(amount),
       },
       {
-        address: WETH,
+        address: WETH.toLowerCase() as Address,
         topics: [
           TRANSFER_TOPIC,
           padAddress(USER),
@@ -212,6 +212,43 @@ describe("parseTransfers", () => {
     ];
 
     expect(parseRawTransfers([makeCall(logs)], { wNative: WETH })).toEqual([]);
+  });
+
+  test("behavior: rejects WETH9 events without deduplicating ERC20 transfers on known tokenless chains", () => {
+    const amount = 1_000n;
+    const mintLog: RawLog = {
+      address: DAI,
+      topics: [TRANSFER_TOPIC, padAddress(zeroAddress), padAddress(USER)],
+      data: encodeUint256(amount),
+    };
+    const calls = [
+      makeCall([
+        {
+          address: DAI,
+          topics: [DEPOSIT_TOPIC, padAddress(USER)],
+          data: encodeUint256(amount),
+        },
+        mintLog,
+        mintLog,
+      ]),
+    ];
+
+    expect(parseRawTransfers(calls, { wNative: null })).toEqual([
+      {
+        token: DAI,
+        from: zeroAddress,
+        to: USER,
+        amount,
+        txIdx: 0,
+      },
+      {
+        token: DAI,
+        from: zeroAddress,
+        to: USER,
+        amount,
+        txIdx: 0,
+      },
+    ]);
   });
 
   test("behavior: keeps signature-based parsing without registry metadata", () => {

--- a/packages/evm-simulation/src/simulate/parsing/transfers.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.ts
@@ -28,10 +28,11 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  * with the index of the originating call.
  *
  * **Supported event types:** ERC20 `Transfer(from, to, amount)` and WETH9
- * `Deposit(to, amount)` / `Withdrawal(from, amount)`. WETH9 mint/burn Transfer
- * events paired with their Deposit/Withdrawal are deduplicated. ERC721 and
- * ERC1155 transfer events are **not** parsed — consumers with NFT flows will
- * see an incomplete transfer list.
+ * `Deposit(to, amount)` / `Withdrawal(from, amount)` from the registered
+ * wrapped-native token. Chains without registry metadata retain legacy
+ * signature-based parsing. Paired mint/burn Transfer events are deduplicated.
+ * ERC721 and ERC1155 transfer events are **not** parsed — consumers with NFT
+ * flows will see an incomplete transfer list.
  *
  * **Native ETH (`eth_simulateV1` + `traceTransfers`).** When the backend runs
  * `eth_simulateV1` with `traceTransfers` enabled, native-ETH moves — including
@@ -42,39 +43,46 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  * backends. Tenderly does not emit these synthetic logs (it derives native ETH
  * separately), so this path is inert there.
  *
- * **WETH9 dedup assumption — canonical atomic emission.** Dedup is scoped to
- * the same tx: a zero-address `Transfer` is suppressed only if its paired
- * `Deposit`/`Withdrawal` appears in the same `calls[txIdx].logs` slice. This
- * is correct for canonical WETH9, which always emits the `Deposit`/
+ * **WETH9 dedup assumption — canonical atomic emission.** Dedup for the
+ * registered wrapped-native token is scoped to the same tx: a zero-address
+ * `Transfer` is suppressed only if its paired `Deposit`/`Withdrawal` appears
+ * in the same `calls[txIdx].logs` slice. This is correct for canonical WETH9,
+ * which always emits the `Deposit`/
  * `Withdrawal` and the matching `Transfer(0x0, …)` / `Transfer(…, 0x0)`
  * atomically inside a single call frame. A **non-canonical wrapped-native**
  * that splits these emissions across two txs in the same bundle would leave
  * a phantom zero-address `Transfer` in the parsed output, which can be summed
  * by `assertNoBundlerRetention` and produce a false `BlacklistViolationError`.
- * When a zero-address `Transfer` misses same-tx dedup *and* its token has
- * emitted a `Deposit`/`Withdrawal` somewhere else in the bundle (i.e. it
- * looks wnative-shaped), the parser emits a `warn` so the assumption break
- * is observable before it reaches retention. None of `morpho-sdk`'s currently
- * supported chains require cross-tx dedup; the assumption is rechecked when
- * onboarding a new chain (see `evm-simulation/CLAUDE.md`).
+ * When its zero-address `Transfer` misses same-tx dedup, the parser emits a
+ * `warn` so the assumption break is observable before it reaches retention.
+ * None of `morpho-sdk`'s currently supported chains require cross-tx dedup;
+ * the assumption is rechecked when onboarding a new chain (see
+ * `evm-simulation/CLAUDE.md`).
  *
  * **Failure mode:** on a per-log parse failure (malformed topic length,
  * non-hex data), the log is skipped and a `warn` is emitted via the logger.
  *
  * Output is sorted canonically by token, from, to, amount for determinism.
  * `txIdx` is attached but does not influence sort order.
+ *
+ * @param calls - Per-transaction call results to parse.
+ * @param options - Registered wrapped-native metadata and optional logger.
+ * @returns Canonically sorted transfers with their originating transaction index.
+ * @internal
  */
 export function parseTransfers(
   calls: readonly RawCall[],
-  logger?: SimulationLogger,
+  options: {
+    readonly wNative?: Address;
+    readonly logger?: SimulationLogger;
+  } = {},
 ): Transfer[] {
   const transfers: Transfer[] = [];
-
-  // Tokens that emit `Deposit` or `Withdrawal` somewhere in the bundle look
-  // wnative-shaped. If a zero-address `Transfer` for one of these tokens
-  // misses same-tx dedup, the contract is likely emitting non-canonically
-  // (split across txs) and a phantom transfer would leak into retention.
+  const { logger } = options;
+  const wNative = options.wNative?.toLowerCase();
   const wnativeShapedTokens = collectWnativeShapedTokens(calls);
+  const acceptsWnativeEvent = (address: Address): boolean =>
+    wNative === undefined || address.toLowerCase() === wNative;
 
   for (let txIdx = 0; txIdx < calls.length; txIdx++) {
     const logs = calls[txIdx]!.logs;
@@ -85,6 +93,7 @@ export function parseTransfers(
 
         switch (topic0) {
           case WITHDRAWAL_TOPIC: {
+            if (!acceptsWnativeEvent(log.address)) continue;
             const fromTopic = log.topics[1];
             if (!isTopicHex(fromTopic) || !isUint256Hex(log.data)) {
               warnMalformed(
@@ -105,6 +114,7 @@ export function parseTransfers(
           }
 
           case DEPOSIT_TOPIC: {
+            if (!acceptsWnativeEvent(log.address)) continue;
             const toTopic = log.topics[1];
             if (!isTopicHex(toTopic) || !isUint256Hex(log.data)) {
               warnMalformed(
@@ -147,7 +157,7 @@ export function parseTransfers(
 
             // WETH9 unwrap dedup: Transfer to zero paired with a Withdrawal of
             // equal amount in the SAME tx.
-            if (toTopic === zeroHash) {
+            if (toTopic === zeroHash && acceptsWnativeEvent(log.address)) {
               const paired = logs.some(
                 (other) =>
                   other.topics[0] === WITHDRAWAL_TOPIC &&
@@ -157,14 +167,17 @@ export function parseTransfers(
                   other.topics[1] === fromTopic,
               );
               if (paired) continue;
-              if (wnativeShapedTokens.has(log.address.toLowerCase())) {
+              if (
+                wNative !== undefined ||
+                wnativeShapedTokens.has(log.address.toLowerCase())
+              ) {
                 warnNonCanonicalWnative(logger, log, "burn", txIdx);
               }
             }
 
             // WETH9 wrap dedup: Transfer from zero paired with a Deposit of
             // equal amount in the SAME tx.
-            if (fromTopic === zeroHash) {
+            if (fromTopic === zeroHash && acceptsWnativeEvent(log.address)) {
               const paired = logs.some(
                 (other) =>
                   other.topics[0] === DEPOSIT_TOPIC &&
@@ -174,7 +187,10 @@ export function parseTransfers(
                   other.topics[1] === toTopic,
               );
               if (paired) continue;
-              if (wnativeShapedTokens.has(log.address.toLowerCase())) {
+              if (
+                wNative !== undefined ||
+                wnativeShapedTokens.has(log.address.toLowerCase())
+              ) {
                 warnNonCanonicalWnative(logger, log, "mint", txIdx);
               }
             }
@@ -226,24 +242,18 @@ function warnMalformed(
   });
 }
 
-/**
- * Collect token addresses (lowercased) that emit `Deposit` or `Withdrawal`
- * anywhere in the bundle. Used to detect when a zero-address `Transfer` that
- * misses same-tx dedup is on a wnative-shaped contract — a strong signal
- * that the contract is emitting non-canonically and a phantom transfer is
- * about to leak into bundler retention.
- */
+/** Collect contracts that emit WETH9-shaped events anywhere in the bundle. */
 function collectWnativeShapedTokens(calls: readonly RawCall[]): Set<string> {
-  const set = new Set<string>();
-  for (const c of calls) {
-    for (const l of c.logs) {
-      const t0 = l.topics[0];
-      if (t0 === WITHDRAWAL_TOPIC || t0 === DEPOSIT_TOPIC) {
-        set.add(l.address.toLowerCase());
+  const tokens = new Set<string>();
+  for (const call of calls) {
+    for (const log of call.logs) {
+      const topic0 = log.topics[0];
+      if (topic0 === WITHDRAWAL_TOPIC || topic0 === DEPOSIT_TOPIC) {
+        tokens.add(log.address.toLowerCase());
       }
     }
   }
-  return set;
+  return tokens;
 }
 
 // biome-ignore lint/complexity/useMaxParams: structured warn with full context

--- a/packages/evm-simulation/src/simulate/parsing/transfers.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.ts
@@ -1,4 +1,11 @@
-import { getAddress, type Hex, zeroAddress, zeroHash } from "viem";
+import {
+  type Address,
+  getAddress,
+  type Hex,
+  isAddressEqual,
+  zeroAddress,
+  zeroHash,
+} from "viem";
 
 import type {
   RawCall,
@@ -29,10 +36,12 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  *
  * **Supported event types:** ERC20 `Transfer(from, to, amount)` and WETH9
  * `Deposit(to, amount)` / `Withdrawal(from, amount)` from the registered
- * wrapped-native token. Chains without registry metadata retain legacy
- * signature-based parsing. Paired mint/burn Transfer events are deduplicated.
- * ERC721 and ERC1155 transfer events are **not** parsed — consumers with NFT
- * flows will see an incomplete transfer list.
+ * wrapped-native token. Known chains without a wrapped-native token ignore
+ * WETH9 events and skip wrapped-native deduplication; chains without registry
+ * metadata retain legacy signature-based parsing. On enabled paths, paired
+ * mint/burn Transfer events are deduplicated. ERC721 and ERC1155 transfer
+ * events are **not** parsed — consumers with NFT flows will see an incomplete
+ * transfer list.
  *
  * **Native ETH (`eth_simulateV1` + `traceTransfers`).** When the backend runs
  * `eth_simulateV1` with `traceTransfers` enabled, native-ETH moves — including
@@ -66,23 +75,25 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  * `txIdx` is attached but does not influence sort order.
  *
  * @param calls - Per-transaction call results to parse.
- * @param options - Registered wrapped-native metadata and optional logger.
+ * @param options - Wrapped-native metadata and optional logger. Pass `null` for
+ *   a known chain without a wrapped-native token; omit it for legacy parsing on
+ *   an unknown chain.
  * @returns Canonically sorted transfers with their originating transaction index.
  * @internal
  */
 export function parseTransfers(
   calls: readonly RawCall[],
   options: {
-    readonly wNative?: Address;
+    readonly wNative?: Address | null;
     readonly logger?: SimulationLogger;
   } = {},
 ): Transfer[] {
   const transfers: Transfer[] = [];
-  const { logger } = options;
-  const wNative = options.wNative?.toLowerCase();
+  const { logger, wNative } = options;
   const wnativeShapedTokens = collectWnativeShapedTokens(calls);
   const acceptsWnativeEvent = (address: Address): boolean =>
-    wNative === undefined || address.toLowerCase() === wNative;
+    wNative === undefined ||
+    (wNative !== null && isAddressEqual(address, wNative));
 
   for (let txIdx = 0; txIdx < calls.length; txIdx++) {
     const logs = calls[txIdx]!.logs;
@@ -161,7 +172,7 @@ export function parseTransfers(
               const paired = logs.some(
                 (other) =>
                   other.topics[0] === WITHDRAWAL_TOPIC &&
-                  other.address === log.address &&
+                  isAddressEqual(other.address, log.address) &&
                   other.data === log.data &&
                   other.topics.length === 2 &&
                   other.topics[1] === fromTopic,
@@ -181,7 +192,7 @@ export function parseTransfers(
               const paired = logs.some(
                 (other) =>
                   other.topics[0] === DEPOSIT_TOPIC &&
-                  other.address === log.address &&
+                  isAddressEqual(other.address, log.address) &&
                   other.data === log.data &&
                   other.topics.length === 2 &&
                   other.topics[1] === toTopic,

--- a/packages/evm-simulation/src/simulate/pipeline/execute-simulation.test.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/execute-simulation.test.ts
@@ -31,6 +31,7 @@ vi.mock("../backends/eth-simulate-v1", () => ({
 
 const USER: Address = "0x1111111111111111111111111111111111111111";
 const VAULT: Address = "0x2222222222222222222222222222222222222222";
+const WETH: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
 const txs: SimulationTransaction[] = [
   { from: USER, to: VAULT, data: "0x12" as Hex },
@@ -108,9 +109,13 @@ describe.sequential("executeSimulation — Tenderly + simulateV1 configured", ()
       config: bothBackends(),
       chainId: 1,
       transactions: txs,
+      wNative: WETH,
     });
 
     expect(mockSimulateV1).toHaveBeenCalledTimes(1);
+    expect(mockSimulateV1).toHaveBeenCalledWith(
+      expect.objectContaining({ wNative: WETH }),
+    );
   });
 
   it("does NOT fall back when Tenderly throws SimulationRevertedError", async () => {

--- a/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
@@ -43,7 +43,7 @@ export async function executeSimulation(params: {
   chainId: number;
   transactions: SimulationTransaction[];
   blockNumber?: bigint | BlockTag;
-  wNative?: Address;
+  wNative?: Address | null;
 }): Promise<RawSimulationResult> {
   const { config, chainId, transactions, blockNumber, wNative } = params;
   const chain = resolveChain(config, chainId);

--- a/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
+++ b/packages/evm-simulation/src/simulate/pipeline/execute-simulation.ts
@@ -1,4 +1,4 @@
-import type { BlockTag } from "viem";
+import type { Address, BlockTag } from "viem";
 import { ExternalServiceError, UnsupportedChainError } from "../../errors.js";
 import type {
   RawSimulationResult,
@@ -43,8 +43,9 @@ export async function executeSimulation(params: {
   chainId: number;
   transactions: SimulationTransaction[];
   blockNumber?: bigint | BlockTag;
+  wNative?: Address;
 }): Promise<RawSimulationResult> {
-  const { config, chainId, transactions, blockNumber } = params;
+  const { config, chainId, transactions, blockNumber, wNative } = params;
   const chain = resolveChain(config, chainId);
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
@@ -80,6 +81,7 @@ export async function executeSimulation(params: {
         chainId,
         transactions,
         blockNumber,
+        wNative,
         signal: AbortSignal.timeout(fallbackBudget),
       });
     }
@@ -95,6 +97,7 @@ export async function executeSimulation(params: {
     chainId,
     transactions,
     blockNumber,
+    wNative,
     signal: AbortSignal.timeout(timeoutMs),
   });
 }

--- a/packages/evm-simulation/src/simulate/simulate.test.ts
+++ b/packages/evm-simulation/src/simulate/simulate.test.ts
@@ -1,4 +1,4 @@
-import { getChainAddresses } from "@morpho-org/blue-sdk";
+import { ChainId, getChainAddresses } from "@morpho-org/blue-sdk";
 import { type Address, ethAddress, type Hex, zeroAddress } from "viem";
 import { vi } from "vitest";
 import {
@@ -469,6 +469,29 @@ describe.sequential("simulate — backend fallback", () => {
     expect(mockSimulateV1).toHaveBeenCalled();
   });
 
+  test("behavior: ignores WETH9 events on registered tokenless chains", async () => {
+    const chainId = ChainId.StableMainnet;
+    mockSimulateV1.mockResolvedValueOnce(
+      makeSuccessResult([
+        {
+          address: USDC,
+          topics: [WITHDRAWAL_TOPIC, padAddress(USER)],
+          data: encodeUint256(1_000n),
+        },
+      ]),
+    );
+
+    const result = await simulate(
+      {
+        chains: new Map([[chainId, { simulateV1Url: "http://rpc.local" }]]),
+      },
+      makeParams({ chainId }),
+    );
+
+    expect(result.transfers).toEqual([]);
+    expect(mockSimulateV1.mock.calls[0]![0].wNative).toBeNull();
+  });
+
   test("behavior: keeps configured custom chains without registered addresses", async () => {
     const chainId = 999_999;
     const amount = 1_000n;
@@ -498,6 +521,7 @@ describe.sequential("simulate — backend fallback", () => {
         txIdx: 0,
       },
     ]);
+    expect(mockSimulateV1.mock.calls[0]![0].wNative).toBeUndefined();
   });
 });
 

--- a/packages/evm-simulation/src/simulate/simulate.test.ts
+++ b/packages/evm-simulation/src/simulate/simulate.test.ts
@@ -8,7 +8,11 @@ import {
   SimulationValidationError,
   UnsupportedChainError,
 } from "../errors.js";
-import { makeTransferLog } from "../test-helpers/index.js";
+import {
+  encodeUint256,
+  makeTransferLog,
+  padAddress,
+} from "../test-helpers/index.js";
 import type {
   AccountAssetChanges,
   RawLog,
@@ -19,6 +23,7 @@ import type {
 } from "../types.js";
 import type { simulateV1 } from "./backends/eth-simulate-v1.js";
 import type { simulateTenderlyRpc } from "./backends/tenderly-rpc.js";
+import { WITHDRAWAL_TOPIC } from "./parsing/transfers.js";
 import { simulate } from "./simulate.js";
 
 const mockTenderlyRpc = vi.fn<typeof simulateTenderlyRpc>();
@@ -462,6 +467,37 @@ describe.sequential("simulate — backend fallback", () => {
     expect(result.transfers).toHaveLength(1);
     expect(mockTenderlyRpc).not.toHaveBeenCalled();
     expect(mockSimulateV1).toHaveBeenCalled();
+  });
+
+  test("behavior: keeps configured custom chains without registered addresses", async () => {
+    const chainId = 999_999;
+    const amount = 1_000n;
+    mockSimulateV1.mockResolvedValueOnce(
+      makeSuccessResult([
+        {
+          address: USDC,
+          topics: [WITHDRAWAL_TOPIC, padAddress(USER)],
+          data: encodeUint256(amount),
+        },
+      ]),
+    );
+
+    const result = await simulate(
+      {
+        chains: new Map([[chainId, { simulateV1Url: "http://rpc.local" }]]),
+      },
+      makeParams({ chainId }),
+    );
+
+    expect(result.transfers).toEqual([
+      {
+        token: USDC,
+        from: USER,
+        to: zeroAddress,
+        amount,
+        txIdx: 0,
+      },
+    ]);
   });
 });
 

--- a/packages/evm-simulation/src/simulate/simulate.ts
+++ b/packages/evm-simulation/src/simulate/simulate.ts
@@ -1,3 +1,8 @@
+import {
+  getChainAddresses,
+  UnsupportedChainIdError,
+} from "@morpho-org/blue-sdk";
+import type { Address } from "viem";
 import { ExternalServiceError } from "../errors.js";
 import type {
   SimulateParams,
@@ -82,12 +87,20 @@ export async function simulate(
 ): Promise<SimulationResult> {
   validateInput(params);
 
+  let wNative: Address | undefined;
+  try {
+    wNative = getChainAddresses(params.chainId).wNative;
+  } catch (error) {
+    if (!(error instanceof UnsupportedChainIdError)) throw error;
+  }
+
   const simulationTxs = buildSimulationTxs(params);
   const result = await executeSimulation({
     config,
     chainId: params.chainId,
     transactions: simulationTxs,
     blockNumber: params.blockNumber,
+    wNative,
   });
   if (result.calls.length !== simulationTxs.length) {
     throw new ExternalServiceError(
@@ -95,7 +108,10 @@ export async function simulate(
     );
   }
 
-  const transfers = parseTransfers(result.calls, config.logger);
+  const transfers = parseTransfers(result.calls, {
+    wNative,
+    logger: config.logger,
+  });
 
   assertNoBundlerRetention({
     chainId: params.chainId,

--- a/packages/evm-simulation/src/simulate/simulate.ts
+++ b/packages/evm-simulation/src/simulate/simulate.ts
@@ -1,8 +1,8 @@
 import {
+  _try,
   getChainAddresses,
   UnsupportedChainIdError,
 } from "@morpho-org/blue-sdk";
-import type { Address } from "viem";
 import { ExternalServiceError } from "../errors.js";
 import type {
   SimulateParams,
@@ -24,10 +24,10 @@ import {
  * Validates input → resolves authorizations into prepended approve txs → runs the bundle
  * through Tenderly RPC (primary) or `eth_simulateV1` (fallback) with a shared timeout
  * budget → parses ERC20 transfers and WETH9 events from per-tx logs, restricting WETH9
- * events to the registered wrapped-native token when chain metadata exists and retaining
- * signature-based parsing otherwise → asserts no funds are retained by `bundler3` or the
- * standalone `bundles` periphery contracts → returns the full result set. The caller reads
- * whichever fields they need:
+ * events to the registered wrapped-native token, rejecting them on known tokenless chains,
+ * and retaining signature-based parsing for unknown chains → asserts no funds are retained
+ * by `bundler3` or the standalone `bundles` periphery contracts → returns the full result
+ * set. The caller reads whichever fields they need:
  *
  * - `transfers` → user-facing preview / server-side verification.
  * - `simulationTxs` + `transfers` → server-side verification before broadcast.
@@ -89,12 +89,10 @@ export async function simulate(
 ): Promise<SimulationResult> {
   validateInput(params);
 
-  let wNative: Address | undefined;
-  try {
-    wNative = getChainAddresses(params.chainId).wNative;
-  } catch (error) {
-    if (!(error instanceof UnsupportedChainIdError)) throw error;
-  }
+  const wNative = _try(
+    () => getChainAddresses(params.chainId).wNative ?? null,
+    UnsupportedChainIdError,
+  );
 
   const simulationTxs = buildSimulationTxs(params);
   const result = await executeSimulation({

--- a/packages/evm-simulation/src/simulate/simulate.ts
+++ b/packages/evm-simulation/src/simulate/simulate.ts
@@ -23,9 +23,11 @@ import {
  *
  * Validates input → resolves authorizations into prepended approve txs → runs the bundle
  * through Tenderly RPC (primary) or `eth_simulateV1` (fallback) with a shared timeout
- * budget → parses ERC20/WETH transfers from per-tx logs → asserts no funds are retained
- * by `bundler3` or the standalone `bundles` periphery contracts → returns the full result
- * set. The caller reads whichever fields they need:
+ * budget → parses ERC20 transfers and WETH9 events from per-tx logs, restricting WETH9
+ * events to the registered wrapped-native token when chain metadata exists and retaining
+ * signature-based parsing otherwise → asserts no funds are retained by `bundler3` or the
+ * standalone `bundles` periphery contracts → returns the full result set. The caller reads
+ * whichever fields they need:
  *
  * - `transfers` → user-facing preview / server-side verification.
  * - `simulationTxs` + `transfers` → server-side verification before broadcast.

--- a/packages/evm-simulation/test/simulate/backends/eth-simulate-v1.integration.test.ts
+++ b/packages/evm-simulation/test/simulate/backends/eth-simulate-v1.integration.test.ts
@@ -103,6 +103,7 @@ describe.sequential("simulateV1 — assetChanges on a mainnet fork", () => {
     const result = await simulateV1({
       rpcUrl: client.transport.url!,
       chainId: mainnet.id,
+      wNative: WETH,
       transactions: [
         {
           from: client.account.address,

--- a/packages/evm-simulation/test/simulate/simulate.integration.test.ts
+++ b/packages/evm-simulation/test/simulate/simulate.integration.test.ts
@@ -1,0 +1,94 @@
+import { getChainAddresses } from "@morpho-org/blue-sdk";
+import {
+  type Address,
+  concatHex,
+  encodeFunctionData,
+  padHex,
+  parseEther,
+  toHex,
+  zeroAddress,
+} from "viem";
+import { mainnet } from "viem/chains";
+import { expect } from "vitest";
+import { simulate } from "../../src/index.js";
+import { WITHDRAWAL_TOPIC } from "../../src/simulate/parsing/transfers.js";
+import { test } from "../setup.js";
+
+const LOOKALIKE_TOKEN: Address = "0x1000000000000000000000000000000000000001";
+const WETH: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const wethAbi = [
+  {
+    type: "function",
+    name: "withdraw",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "wad", type: "uint256" }],
+    outputs: [],
+  },
+] as const;
+
+describe.sequential("simulate — registered wrapped-native events", () => {
+  test("behavior: parses WETH9 events only from the registered contract", async ({
+    client,
+  }) => {
+    const amount = parseEther("1");
+    const bundler = getChainAddresses(mainnet.id).bundler3.bundler3;
+    await client.deal({ erc20: WETH, amount });
+
+    // Runtime bytecode that emits Withdrawal(bundler, amount) without moving
+    // value. The log is produced by a real EVM execution through eth_simulateV1.
+    await client.setCode({
+      address: LOOKALIKE_TOKEN,
+      bytecode: concatHex([
+        "0x7f",
+        padHex(toHex(amount), { size: 32 }),
+        "0x5f52",
+        "0x73",
+        bundler,
+        "0x7f",
+        WITHDRAWAL_TOPIC,
+        "0x60205fa200",
+      ]),
+    });
+
+    const result = await simulate(
+      {
+        chains: new Map([
+          [mainnet.id, { simulateV1Url: client.transport.url! }],
+        ]),
+      },
+      {
+        chainId: mainnet.id,
+        transactions: [
+          {
+            from: client.account.address,
+            to: WETH,
+            data: encodeFunctionData({
+              abi: wethAbi,
+              functionName: "withdraw",
+              args: [amount],
+            }),
+          },
+          { from: client.account.address, to: LOOKALIKE_TOKEN, data: "0x" },
+        ],
+      },
+    );
+
+    expect(result.calls[1]?.logs[0]?.address).toBe(LOOKALIKE_TOKEN);
+    expect(result.calls[1]?.logs[0]?.topics[0]).toBe(WITHDRAWAL_TOPIC);
+    expect(result.transfers).toContainEqual({
+      token: WETH,
+      from: client.account.address,
+      to: zeroAddress,
+      amount,
+      txIdx: 0,
+    });
+    expect(
+      result.transfers.every(({ token }) => token !== LOOKALIKE_TOKEN),
+    ).toBe(true);
+    expect(
+      result.assetChanges.every(({ changes }) =>
+        changes.every(({ token }) => token !== LOOKALIKE_TOKEN),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Motivation

`parseTransfers` currently interprets any contract emitting the WETH9 `Deposit(address,uint256)` or `Withdrawal(address,uint256)` signature as wrapped-native value movement. A real Anvil execution reproduces the issue: a non-`wNative` contract emits `Withdrawal(bundler, amount)`, and `origin/main` includes that lookalike token in both `transfers` and `assetChanges`.

SDKS-120 is intentionally excluded because no current Tenderly response omitting `assetChanges` could be reproduced or found in captured evidence.

## Solution

- Resolve the chain registry `wNative` once in `simulate` and thread it through both transfer-parsing passes.
- Accept WETH9-specific events and apply mint/burn deduplication only for that registered emitter.
- Preserve legacy signature-based parsing for configured custom chains without registry metadata.
- Add a mainnet-fork regression that executes a real WETH withdrawal and an EVM lookalike emitter in the same bundle. It proves registered WETH is retained while the lookalike is absent from both outputs; the same test fails on `origin/main`.
- Add a patch changeset for `@morpho-org/evm-simulation`.

## Testing

- `pnpm --filter @morpho-org/evm-simulation test` (238 tests)
- `pnpm --filter @morpho-org/evm-simulation test:fork` (4 tests)
- `pnpm --filter @morpho-org/evm-simulation build`
- Biome on all 9 changed TypeScript files
- JSDoc self-check and checksum-address lint
