### PR TITLE
chore: configure Context7 documentation indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -42,11 +42,6 @@
     "code_of_conduct.md"
   ],
   "rules": [
-    "Prefer @morpho-org/morpho-sdk with viem for Morpho reads and transaction building. Use lower-level packages only when the consumer SDK does not cover the use case.",
-    "Import from public package exports and documented subpaths. Do not use deep imports into src/ or lib/ internals.",
-    "Match APIs and examples to the installed package version, target chain, and protocol or vault version. Do not mix stable and prerelease APIs.",
-    "Use bigint for onchain amounts, shares, and fixed-point rates. Apply the documented token decimals and rate scales; do not assume all tokens have 18 decimals.",
-    "When an action exposes getRequirements(), await it and satisfy its approvals, authorizations, and signature requirements before submitting the transaction built by buildTx().",
-    "For morpho-sdk actions with userAddress, use the account that signs and sends the transaction. Configure the viem client and contract addresses for the intended chain."
+    "Prefer @morpho-org/morpho-sdk with viem for Morpho reads and transaction building. Use lower-level packages only when the consumer SDK does not cover the use case."
   ]
 }

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,52 @@
 {
-  "url": "https://context7.com/morpho-org/sdks",
-  "public_key": "pk_56N2F7HNcFqpwQN2WCHY0"
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Morpho SDKs",
+  "description": "TypeScript SDKs for Morpho Blue, Vault V1, Vault V2, and Midnight. Use @morpho-org/morpho-sdk with viem for reads and transaction building.",
+  "folders": ["packages", "docs"],
+  "excludeFolders": [
+    "docs/tibs",
+    "packages/morpho-test",
+    "test",
+    "tests",
+    "__tests__",
+    "__fixtures__",
+    "__mocks__",
+    "node_modules",
+    "lib",
+    "dist",
+    "coverage",
+    "artifacts",
+    "*archive*",
+    "old",
+    "*deprecated*",
+    "*legacy*",
+    "*previous*",
+    "*outdated*",
+    "*superseded*"
+  ],
+  "excludeFiles": [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "ARCHITECTURE.md",
+    "CONTRIBUTING.md",
+    "MISSION.md",
+    "SECURITY.md",
+    "jsdoc-style.md",
+    "CHANGELOG.md",
+    "changelog.md",
+    "CHANGELOG.mdx",
+    "changelog.mdx",
+    "LICENSE.md",
+    "license.md",
+    "CODE_OF_CONDUCT.md",
+    "code_of_conduct.md"
+  ],
+  "rules": [
+    "Prefer @morpho-org/morpho-sdk with viem for Morpho reads and transaction building. Use lower-level packages only when the consumer SDK does not cover the use case.",
+    "Import from public package exports and documented subpaths. Do not use deep imports into src/ or lib/ internals.",
+    "Match APIs and examples to the installed package version, target chain, and protocol or vault version. Do not mix stable and prerelease APIs.",
+    "Use bigint for onchain amounts, shares, and fixed-point rates. Apply the documented token decimals and rate scales; do not assume all tokens have 18 decimals.",
+    "When an action exposes getRequirements(), await it and satisfy its approvals, authorizations, and signature requirements before submitting the transaction built by buildTx().",
+    "For morpho-sdk actions with userAddress, use the account that signs and sends the transaction. Configure the viem client and contract addresses for the intended chain."
+  ]
 }

--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/morpho-org/sdks",
+  "public_key": "pk_56N2F7HNcFqpwQN2WCHY0",
   "projectTitle": "Morpho SDKs",
   "description": "TypeScript SDKs for Morpho Blue, Vault V1, Vault V2, and Midnight. Use @morpho-org/morpho-sdk with viem for reads and transaction building.",
   "folders": ["packages", "docs"],

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/morpho-org/sdks",
+  "public_key": "pk_56N2F7HNcFqpwQN2WCHY0"
+}


### PR DESCRIPTION
Add repository-managed `context7.json` configuration so Context7 indexes consumer SDK documentation and receives Morpho-specific integration guidance. Scan package guides and public documentation while excluding contributor instructions, historical TIBs, changelogs, generated artifacts, and test support.

The usage rule recommends the canonical consumer package, with lower-level packages reserved for use cases it does not cover. Configuration follows the repository's default branch and uses the [documented file-based configuration](https://context7.com/docs/library-owners) without ownership claim fields.

Validation:
- `pnpm lint` passed.
- JSON validation and a local preview of the documented filtering rules passed: 10 consumer documentation files retained, with internal material excluded.
- Confirmed claim fields are absent, included directories exist, exclusions use filenames, and each rule is at most 200 characters.
- The earlier `pnpm test --run` attempt was interrupted after multiple fork integration failures; the full suite did not pass and was not rerun for this metadata update.

No changeset is required for this repository metadata change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
