### PR TITLE
fix: compare token addresses case-insensitively in registries and fetchers (SDK-518, SDK-524)

### DIFF
--- a/.changeset/case-insensitive-token-addresses.md
+++ b/.changeset/case-insensitive-token-addresses.md
@@ -1,6 +1,8 @@
 ---
 "@morpho-org/morpho-ts": patch
 "@morpho-org/blue-sdk-viem": patch
+"@morpho-org/blue-sdk": patch
+"@morpho-org/morpho-sdk": patch
 ---
 
 Compare token addresses case-insensitively: `getUnwrappedToken` resolves lowercased wrapped-token addresses against the checksummed registry (and re-registering the same mapping under a different casing no longer creates a duplicate key), while `fetchHolding`/`fetchToken` now detect permissioned Backed/wrapper tokens, wstETH, and the native token regardless of the caller's address casing.

--- a/.changeset/case-insensitive-token-addresses.md
+++ b/.changeset/case-insensitive-token-addresses.md
@@ -1,0 +1,6 @@
+---
+"@morpho-org/morpho-ts": patch
+"@morpho-org/blue-sdk-viem": patch
+---
+
+Compare token addresses case-insensitively: `getUnwrappedToken` resolves lowercased wrapped-token addresses against the checksummed registry (and re-registering the same mapping under a different casing no longer creates a duplicate key), while `fetchHolding`/`fetchToken` now detect permissioned Backed/wrapper tokens, wstETH, and the native token regardless of the caller's address casing.

--- a/packages/blue-sdk-viem/src/fetch/Holding.ts
+++ b/packages/blue-sdk-viem/src/fetch/Holding.ts
@@ -7,7 +7,7 @@ import {
   permissionedBackedTokens,
   permissionedWrapperTokens,
 } from "@morpho-org/blue-sdk";
-import { fromEntries, getValue } from "@morpho-org/morpho-ts";
+import { fromEntries, getValue, isHexEqual } from "@morpho-org/morpho-ts";
 import {
   type Address,
   type Client,
@@ -68,7 +68,7 @@ export async function fetchHolding(
 ) {
   parameters.chainId ??= await getChainId(client);
 
-  if (token === NATIVE_ADDRESS)
+  if (isHexEqual(token, NATIVE_ADDRESS))
     return new Holding({
       user,
       token,
@@ -88,6 +88,16 @@ export async function fetchHolding(
           })
         : 0n,
     });
+
+  const isRegistered = (tokens?: Set<Address>) =>
+    tokens != null &&
+    [...tokens].some((registered) => isHexEqual(registered, token));
+  const isPermissionedBackedToken = isRegistered(
+    permissionedBackedTokens[parameters.chainId],
+  );
+  const isPermissionedWrapperToken = isRegistered(
+    permissionedWrapperTokens[parameters.chainId],
+  );
 
   if (deployless) {
     const {
@@ -118,8 +128,8 @@ export async function fetchHolding(
           morpho,
           permit2,
           generalAdapter1,
-          !!permissionedBackedTokens[parameters.chainId]?.has(token),
-          !!permissionedWrapperTokens[parameters.chainId]?.has(token),
+          isPermissionedBackedToken,
+          isPermissionedWrapperToken,
         ],
       });
 
@@ -195,7 +205,7 @@ export async function fetchHolding(
       functionName: "nonces",
       args: [user],
     }).catch(() => undefined),
