### PR TITLE
fix(evm-simulation): reject partial Tenderly bundles, pair WETH9 logs 1:1 case-insensitively (SDK-421, SDK-510, SDK-519)

### DIFF
--- a/.changeset/simulation-log-integrity.md
+++ b/.changeset/simulation-log-integrity.md
@@ -1,0 +1,9 @@
+---
+"@morpho-org/evm-simulation": patch
+---
+
+Harden simulation backend integrity and WETH9 log pairing:
+
+- `simulateTenderlyRpc` now throws `ExternalServiceError` when `tenderly_simulateBundle` returns a different number of results than transactions submitted, so `executeSimulation` falls back to `eth_simulateV1` instead of failing the request.
+- `parseTransfers` compares log `address`/`topics`/`data` case-insensitively when recognising ERC-20 `Transfer` and WETH9 `Deposit`/`Withdrawal` events.
+- WETH9 wrap/unwrap deduplication is now one-to-one: each `Deposit`/`Withdrawal` absolves at most one matching zero-address `Transfer`, so duplicate mint/burn transfers are no longer silently dropped.

--- a/packages/evm-simulation/src/simulate/backends/tenderly-rpc.test.ts
+++ b/packages/evm-simulation/src/simulate/backends/tenderly-rpc.test.ts
@@ -501,6 +501,34 @@ describe.sequential("simulateTenderlyRpc — bundle", () => {
     expect(txs[1]!.input).toBe("0x34");
   });
 
