### PR TITLE
fix(blue-sdk-viem): stop mutating caller-owned fetch parameters (SDK-411, SDK-414)

### DIFF
--- a/.changeset/copy-fetch-parameters.md
+++ b/.changeset/copy-fetch-parameters.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk-viem": patch
+---
+
+Stop mutating caller-owned fetch `parameters` objects: every fetcher now defaults `chainId`/`deployless` on its own copy, so a shared options object reused across clients or chains is no longer silently pinned to the first resolved chain id.

--- a/packages/blue-sdk-viem/src/fetch/Position.ts
+++ b/packages/blue-sdk-viem/src/fetch/Position.ts
@@ -48,7 +48,7 @@ export async function fetchPosition(
   user: Address,
   marketId: MarketId,
   client: Client,
-  parameters: FetchParameters = {},
+  { ...parameters }: FetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 
@@ -102,7 +102,7 @@ export async function fetchPosition(
 export async function fetchPreLiquidationParams(
   preLiquidation: Address,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ): Promise<PreLiquidationParams> {
   parameters.chainId ??= await getChainId(client);
   const { preLltv, preLIF1, preLIF2, preLCF1, preLCF2, preLiquidationOracle } =
@@ -159,7 +159,7 @@ export async function fetchAccrualPosition(
   user: Address,
   marketId: MarketId,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 
@@ -215,7 +215,7 @@ export async function fetchPreLiquidationPosition(
   marketId: MarketId,
   preLiquidation: Address,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 

--- a/packages/blue-sdk-viem/src/fetch/User.ts
+++ b/packages/blue-sdk-viem/src/fetch/User.ts
@@ -34,7 +34,7 @@ import type { FetchParameters } from "../types.js";
 export async function fetchUser(
   address: Address,
   client: Client,
-  parameters: FetchParameters = {},
+  { ...parameters }: FetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 

--- a/packages/blue-sdk-viem/src/fetch/Vault.ts
+++ b/packages/blue-sdk-viem/src/fetch/Vault.ts
@@ -403,7 +403,7 @@ export async function fetchVault(
 export async function fetchAccrualVault(
   address: Address,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 

--- a/packages/blue-sdk-viem/src/fetch/VaultConfig.ts
+++ b/packages/blue-sdk-viem/src/fetch/VaultConfig.ts
@@ -36,7 +36,7 @@ import { fetchToken } from "./Token.js";
 export async function fetchVaultConfig(
   address: Address,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 

--- a/packages/blue-sdk-viem/src/fetch/VaultMarketAllocation.ts
+++ b/packages/blue-sdk-viem/src/fetch/VaultMarketAllocation.ts
@@ -45,7 +45,7 @@ export async function fetchVaultMarketAllocation(
   vault: Address,
   marketId: MarketId,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 

--- a/packages/blue-sdk-viem/src/fetch/VaultMarketConfig.ts
+++ b/packages/blue-sdk-viem/src/fetch/VaultMarketConfig.ts
@@ -45,7 +45,7 @@ export async function fetchVaultMarketConfig(
   vault: Address,
   marketId: MarketId,
   client: Client,
-  parameters: FetchParameters = {},
+  { ...parameters }: FetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 

--- a/packages/blue-sdk-viem/src/fetch/VaultMarketPublicAllocatorConfig.ts
+++ b/packages/blue-sdk-viem/src/fetch/VaultMarketPublicAllocatorConfig.ts
@@ -45,7 +45,7 @@ export async function fetchVaultMarketPublicAllocatorConfig(
   vault: Address,
   marketId: MarketId,
   client: Client,
-  parameters: FetchParameters = {},
+  { ...parameters }: FetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
 

--- a/packages/blue-sdk-viem/src/fetch/fetch.test.ts
+++ b/packages/blue-sdk-viem/src/fetch/fetch.test.ts
@@ -1140,6 +1140,27 @@ describe("fetchUser", () => {
 
     expect(user.isBundlerAuthorized).toBe(false);
   });
+
+  test("behavior: does not write the resolved chainId into caller-owned parameters", async () => {
+    const handle = createMockClient(mainnet);
+    mockRead(handle, {
+      address: ADDRESSES.morpho,
+      abi: blueAbi,
+      functionName: "isAuthorized",
+      result: false,
+    });
+    mockRead(handle, {
+      address: ADDRESSES.morpho,
+      abi: blueAbi,
+      functionName: "nonce",
+      result: 0n,
+    });
+    const parameters = {};
+
+    await fetchUser(USER, handle.client, parameters);
+
+    expect(parameters).toStrictEqual({});
+  });
 });
 
 describe("vault fetchers", () => {
@@ -1754,9 +1775,12 @@ describe("vault fetchers", () => {
     mockVaultMarketConfigReads(handle);
     mockPositionReads(handle);
 
-    const vault = await fetchAccrualVault(VAULT, handle.client);
+    const parameters = {};
+
+    const vault = await fetchAccrualVault(VAULT, handle.client, parameters);
 
     expect(vault).toBeInstanceOf(AccrualVault);
     expect(vault.allocations.get(ID)?.marketId).toBe(ID);
+    expect(parameters).toStrictEqual({});
   });
 });

--- a/packages/blue-sdk-viem/src/fetch/vault-v2/VaultV2Adapter.ts
+++ b/packages/blue-sdk-viem/src/fetch/vault-v2/VaultV2Adapter.ts
@@ -56,7 +56,7 @@ import {
 export async function fetchVaultV2Adapter(
   address: Address,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
   parameters.deployless ??= true;
@@ -154,7 +154,7 @@ export async function fetchVaultV2Adapter(
 export async function fetchAccrualVaultV2Adapter(
   address: Address,
   client: Client,
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);
   parameters.deployless ??= true;

--- a/packages/blue-sdk-viem/src/fetch/vault-v2/vault-v2.test.ts
+++ b/packages/blue-sdk-viem/src/fetch/vault-v2/vault-v2.test.ts
@@ -682,12 +682,17 @@ describe("fetchVaultV2Adapter", () => {
       skimRecipient: RECIPIENT,
     });
 
-    const adapter = await fetchVaultV2Adapter(ADAPTER, handle.client, {
-      chainId: CHAIN_ID,
-    });
+    const parameters = { chainId: CHAIN_ID };
+
+    const adapter = await fetchVaultV2Adapter(
+      ADAPTER,
+      handle.client,
+      parameters,
+    );
 
     expect(adapter).toBeInstanceOf(VaultV2MorphoVaultV1Adapter);
     expect((adapter as VaultV2MorphoVaultV1Adapter).morphoVaultV1).toBe(VAULT);
+    expect(parameters).toStrictEqual({ chainId: CHAIN_ID });
   });
 
   test("routes to the MorphoMarketV1 adapter fetcher", async () => {


### PR DESCRIPTION
## Summary

Cantina AI Audit #2 findings SDKS-32 (`fetchVault`, SDK-411) and SDKS-35 (`fetchVaultV2Adapter`, SDK-414): fetchers did `parameters.chainId ??= await getChainId(client)` (and `parameters.deployless ??= true`) directly on the object the caller passed in. A caller reusing one options literal across clients on different chains had it silently pinned to the first resolved chain id, and later calls read addresses for the wrong chain.

`fetchVault` and `fetchVaultV2` already used the `{ deployless = true, ...parameters }` rest-destructure so the mutation hit a private copy. This PR applies the same idiom to every remaining fetcher that still mutated the argument:

```diff
-  parameters: DeploylessFetchParameters = {},
+  { ...parameters }: DeploylessFetchParameters = {},
 ) {
   parameters.chainId ??= await getChainId(client);   // now writes to our copy
```

Touched: `fetchPosition`, `fetchPreLiquidationParams`, `fetchAccrualPosition`, `fetchPreLiquidationPosition`, `fetchAccrualVault`, `fetchUser`, `fetchVaultConfig`, `fetchVaultMarketAllocation`, `fetchVaultMarketConfig`, `fetchVaultMarketPublicAllocatorConfig`, `fetchVaultV2Adapter`, `fetchAccrualVaultV2Adapter`. No behaviour change for callers passing fresh literals; the resolved defaults are still forwarded to nested fetchers via the copy.

Tests assert the caller's object is `toStrictEqual` to what was passed (fail on `main`, pass here). Patch changeset for `@morpho-org/blue-sdk-viem`.

Linear: SDK-411, SDK-414

Link to Devin session: https://app.devin.ai/sessions/47b25991531f4a0cb471fb6526302197
Open in Devin Desktop: https://app.devin.ai/desktop/session/47b25991531f4a0cb471fb6526302197?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->