-    permissionedBackedTokens[parameters.chainId]?.has(token)
+    isPermissionedBackedToken
       ? readContract(client, {
           ...parameters,
           abi: wrappedBackedTokenAbi,
@@ -209,7 +219,7 @@ export async function fetchHolding(
       address: token,
       functionName: "hasPermission",
       args: [user],
-    }).catch(() => !permissionedWrapperTokens[parameters.chainId!]?.has(token)),
+    }).catch(() => !isPermissionedWrapperToken),
   ]);
 
   const holding = new Holding({

--- a/packages/blue-sdk-viem/src/fetch/Holding.ts
+++ b/packages/blue-sdk-viem/src/fetch/Holding.ts
@@ -7,11 +7,12 @@ import {
   permissionedBackedTokens,
   permissionedWrapperTokens,
 } from "@morpho-org/blue-sdk";
-import { fromEntries, getValue, isHexEqual } from "@morpho-org/morpho-ts";
+import { fromEntries, getValue } from "@morpho-org/morpho-ts";
 import {
   type Address,
   type Client,
   erc20Abi,
+  isAddressEqual,
   maxUint256,
   zeroAddress,
 } from "viem";
@@ -68,7 +69,7 @@ export async function fetchHolding(
 ) {
   parameters.chainId ??= await getChainId(client);
 
-  if (isHexEqual(token, NATIVE_ADDRESS))
+  if (isAddressEqual(token, NATIVE_ADDRESS))
     return new Holding({
       user,
       token,
@@ -91,10 +92,10 @@ export async function fetchHolding(
 
   const isPermissionedBackedToken = [
     ...(permissionedBackedTokens[parameters.chainId] ?? []),
-  ].some((registered) => isHexEqual(registered, token));
+  ].some((registered) => isAddressEqual(registered, token));
   const isPermissionedWrapperToken = [
     ...(permissionedWrapperTokens[parameters.chainId] ?? []),
-  ].some((registered) => isHexEqual(registered, token));
+  ].some((registered) => isAddressEqual(registered, token));
 
   if (deployless) {
     const {

--- a/packages/blue-sdk-viem/src/fetch/Holding.ts
+++ b/packages/blue-sdk-viem/src/fetch/Holding.ts
@@ -89,15 +89,12 @@ export async function fetchHolding(
         : 0n,
     });
 
-  const isRegistered = (tokens?: Set<Address>) =>
-    tokens != null &&
-    [...tokens].some((registered) => isHexEqual(registered, token));
-  const isPermissionedBackedToken = isRegistered(
-    permissionedBackedTokens[parameters.chainId],
-  );
-  const isPermissionedWrapperToken = isRegistered(
-    permissionedWrapperTokens[parameters.chainId],
-  );
+  const isPermissionedBackedToken = [
+    ...(permissionedBackedTokens[parameters.chainId] ?? []),
+  ].some((registered) => isHexEqual(registered, token));
+  const isPermissionedWrapperToken = [
+    ...(permissionedWrapperTokens[parameters.chainId] ?? []),
+  ].some((registered) => isHexEqual(registered, token));
 
   if (deployless) {
     const {

--- a/packages/blue-sdk-viem/src/fetch/Token.ts
+++ b/packages/blue-sdk-viem/src/fetch/Token.ts
@@ -7,6 +7,7 @@ import {
   NATIVE_ADDRESS,
   Token,
 } from "@morpho-org/blue-sdk";
+import { isHexEqual } from "@morpho-org/morpho-ts";
 import {
   type Address,
   type Client,
@@ -75,14 +76,16 @@ export async function fetchToken(
 ) {
   parameters.chainId ??= await getChainId(client);
 
-  if (address === NATIVE_ADDRESS) return Token.native(parameters.chainId);
+  const isKnownAddress = (known?: Address) =>
+    known != null && typeof address === "string" && isHexEqual(address, known);
+
+  if (isKnownAddress(NATIVE_ADDRESS)) return Token.native(parameters.chainId);
 
   const { wstEth, stEth } = getChainAddresses(parameters.chainId);
+  const isWstEth = isKnownAddress(wstEth);
 
   if (deployless) {
     try {
-      const isWstEth = address === wstEth;
-
       const token = await readContract(client, {
         ...parameters,
         abi,
@@ -195,20 +198,15 @@ export async function fetchToken(
     eip5267Domain,
   };
 
-  switch (address) {
-    case wstEth: {
-      if (stEth) {
-        const stEthPerWstEth = await readContract(client, {
-          ...parameters,
-          address: wstEth!,
-          abi: wstEthAbi,
-          functionName: "stEthPerToken",
-        });
+  if (isWstEth && wstEth != null && stEth != null) {
+    const stEthPerWstEth = await readContract(client, {
+      ...parameters,
+      address: wstEth,
+      abi: wstEthAbi,
+      functionName: "stEthPerToken",
+    });
 
-        return new ExchangeRateWrappedToken(token, stEth, stEthPerWstEth);
-      }
-      break;
-    }
+    return new ExchangeRateWrappedToken(token, stEth, stEthPerWstEth);
   }
 
   const unwrapToken = getUnwrappedToken(address, parameters.chainId);

--- a/packages/blue-sdk-viem/src/fetch/Token.ts
+++ b/packages/blue-sdk-viem/src/fetch/Token.ts
@@ -7,13 +7,13 @@ import {
   NATIVE_ADDRESS,
   Token,
 } from "@morpho-org/blue-sdk";
-import { isHexEqual } from "@morpho-org/morpho-ts";
 import {
   type Address,
   type Client,
   erc20Abi,
   erc20Abi_bytes32,
   hexToString,
+  isAddressEqual,
   isHex,
 } from "viem";
 import { getChainId, readContract } from "viem/actions";
@@ -76,14 +76,14 @@ export async function fetchToken(
 ) {
   parameters.chainId ??= await getChainId(client);
 
-  if (typeof address === "string" && isHexEqual(address, NATIVE_ADDRESS))
+  if (typeof address === "string" && isAddressEqual(address, NATIVE_ADDRESS))
     return Token.native(parameters.chainId);
 
   const { wstEth, stEth } = getChainAddresses(parameters.chainId);
   const isWstEth =
     wstEth != null &&
     typeof address === "string" &&
-    isHexEqual(address, wstEth);
+    isAddressEqual(address, wstEth);
 
   if (deployless) {
     try {

--- a/packages/blue-sdk-viem/src/fetch/Token.ts
+++ b/packages/blue-sdk-viem/src/fetch/Token.ts
@@ -76,13 +76,14 @@ export async function fetchToken(
 ) {
   parameters.chainId ??= await getChainId(client);
 
-  const isKnownAddress = (known?: Address) =>
-    known != null && typeof address === "string" && isHexEqual(address, known);
-
-  if (isKnownAddress(NATIVE_ADDRESS)) return Token.native(parameters.chainId);
+  if (typeof address === "string" && isHexEqual(address, NATIVE_ADDRESS))
+    return Token.native(parameters.chainId);
 
   const { wstEth, stEth } = getChainAddresses(parameters.chainId);
-  const isWstEth = isKnownAddress(wstEth);
+  const isWstEth =
+    wstEth != null &&
+    typeof address === "string" &&
+    isHexEqual(address, wstEth);
 
   if (deployless) {
     try {

--- a/packages/blue-sdk-viem/src/fetch/fetch.test.ts
+++ b/packages/blue-sdk-viem/src/fetch/fetch.test.ts
@@ -456,6 +456,44 @@ describe("fetchToken", () => {
     );
   });
 
+  test("behavior: matches wstETH and unwrap tokens case-insensitively", async () => {
+    const handle = createMockClient(mainnet);
+    const wstEth = ADDRESSES.wstEth.toLowerCase() as Address;
+    mockTokenReads(handle, wstEth, {
+      symbol: "wstETH",
+      name: "Wrapped liquid staked Ether 2.0",
+    });
+    mockRead(handle, {
+      address: ADDRESSES.wstEth,
+      abi: wstEthAbi,
+      functionName: "stEthPerToken",
+      result: 1_000000000000000000n,
+    });
+    const wbIB01 = ADDRESSES.wbIB01.toLowerCase() as Address;
+    mockTokenReads(handle, wbIB01, {
+      symbol: "wBIB01",
+      name: "Wrapped BIB01",
+    });
+
+    const [wstEthToken, wbIB01Token] = await Promise.all([
+      fetchToken(wstEth, handle.client, {
+        chainId: CHAIN_ID,
+        deployless: false,
+      }),
+      fetchToken(wbIB01, handle.client, {
+        chainId: CHAIN_ID,
+        deployless: false,
+      }),
+    ]);
+
+    expect(wstEthToken).toBeInstanceOf(ExchangeRateWrappedToken);
+    expect(wstEthToken.address).toBe(wstEth);
+    expect(wbIB01Token).toBeInstanceOf(ConstantWrappedToken);
+    expect((wbIB01Token as ConstantWrappedToken).underlying).toBe(
+      ADDRESSES.bIB01,
+    );
+  });
+
   test("returns undefined metadata when every optional ERC20 read fails", async () => {
     const handle = createMockClient(mainnet);
     for (const abi of [erc20Abi, erc20Abi_bytes32]) {
@@ -919,6 +957,62 @@ describe("fetchHolding", () => {
       nonce: 24n,
     });
     expect(holding.erc2612Nonce).toBe(25n);
+    expect(holding.canTransfer).toBe(false);
+  });
+
+  test("behavior: matches permissioned backed tokens case-insensitively", async () => {
+    const handle = createMockClient(mainnet);
+    const token = ADDRESSES.wbIB01.toLowerCase() as Address;
+    const whitelist = RECIPIENT;
+
+    mockRead(handle, {
+      address: token,
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      result: 20n,
+    });
+    mockRead(handle, {
+      address: token,
+      abi: erc20Abi,
+      functionName: "allowance",
+      result: 21n,
+    });
+    mockRead(handle, {
+      address: ADDRESSES.permit2,
+      abi: permit2Abi,
+      functionName: "allowance",
+      result: [22n, 23, 24],
+    });
+    mockReadFailure(handle, {
+      address: token,
+      abi: erc2612Abi,
+      functionName: "nonces",
+    });
+    mockRead(handle, {
+      address: token,
+      abi: wrappedBackedTokenAbi,
+      functionName: "whitelistControllerAggregator",
+      result: whitelist,
+    });
+    mockRead(handle, {
+      address: token,
+      abi: permissionedErc20WrapperAbi,
+      functionName: "hasPermission",
+      result: true,
+    });
+    mockRead(handle, {
+      address: whitelist,
+      abi: whitelistControllerAggregatorV2Abi,
+      functionName: "isWhitelisted",
+      result: false,
+    });
+
+    const holding = await fetchHolding(USER, token, handle.client, {
+      chainId: CHAIN_ID,
+      deployless: false,
+    });
+
+    expect(holding.token).toBe(token);
     expect(holding.canTransfer).toBe(false);
   });
 

--- a/packages/morpho-ts/src/addresses.test.ts
+++ b/packages/morpho-ts/src/addresses.test.ts
@@ -10,6 +10,7 @@ import {
   getUnwrappedToken,
   NATIVE_ADDRESS,
   registerCustomAddresses,
+  unwrappedTokensMapping,
 } from "./addresses.js";
 import { ChainId } from "./chain.js";
 import {
@@ -1093,6 +1094,43 @@ describe("registerCustomAddresses", () => {
     ).toThrow(RegistryValueAlreadyRegisteredError);
 
     expect(getChainAddress(chainId, "midnight")).toBe(chainAddresses.midnight);
+  });
+
+  test("behavior: unwrapped token lookup and registration are case-insensitive", () => {
+    const chainId = 31_337_107;
+    const wrappedToken = "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8";
+    const unwrappedToken = randomAddress();
+    const lowercasedWrappedToken = wrappedToken.toLowerCase() as `0x${string}`;
+
+    registerCustomAddresses({
+      unwrappedTokens: {
+        [chainId]: { [wrappedToken]: unwrappedToken },
+      },
+    });
+
+    expect(getUnwrappedToken(lowercasedWrappedToken, chainId)).toBe(
+      unwrappedToken,
+    );
+
+    expect(() =>
+      registerCustomAddresses({
+        unwrappedTokens: {
+          [chainId]: { [lowercasedWrappedToken]: unwrappedToken },
+        },
+      }),
+    ).not.toThrow();
+    expect(Object.keys(unwrappedTokensMapping[chainId] ?? {})).toEqual([
+      wrappedToken,
+    ]);
+
+    expect(() =>
+      registerCustomAddresses({
+        unwrappedTokens: {
+          [chainId]: { [lowercasedWrappedToken]: randomAddress() },
+        },
+      }),
+    ).toThrow(RegistryValueAlreadyRegisteredError);
+    expect(getUnwrappedToken(wrappedToken, chainId)).toBe(unwrappedToken);
   });
 
   test("error: conflicting PublicAllocator addresses", () => {

--- a/packages/morpho-ts/src/addresses.test.ts
+++ b/packages/morpho-ts/src/addresses.test.ts
@@ -1133,6 +1133,41 @@ describe("registerCustomAddresses", () => {
     expect(getUnwrappedToken(wrappedToken, chainId)).toBe(unwrappedToken);
   });
 
+  test("behavior: casing variants of one wrapped token inside a single registration", () => {
+    const wrappedToken = "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8";
+    const lowercased = wrappedToken.toLowerCase() as `0x${string}`;
+    const unwrappedToken = randomAddress();
+    const otherToken = randomAddress();
+
+    for (const [first, second] of [
+      [wrappedToken, lowercased],
+      [lowercased, wrappedToken],
+    ] as const) {
+      const chainId = 31_337_200 + (first === wrappedToken ? 0 : 1);
+
+      expect(() =>
+        registerCustomAddresses({
+          unwrappedTokens: {
+            [chainId]: { [first]: unwrappedToken, [second]: unwrappedToken },
+          },
+        }),
+      ).not.toThrow();
+      expect(Object.keys(unwrappedTokensMapping[chainId] ?? {})).toEqual([
+        first,
+      ]);
+      expect(getUnwrappedToken(second, chainId)).toBe(unwrappedToken);
+
+      expect(() =>
+        registerCustomAddresses({
+          unwrappedTokens: {
+            [chainId + 10]: { [first]: unwrappedToken, [second]: otherToken },
+          },
+        }),
+      ).toThrow(RegistryValueAlreadyRegisteredError);
+      expect(unwrappedTokensMapping[chainId + 10]).toBeUndefined();
+    }
+  });
+
   test("error: conflicting PublicAllocator addresses", () => {
     const chainId = 31_337_015;
 

--- a/packages/morpho-ts/src/addresses.test.ts
+++ b/packages/morpho-ts/src/addresses.test.ts
@@ -1126,6 +1126,20 @@ describe("registerCustomAddresses", () => {
     expect(() =>
       registerCustomAddresses({
         unwrappedTokens: {
+          [chainId]: {
+            [lowercasedWrappedToken]:
+              unwrappedToken.toLowerCase() as `0x${string}`,
+          },
+        },
+      }),
+    ).not.toThrow();
+    expect(unwrappedTokensMapping[chainId]?.[wrappedToken]).toBe(
+      unwrappedToken,
+    );
+
+    expect(() =>
+      registerCustomAddresses({
+        unwrappedTokens: {
           [chainId]: { [lowercasedWrappedToken]: randomAddress() },
         },
       }),

--- a/packages/morpho-ts/src/addresses.ts
+++ b/packages/morpho-ts/src/addresses.ts
@@ -6,7 +6,7 @@ import {
   UnsupportedChainIdError,
 } from "./errors.js";
 import type { DeepPartial, DottedKeys } from "./types.js";
-import { deepFreeze, entries } from "./utils.js";
+import { deepFreeze, entries, isHexEqual } from "./utils.js";
 
 /** Address used to replicate an erc20-behaviour for native token.
  *
@@ -2339,6 +2339,8 @@ const _unwrappedTokensMapping: Record<
 /**
  * Returns the unwrapped token mapped to a wrapped token on a chain.
  *
+ * Lookup is case-insensitive: the registry keys are checksummed, but callers may pass a lowercased address.
+ *
  * @param wrappedToken - The wrapped token address to resolve.
  * @param chainId - The EIP-155 chain id.
  * @returns The unwrapped token address, or `undefined` when no mapping is registered.
@@ -2354,7 +2356,13 @@ export function getUnwrappedToken(
   wrappedToken: `0x${string}`,
   chainId: number,
 ) {
-  return unwrappedTokensMapping[chainId]?.[wrappedToken];
+  const mapping = unwrappedTokensMapping[chainId];
+  if (mapping == null || wrappedToken == null) return undefined;
+
+  return (
+    mapping[wrappedToken] ??
+    entries(mapping).find(([key]) => isHexEqual(key, wrappedToken))?.[1]
+  );
 }
 
 /**
@@ -2522,6 +2530,30 @@ const assertRequiredBlueRegistry = ({
     type,
   });
 };
+
+/**
+ * Rewrites patch keys that differ from a registered wrapped-token key only by case onto the registered key,
+ * so `mergeRegistry` compares the two mappings for the same token instead of adding a duplicate entry.
+ */
+const alignUnwrappedTokenKeys = (
+  base: Record<number, Record<`0x${string}`, `0x${string}`>>,
+  patch: Record<number, Record<`0x${string}`, `0x${string}`>>,
+): Record<number, Record<`0x${string}`, `0x${string}`>> =>
+  Object.fromEntries(
+    Object.entries(patch).map(([chainIdString, tokens]) => {
+      const registeredKeys = Object.keys(base[Number(chainIdString)] ?? {});
+
+      return [
+        chainIdString,
+        Object.fromEntries(
+          Object.entries(tokens).map(([wrapped, unwrapped]) => [
+            registeredKeys.find((key) => isHexEqual(key, wrapped)) ?? wrapped,
+            unwrapped,
+          ]),
+        ),
+      ];
+    }),
+  );
 
 const mergeRegistry = <T>({
   base,
@@ -2814,7 +2846,7 @@ export function registerCustomAddresses<
     unwrappedTokensMapping = deepFreeze(
       mergeRegistry({
         base: unwrappedTokensMapping,
-        patch: unwrappedTokens,
+        patch: alignUnwrappedTokenKeys(unwrappedTokensMapping, unwrappedTokens),
         label: "unwrappedTokens",
         type: "unwrapped token",
       }),

--- a/packages/morpho-ts/src/addresses.ts
+++ b/packages/morpho-ts/src/addresses.ts
@@ -2531,43 +2531,6 @@ const assertRequiredBlueRegistry = ({
   });
 };
 
-/**
- * Rewrites patch keys that differ only by case from a registered wrapped-token key (or from an earlier key
- * of the same patch) onto that key, so `mergeRegistry` compares the two mappings for the same token instead
- * of adding a duplicate entry. Two casing variants of one token inside the same patch must agree on the
- * unwrapped token, otherwise `RegistryValueAlreadyRegisteredError` is thrown.
- */
-const alignUnwrappedTokenKeys = (
-  base: Record<number, Record<`0x${string}`, `0x${string}`>>,
-  patch: Record<number, Record<`0x${string}`, `0x${string}`>>,
-): Record<number, Record<`0x${string}`, `0x${string}`>> =>
-  Object.fromEntries(
-    Object.entries(patch).map(([chainIdString, tokens]) => {
-      const registeredKeys = Object.keys(base[Number(chainIdString)] ?? {});
-      const aligned: Record<string, `0x${string}`> = {};
-
-      for (const [wrapped, unwrapped] of Object.entries(tokens)) {
-        const key =
-          [...registeredKeys, ...Object.keys(aligned)].find((candidate) =>
-            isHexEqual(candidate, wrapped),
-          ) ?? wrapped;
-        const previous = aligned[key];
-
-        if (previous !== undefined && !isHexEqual(previous, unwrapped))
-          throw new RegistryValueAlreadyRegisteredError({
-            label: `unwrappedTokens.${chainIdString}.${key}`,
-            registeredValue: previous,
-            requestedValue: unwrapped,
-            type: "unwrapped token",
-          });
-
-        aligned[key] = previous ?? unwrapped;
-      }
-
-      return [chainIdString, aligned];
-    }),
-  );
-
 const mergeRegistry = <T>({
   base,
   patch,
@@ -2856,10 +2819,45 @@ export function registerCustomAddresses<
   }
 
   if (unwrappedTokens) {
+    // Patch keys that differ only by case from a registered key (or from an earlier key of the same
+    // patch) are rewritten onto that key, so `mergeRegistry` compares values for the same token instead
+    // of adding a duplicate entry. Casing variants within one patch must agree on the unwrapped token.
+    const alignedUnwrappedTokens: Record<
+      number,
+      Record<`0x${string}`, `0x${string}`>
+    > = Object.fromEntries(
+      Object.entries(unwrappedTokens).map(([chainIdString, tokens]) => {
+        const registeredKeys = Object.keys(
+          unwrappedTokensMapping[Number(chainIdString)] ?? {},
+        );
+        const aligned: Record<string, `0x${string}`> = {};
+
+        for (const [wrapped, unwrapped] of Object.entries(tokens)) {
+          const key =
+            [...registeredKeys, ...Object.keys(aligned)].find((candidate) =>
+              isHexEqual(candidate, wrapped),
+            ) ?? wrapped;
+          const previous = aligned[key];
+
+          if (previous !== undefined && !isHexEqual(previous, unwrapped))
+            throw new RegistryValueAlreadyRegisteredError({
+              label: `unwrappedTokens.${chainIdString}.${key}`,
+              registeredValue: previous,
+              requestedValue: unwrapped,
+              type: "unwrapped token",
+            });
+
+          aligned[key] = previous ?? unwrapped;
+        }
+
+        return [chainIdString, aligned];
+      }),
+    );
+
     unwrappedTokensMapping = deepFreeze(
       mergeRegistry({
         base: unwrappedTokensMapping,
-        patch: alignUnwrappedTokenKeys(unwrappedTokensMapping, unwrappedTokens),
+        patch: alignedUnwrappedTokens,
         label: "unwrappedTokens",
         type: "unwrapped token",
       }),

--- a/packages/morpho-ts/src/addresses.ts
+++ b/packages/morpho-ts/src/addresses.ts
@@ -6,7 +6,7 @@ import {
   UnsupportedChainIdError,
 } from "./errors.js";
 import type { DeepPartial, DottedKeys } from "./types.js";
-import { deepFreeze, entries, isHexEqual } from "./utils.js";
+import { deepFreeze, entries, fromEntries, isHexEqual } from "./utils.js";
 
 /** Address used to replicate an erc20-behaviour for native token.
  *
@@ -2820,24 +2820,21 @@ export function registerCustomAddresses<
 
   if (unwrappedTokens) {
     // Patch keys that differ only by case from a registered key (or from an earlier key of the same
-    // patch) are rewritten onto that key, so `mergeRegistry` compares values for the same token instead
-    // of adding a duplicate entry. Casing variants within one patch must agree on the unwrapped token.
-    const alignedUnwrappedTokens: Record<
-      number,
-      Record<`0x${string}`, `0x${string}`>
-    > = Object.fromEntries(
-      Object.entries(unwrappedTokens).map(([chainIdString, tokens]) => {
-        const registeredKeys = Object.keys(
-          unwrappedTokensMapping[Number(chainIdString)] ?? {},
-        );
+    // patch) are rewritten onto that key, and values that differ only by case from the registered
+    // value are rewritten onto that value, so `mergeRegistry` compares the same token instead of
+    // adding a duplicate entry. Casing variants within one patch must agree on the unwrapped token.
+    const alignedUnwrappedTokens = fromEntries(
+      entries(unwrappedTokens).map(([chainIdString, tokens]) => {
+        const registered = unwrappedTokensMapping[Number(chainIdString)] ?? {};
+        const registeredKeys = Object.keys(registered);
         const aligned: Record<string, `0x${string}`> = {};
 
-        for (const [wrapped, unwrapped] of Object.entries(tokens)) {
+        for (const [wrapped, unwrapped] of entries(tokens)) {
           const key =
             [...registeredKeys, ...Object.keys(aligned)].find((candidate) =>
               isHexEqual(candidate, wrapped),
             ) ?? wrapped;
-          const previous = aligned[key];
+          const previous = aligned[key] ?? registered[key as `0x${string}`];
 
           if (previous !== undefined && !isHexEqual(previous, unwrapped))
             throw new RegistryValueAlreadyRegisteredError({
@@ -2850,7 +2847,7 @@ export function registerCustomAddresses<
           aligned[key] = previous ?? unwrapped;
         }
 
-        return [chainIdString, aligned];
+        return [chainIdString, aligned] as const;
       }),
     );
 

--- a/packages/morpho-ts/src/addresses.ts
+++ b/packages/morpho-ts/src/addresses.ts
@@ -2532,8 +2532,10 @@ const assertRequiredBlueRegistry = ({
 };
 
 /**
- * Rewrites patch keys that differ from a registered wrapped-token key only by case onto the registered key,
- * so `mergeRegistry` compares the two mappings for the same token instead of adding a duplicate entry.
+ * Rewrites patch keys that differ only by case from a registered wrapped-token key (or from an earlier key
+ * of the same patch) onto that key, so `mergeRegistry` compares the two mappings for the same token instead
+ * of adding a duplicate entry. Two casing variants of one token inside the same patch must agree on the
+ * unwrapped token, otherwise `RegistryValueAlreadyRegisteredError` is thrown.
  */
 const alignUnwrappedTokenKeys = (
   base: Record<number, Record<`0x${string}`, `0x${string}`>>,
@@ -2542,16 +2544,27 @@ const alignUnwrappedTokenKeys = (
   Object.fromEntries(
     Object.entries(patch).map(([chainIdString, tokens]) => {
       const registeredKeys = Object.keys(base[Number(chainIdString)] ?? {});
+      const aligned: Record<string, `0x${string}`> = {};
 
-      return [
-        chainIdString,
-        Object.fromEntries(
-          Object.entries(tokens).map(([wrapped, unwrapped]) => [
-            registeredKeys.find((key) => isHexEqual(key, wrapped)) ?? wrapped,
-            unwrapped,
-          ]),
-        ),
-      ];
+      for (const [wrapped, unwrapped] of Object.entries(tokens)) {
+        const key =
+          [...registeredKeys, ...Object.keys(aligned)].find((candidate) =>
+            isHexEqual(candidate, wrapped),
+          ) ?? wrapped;
+        const previous = aligned[key];
+
+        if (previous !== undefined && !isHexEqual(previous, unwrapped))
+          throw new RegistryValueAlreadyRegisteredError({
+            label: `unwrappedTokens.${chainIdString}.${key}`,
+            registeredValue: previous,
+            requestedValue: unwrapped,
+            type: "unwrapped token",
+          });
+
+        aligned[key] = previous ?? unwrapped;
+      }
+
+      return [chainIdString, aligned];
     }),
   );
 

--- a/packages/morpho-ts/src/addresses.ts
+++ b/packages/morpho-ts/src/addresses.ts
@@ -6,7 +6,7 @@ import {
   UnsupportedChainIdError,
 } from "./errors.js";
 import type { DeepPartial, DottedKeys } from "./types.js";
-import { deepFreeze, entries, fromEntries, isHexEqual } from "./utils.js";
+import { deepFreeze, entries, fromEntries, isHexEqual, keys } from "./utils.js";
 
 /** Address used to replicate an erc20-behaviour for native token.
  *
@@ -2826,15 +2826,15 @@ export function registerCustomAddresses<
     const alignedUnwrappedTokens = fromEntries(
       entries(unwrappedTokens).map(([chainIdString, tokens]) => {
         const registered = unwrappedTokensMapping[Number(chainIdString)] ?? {};
-        const registeredKeys = Object.keys(registered);
-        const aligned: Record<string, `0x${string}`> = {};
+        const registeredKeys = keys(registered);
+        const aligned: Record<`0x${string}`, `0x${string}`> = {};
 
         for (const [wrapped, unwrapped] of entries(tokens)) {
           const key =
-            [...registeredKeys, ...Object.keys(aligned)].find((candidate) =>
+            [...registeredKeys, ...keys(aligned)].find((candidate) =>
               isHexEqual(candidate, wrapped),
             ) ?? wrapped;
-          const previous = aligned[key] ?? registered[key as `0x${string}`];
+          const previous = aligned[key] ?? registered[key];
 
           if (previous !== undefined && !isHexEqual(previous, unwrapped))
             throw new RegistryValueAlreadyRegisteredError({


### PR DESCRIPTION
## Summary

Cantina AI Audit #2 findings SDKS-133 (SDK-518) and SDKS-149 (SDK-524): several token-address lookups used strict `===` / `Set.has` / object-key equality against checksummed registry entries, so a caller passing a lowercased (or otherwise differently-cased) address silently lost the classification instead of failing loudly.

- `fetchHolding`: `permissionedBackedTokens` / `permissionedWrapperTokens` membership is now resolved once, case-insensitively, and reused by both the deployless `query(...)` args and the multicall fallback (`whitelistControllerAggregator` read gate, `hasPermission` catch default). Previously a lowercased wbIB01 was treated as a plain ERC20 and `canTransfer` was skipped.
- `fetchToken`: `NATIVE_ADDRESS` and `wstEth` matching go through `isHexEqual`; the `switch (address) { case wstEth }` fallback is replaced by the same `isWstEth` flag as the deployless path.
- `getUnwrappedToken`: exact key hit first, otherwise a case-insensitive scan of the chain's mapping.
- `registerCustomAddresses({ unwrappedTokens })`: patch keys that differ from an already-registered wrapped token only by case are rewritten onto the registered key before `mergeRegistry`, so they hit the existing value comparison (same value → no-op, different value → `RegistryValueAlreadyRegisteredError`) instead of creating a duplicate entry.

Behaviour for already-checksummed input is unchanged; the `token`/`address` echoed in returned entities is still the caller's value. `isHexEqual` (existing `morpho-ts` helper) is used rather than `safeGetAddress` so malformed input keeps failing at the RPC boundary exactly as before.

Tests: lowercased wbIB01 holding takes the backed-token whitelist path; lowercased wstETH/wbIB01 resolve to `ExchangeRateWrappedToken`/`ConstantWrappedToken`; unwrapped-token registry lookup + same-value re-registration under different casing + conflicting-value rejection. All three fail on `main`.

Changeset: patch for `@morpho-org/morpho-ts` and `@morpho-org/blue-sdk-viem`.


Link to Devin session: https://app.devin.ai/sessions/47b25991531f4a0cb471fb6526302197
Open in Devin Desktop: https://app.devin.ai/desktop/session/47b25991531f4a0cb471fb6526302197?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->