+  it("error: ExternalServiceError when the bundle returns fewer results than transactions", async () => {
+    const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+      ok: true,
+      json: async () => envelope([successResult()]),
+    });
+    installFetchMock(fetchMock);
+
+    const promise = simulateTenderlyRpc({
+      config: CONFIG,
+      transactions: [TX1, TX2],
+    });
+    await expect(promise).rejects.toBeInstanceOf(ExternalServiceError);
+    await expect(promise).rejects.not.toBeInstanceOf(SimulationRevertedError);
+  });
+
+  it("error: ExternalServiceError when the bundle returns more results than transactions", async () => {
+    const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        envelope([successResult(), successResult(), successResult()]),
+    });
+    installFetchMock(fetchMock);
+
+    await expect(
+      simulateTenderlyRpc({ config: CONFIG, transactions: [TX1, TX2] }),
+    ).rejects.toBeInstanceOf(ExternalServiceError);
+  });
+
   it("emits one call per bundle step with its own gas/output/logs", async () => {
     const fetchMock = vi.fn<MockFetch>().mockResolvedValueOnce({
       ok: true,

--- a/packages/evm-simulation/src/simulate/backends/tenderly-rpc.ts
+++ b/packages/evm-simulation/src/simulate/backends/tenderly-rpc.ts
@@ -122,7 +122,8 @@ const bundleEnvelope = rpcEnvelope(z.array(simResultSchema).min(1));
  * @throws {SimulationValidationError} when `transactions` is empty.
  * @throws {SimulationRevertedError} when any simulated tx reports `status: false`.
  * @throws {ExternalServiceError} on non-2xx response, JSON-RPC envelope error,
- *   schema-validation failure, or fetch-layer failure.
+ *   schema-validation failure, fetch-layer failure, or a bundle response whose
+ *   result count differs from the number of submitted transactions.
  */
 export async function simulateTenderlyRpc(params: {
   config: TenderlyRpcConfig;
@@ -167,6 +168,11 @@ export async function simulateTenderlyRpc(params: {
       signal,
     });
     const results = unwrapResult(bundleEnvelope.parse(json));
+    if (results.length !== transactions.length) {
+      throw new ExternalServiceError(
+        `Tenderly RPC returned ${results.length} result(s) for ${transactions.length} transaction(s)`,
+      );
+    }
     return {
       calls: results.map(toRawCall),
       assetChanges: toAssetChanges(results),

--- a/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.test.ts
@@ -565,4 +565,111 @@ describe("parseTransfers", () => {
     expect(result[0]!.to).toBe(zeroAddress);
     expect(logger.warn).not.toHaveBeenCalled();
   });
+
+  test("behavior: WETH9 wrap dedup pairs mixed-case topics/address/data", () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const amount = 1_000_000_000_000_000_000n;
+    const upper = (hex: Hex): Hex => `0x${hex.slice(2).toUpperCase()}`;
+    const logs: RawLog[] = [
+      {
+        address: upper(WETH),
+        topics: [upper(DEPOSIT_TOPIC), upper(padAddress(USER))],
+        data: upper(encodeUint256(amount)),
+      },
+      {
+        address: WETH.toLowerCase() as Address,
+        topics: [
+          TRANSFER_TOPIC,
+          `0x${"0".repeat(64)}` as Hex,
+          padAddress(USER),
+        ],
+        data: encodeUint256(amount),
+      },
+    ];
+
+    const result = parseTransfers([makeCall(logs)], logger);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      token: getAddress(WETH),
+      from: zeroAddress,
+      to: getAddress(USER),
+      amount,
+      txIdx: 0,
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("behavior: one WETH9 Deposit absolves at most one identical mint Transfer", () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const amount = 1_000_000_000_000_000_000n;
+    const mint: RawLog = {
+      address: WETH,
+      topics: [TRANSFER_TOPIC, `0x${"0".repeat(64)}` as Hex, padAddress(USER)],
+      data: encodeUint256(amount),
+    };
+    const logs: RawLog[] = [
+      {
+        address: WETH,
+        topics: [DEPOSIT_TOPIC, padAddress(USER)],
+        data: encodeUint256(amount),
+      },
+      mint,
+      mint,
+    ];
+
+    const result = parseTransfers([makeCall(logs)], logger);
+    // Deposit + first mint collapse into one; the second mint has no partner.
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.from === zeroAddress)).toBe(true);
+    expect(result.every((t) => t.amount === amount)).toBe(true);
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("WETH9 dedup miss"),
+      expect.objectContaining({ kind: "mint", txIdx: 0 }),
+    );
+  });
+
+  test("behavior: one WETH9 Withdrawal absolves at most one identical burn Transfer", () => {
+    const amount = 1_000_000_000_000_000_000n;
+    const burn: RawLog = {
+      address: WETH,
+      topics: [TRANSFER_TOPIC, padAddress(USER), `0x${"0".repeat(64)}` as Hex],
+      data: encodeUint256(amount),
+    };
+    const logs: RawLog[] = [
+      burn,
+      {
+        address: WETH,
+        topics: [WITHDRAWAL_TOPIC, padAddress(USER)],
+        data: encodeUint256(amount),
+      },
+      burn,
+    ];
+
+    const result = parseTransfers([makeCall(logs)]);
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.to === zeroAddress)).toBe(true);
+  });
+
+  test("behavior: two WETH9 Deposits absolve two identical mint Transfers", () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const amount = 1_000_000_000_000_000_000n;
+    const deposit: RawLog = {
+      address: WETH,
+      topics: [DEPOSIT_TOPIC, padAddress(USER)],
+      data: encodeUint256(amount),
+    };
+    const mint: RawLog = {
+      address: WETH,
+      topics: [TRANSFER_TOPIC, `0x${"0".repeat(64)}` as Hex, padAddress(USER)],
+      data: encodeUint256(amount),
+    };
+
+    const result = parseTransfers(
+      [makeCall([deposit, mint, deposit, mint])],
+      logger,
+    );
+    expect(result).toHaveLength(2);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });

--- a/packages/evm-simulation/src/simulate/parsing/transfers.ts
+++ b/packages/evm-simulation/src/simulate/parsing/transfers.ts
@@ -55,7 +55,9 @@ const UINT256_HEX_LENGTH = 66; // "0x" + 32 bytes
  * **WETH9 dedup assumption — canonical atomic emission.** Dedup for the
  * registered wrapped-native token is scoped to the same tx: a zero-address
  * `Transfer` is suppressed only if its paired `Deposit`/`Withdrawal` appears
- * in the same `calls[txIdx].logs` slice. This is correct for canonical WETH9,
+ * in the same `calls[txIdx].logs` slice. Pairing is one-to-one (each
+ * `Deposit`/`Withdrawal` absolves at most one `Transfer`) and compares
+ * `address`/`topics`/`data` case-insensitively. This is correct for canonical WETH9,
  * which always emits the `Deposit`/
  * `Withdrawal` and the matching `Transfer(0x0, …)` / `Transfer(…, 0x0)`
  * atomically inside a single call frame. A **non-canonical wrapped-native**
@@ -97,9 +99,10 @@ export function parseTransfers(
 
   for (let txIdx = 0; txIdx < calls.length; txIdx++) {
     const logs = calls[txIdx]!.logs;
+    const unpairedWnativeEvents = countWnativeEvents(logs);
     for (const log of logs) {
       try {
-        const topic0 = log.topics[0];
+        const topic0 = log.topics[0]?.toLowerCase();
         if (topic0 === undefined) continue;
 
         switch (topic0) {
@@ -168,16 +171,22 @@ export function parseTransfers(
 
             // WETH9 unwrap dedup: Transfer to zero paired with a Withdrawal of
             // equal amount in the SAME tx.
-            if (toTopic === zeroHash && acceptsWnativeEvent(log.address)) {
-              const paired = logs.some(
-                (other) =>
-                  other.topics[0] === WITHDRAWAL_TOPIC &&
-                  isAddressEqual(other.address, log.address) &&
-                  other.data === log.data &&
-                  other.topics.length === 2 &&
-                  other.topics[1] === fromTopic,
-              );
-              if (paired) continue;
+            if (
+              toTopic.toLowerCase() === zeroHash &&
+              acceptsWnativeEvent(log.address)
+            ) {
+              if (
+                consumeWnativeEvent(
+                  unpairedWnativeEvents,
+                  wnativeEventKey(
+                    WITHDRAWAL_TOPIC,
+                    log.address,
+                    fromTopic,
+                    log.data,
+                  ),
+                )
+              )
+                continue;
               if (
                 wNative !== undefined ||
                 wnativeShapedTokens.has(log.address.toLowerCase())
@@ -188,16 +197,22 @@ export function parseTransfers(
 
             // WETH9 wrap dedup: Transfer from zero paired with a Deposit of
             // equal amount in the SAME tx.
-            if (fromTopic === zeroHash && acceptsWnativeEvent(log.address)) {
-              const paired = logs.some(
-                (other) =>
-                  other.topics[0] === DEPOSIT_TOPIC &&
-                  isAddressEqual(other.address, log.address) &&
-                  other.data === log.data &&
-                  other.topics.length === 2 &&
-                  other.topics[1] === toTopic,
-              );
-              if (paired) continue;
+            if (
+              fromTopic.toLowerCase() === zeroHash &&
+              acceptsWnativeEvent(log.address)
+            ) {
+              if (
+                consumeWnativeEvent(
+                  unpairedWnativeEvents,
+                  wnativeEventKey(
+                    DEPOSIT_TOPIC,
+                    log.address,
+                    toTopic,
+                    log.data,
+                  ),
+                )
+              )
+                continue;
               if (
                 wNative !== undefined ||
                 wnativeShapedTokens.has(log.address.toLowerCase())
@@ -253,12 +268,54 @@ function warnMalformed(
   });
 }
 
+/** Case-insensitive identity of a WETH9 `Deposit`/`Withdrawal` log. */
+// biome-ignore lint/complexity/useMaxParams: flat key over the four pairing fields
+function wnativeEventKey(
+  topic0: Hex,
+  address: Address,
+  account: Hex,
+  data: Hex,
+): string {
+  return `${topic0}:${address.toLowerCase()}:${account.toLowerCase()}:${data.toLowerCase()}`;
+}
+
+/** Count WETH9 `Deposit`/`Withdrawal` logs of one tx, keyed by {@link wnativeEventKey}. */
+function countWnativeEvents(logs: readonly RawLog[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const log of logs) {
+    const topic0 = log.topics[0]?.toLowerCase();
+    const account = log.topics[1];
+    if (
+      (topic0 !== WITHDRAWAL_TOPIC && topic0 !== DEPOSIT_TOPIC) ||
+      log.topics.length !== 2 ||
+      !isTopicHex(account) ||
+      !isUint256Hex(log.data)
+    )
+      continue;
+    const key = wnativeEventKey(topic0, log.address, account, log.data);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Consume one unpaired WETH9 event for `key`; returns whether one was available. */
+function consumeWnativeEvent(
+  counts: Map<string, number>,
+  key: string,
+): boolean {
+  const remaining = counts.get(key);
+  if (remaining === undefined) return false;
+  if (remaining === 1) counts.delete(key);
+  else counts.set(key, remaining - 1);
+  return true;
+}
+
 /** Collect contracts that emit WETH9-shaped events anywhere in the bundle. */
 function collectWnativeShapedTokens(calls: readonly RawCall[]): Set<string> {
   const tokens = new Set<string>();
   for (const call of calls) {
     for (const log of call.logs) {
-      const topic0 = log.topics[0];
+      const topic0 = log.topics[0]?.toLowerCase();
       if (topic0 === WITHDRAWAL_TOPIC || topic0 === DEPOSIT_TOPIC) {
         tokens.add(log.address.toLowerCase());
       }


### PR DESCRIPTION
## Summary

Cantina AI Audit #2 low findings SDKS-42 / SDKS-75 / SDKS-78 (Linear SDK-421, SDK-510, SDK-519) — all in `@morpho-org/evm-simulation` backend-result integrity and WETH9 log parsing.

**SDK-421 — partial Tenderly bundle now falls back.** `simulateTenderlyRpc` validates `results.length === transactions.length` for `tenderly_simulateBundle` and throws `ExternalServiceError` *inside the backend*. Previously only `simulate.ts` checked this, after `executeSimulation` had already returned, so a truncated Tenderly response failed the whole request even when `simulateV1Url` was configured. Now the existing `catch (ExternalServiceError)` in `executeSimulation` runs `eth_simulateV1`. The late check in `simulate.ts` is kept as a guard for any backend. Not classified as `SimulationRevertedError`: an omitted result is a backend integrity problem, not evidence the tx reverted.

**SDK-510 — case-insensitive log matching.** `parseTransfers` lowercases `topic0` before the `switch` and compares `zeroHash`/pairing fields case-insensitively; `collectWnativeShapedTokens` does the same. Output `RawLog` casing is untouched.

**SDK-519 — one-to-one WETH9 pairing.** Replaced the unbounded `logs.some(...)` lookup (one `Deposit` could suppress N identical mint `Transfer`s) with a per-tx count map:

```ts
const unpaired = countWnativeEvents(logs);            // key = topic0:address:account:data (lowercased)
...
if (consumeWnativeEvent(unpaired, wnativeEventKey(DEPOSIT_TOPIC, log.address, toTopic, log.data))) continue;
```

Each `Deposit`/`Withdrawal` absolves at most one matching zero-address `Transfer`; the surplus is kept (and warned as a dedup miss as before).

Tests: bundle under/over-count → `ExternalServiceError` (not `SimulationRevertedError`); mixed-case Deposit pairing; 1 Deposit + 2 mints → 2 transfers; 1 Withdrawal + 2 burns → 2 transfers; 2 Deposits + 2 mints → 2 transfers, no warn. Changeset: patch.

Related: #1041 (SDKS-32/35), #1042 (SDKS-133/149).

Link to Devin session: https://app.devin.ai/sessions/47b25991531f4a0cb471fb6526302197
Open in Devin Desktop: https://app.devin.ai/desktop/session/47b25991531f4a0cb471fb6526302197?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->