### PR TITLE
fix: align runtime values with declared types and semantics (SDK-431, SDK-515, SDK-525, SDK-511)

### DIFF
--- a/.changeset/type-metadata-fidelity.md
+++ b/.changeset/type-metadata-fidelity.md
@@ -1,6 +1,6 @@
 ---
 "@morpho-org/blue-sdk": patch
-"@morpho-org/morpho-sdk": patch
+"@morpho-org/morpho-sdk": minor
 "@morpho-org/liquidity-sdk-viem": patch
 ---
 

--- a/.changeset/type-metadata-fidelity.md
+++ b/.changeset/type-metadata-fidelity.md
@@ -1,0 +1,12 @@
+---
+"@morpho-org/blue-sdk": patch
+"@morpho-org/morpho-sdk": patch
+"@morpho-org/liquidity-sdk-viem": patch
+---
+
+Make runtime values match their declared types and semantics:
+
+- `ConstantWrappedToken` now honours the requested `RoundingDirection` in `_wrap`/`_unwrap` (previously always rounded down, so `"Up"` conversions between tokens with different decimals could under-quote by one unit).
+- `PreLiquidationPosition.marketId` now equals `position.market.id` (the underlying Blue market) instead of the id of the internal pre-LLTV-substituted market; pre-liquidation health math is unchanged.
+- Vault V1/V2 `withdraw`/`redeem` action metadata (`transaction.action.args`) now includes `onBehalf`, which was already encoded in calldata.
+- `LiquidityLoader` converts the API's `targetBorrowUtilization` string to `bigint`, matching its declared return type.

--- a/packages/blue-sdk/src/position/PreLiquidationPosition.test.ts
+++ b/packages/blue-sdk/src/position/PreLiquidationPosition.test.ts
@@ -142,6 +142,18 @@ describe("PreLiquidationPosition", () => {
     expect(position.market.params.lltv).toBe(market().params.lltv);
   });
 
+  test("behavior: marketId is the base market id, before and after accrual", () => {
+    const position = preLiquidationPosition();
+    const baseId = market().id;
+
+    expect(position.marketId).toBe(baseId);
+    expect(position.marketId).toBe(position.market.id);
+
+    const accrued = position.accrueInterest(market().lastUpdate + 3600n);
+    expect(accrued.marketId).toBe(baseId);
+    expect(accrued.market.id).toBe(baseId);
+  });
+
   test("price-dependent states are undefined when the pre-liquidation oracle price is missing", () => {
     const position = preLiquidationPosition({
       preLiquidationOraclePrice: undefined,

--- a/packages/blue-sdk/src/position/PreLiquidationPosition.ts
+++ b/packages/blue-sdk/src/position/PreLiquidationPosition.ts
@@ -2,7 +2,7 @@ import type { Address } from "viem";
 import { ORACLE_PRICE_SCALE } from "../constants.js";
 import { type IMarket, Market } from "../market/index.js";
 import { MathLib, SharesMath } from "../math/index.js";
-import type { BigIntish } from "../types.js";
+import type { BigIntish, MarketId } from "../types.js";
 import { AccrualPosition, type IAccrualPosition } from "./Position.js";
 
 /** Plain input shape for PreLiquidation contract parameters. */
@@ -78,6 +78,8 @@ export class PreLiquidationPosition
   public readonly preLiquidationParams: PreLiquidationParams;
   public readonly preLiquidation;
   public readonly preLiquidationOraclePrice?: bigint;
+  /** The id of the underlying Blue market (not of the pre-LLTV-substituted market used for health math). */
+  public override readonly marketId: MarketId;
 
   protected readonly _baseMarket: Market;
 
@@ -102,13 +104,14 @@ export class PreLiquidationPosition
           : undefined,
     });
 
+    this._baseMarket = new Market(market);
+    this.marketId = this._baseMarket.id;
+
     this.preLiquidationParams = new PreLiquidationParams(preLiquidationParams);
     this.preLiquidation = preLiquidation;
 
     if (preLiquidationOraclePrice != null)
       this.preLiquidationOraclePrice = BigInt(preLiquidationOraclePrice);
-
-    this._baseMarket = new Market(market);
   }
 
   get market() {

--- a/packages/blue-sdk/src/token/ConstantWrappedToken.test.ts
+++ b/packages/blue-sdk/src/token/ConstantWrappedToken.test.ts
@@ -46,6 +46,31 @@ describe("ConstantWrappedToken", () => {
     );
   });
 
+  test("behavior: honours the rounding direction on inexact conversions", () => {
+    const t = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 6 },
+      UNDERLYING,
+      18,
+    );
+    // 1.5e12 underlying wei = 1.5 wrapped units
+    const amount = 1_500_000_000_000n;
+
+    expect(t.toWrappedExactAmountIn(amount)).toBe(1n);
+    expect(t.toWrappedExactAmountIn(amount, 0n, "Up")).toBe(2n);
+    expect(t.toUnwrappedExactAmountOut(amount)).toBe(2n);
+    expect(t.toUnwrappedExactAmountOut(amount, 0n, "Down")).toBe(1n);
+
+    const inverse = new ConstantWrappedToken(
+      { address: WRAPPED, decimals: 18 },
+      UNDERLYING,
+      6,
+    );
+    expect(inverse.toUnwrappedExactAmountIn(amount)).toBe(1n);
+    expect(inverse.toUnwrappedExactAmountIn(amount, 0n, "Up")).toBe(2n);
+    expect(inverse.toWrappedExactAmountOut(amount)).toBe(2n);
+    expect(inverse.toWrappedExactAmountOut(amount, 0n, "Down")).toBe(1n);
+  });
+
   test("ignores slippage parameter (always treats as 0)", () => {
     const t = new ConstantWrappedToken(
       { address: WRAPPED, decimals: 18 },

--- a/packages/blue-sdk/src/token/ConstantWrappedToken.ts
+++ b/packages/blue-sdk/src/token/ConstantWrappedToken.ts
@@ -58,19 +58,21 @@ export class ConstantWrappedToken extends WrappedToken {
     return super.toUnwrappedExactAmountOut(unwrappedAmount, 0n, rounding);
   }
 
-  protected _wrap(amount: bigint) {
-    return MathLib.mulDivDown(
+  protected _wrap(amount: bigint, rounding: RoundingDirection) {
+    return MathLib.mulDiv(
       amount,
       10n ** BigInt(this.decimals),
       10n ** this.underlyingDecimals,
+      rounding,
     );
   }
 
-  protected _unwrap(amount: bigint) {
-    return MathLib.mulDivDown(
+  protected _unwrap(amount: bigint, rounding: RoundingDirection) {
+    return MathLib.mulDiv(
       amount,
       10n ** this.underlyingDecimals,
       10n ** BigInt(this.decimals),
+      rounding,
     );
   }
 }

--- a/packages/liquidity-sdk-viem/src/loader.test.ts
+++ b/packages/liquidity-sdk-viem/src/loader.test.ts
@@ -622,6 +622,7 @@ describe.sequential("LiquidityLoader.fetch", () => {
     expect(first.withdrawals).toStrictEqual([
       { id: sourceMarketId, vault, assets: 100n },
     ]);
+    expect(first.targetBorrowUtilization).toBe(900000000000000000n);
     expect(second.withdrawals).toStrictEqual([
       { id: sourceMarketId, vault, assets: 1000n },
     ]);

--- a/packages/liquidity-sdk-viem/src/loader.ts
+++ b/packages/liquidity-sdk-viem/src/loader.ts
@@ -197,7 +197,7 @@ export class LiquidityLoader<chain extends Chain = Chain> {
               startState,
               endState,
               withdrawals,
-              targetBorrowUtilization,
+              targetBorrowUtilization: BigInt(targetBorrowUtilization),
             };
           } catch (error) {
             return Error(

--- a/packages/morpho-sdk/src/actions/vaultV1/redeem.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/redeem.test.ts
@@ -30,6 +30,7 @@ describe("redeemVaultV1 unit tests", () => {
     expect(tx.action.args.vault).toBe(SteakhouseUsdcVaultV1.address);
     expect(tx.action.args.shares).toBe(shares);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(client.account.address);
     expect(tx.to).toBe(SteakhouseUsdcVaultV1.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);
@@ -47,7 +48,7 @@ describe("redeemVaultV1 unit tests", () => {
       args: {
         shares,
         recipient: client.account.address,
-        onBehalf: client.account.address,
+        onBehalf: "0x000000000000000000000000000000000000dEaD",
       },
     });
 
@@ -56,6 +57,9 @@ describe("redeemVaultV1 unit tests", () => {
     expect(tx.action.args.vault).toBe(GauntletWethVaultV1.address);
     expect(tx.action.args.shares).toBe(shares);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(
+      "0x000000000000000000000000000000000000dEaD",
+    );
     expect(tx.to).toBe(GauntletWethVaultV1.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);

--- a/packages/morpho-sdk/src/actions/vaultV1/redeem.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/redeem.ts
@@ -73,7 +73,7 @@ export const vaultV1Redeem = ({
     ...tx,
     action: {
       type: "vaultV1Redeem",
-      args: { vault: vaultAddress, shares, recipient },
+      args: { vault: vaultAddress, shares, recipient, onBehalf },
     },
   });
 };

--- a/packages/morpho-sdk/src/actions/vaultV1/withdraw.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/withdraw.test.ts
@@ -30,6 +30,7 @@ describe("withdrawVaultV1 unit tests", () => {
     expect(tx.action.args.vault).toBe(SteakhouseUsdcVaultV1.address);
     expect(tx.action.args.amount).toBe(amount);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(client.account.address);
     expect(tx.to).toBe(SteakhouseUsdcVaultV1.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);
@@ -47,7 +48,7 @@ describe("withdrawVaultV1 unit tests", () => {
       args: {
         amount,
         recipient: client.account.address,
-        onBehalf: client.account.address,
+        onBehalf: "0x000000000000000000000000000000000000dEaD",
       },
     });
 
@@ -56,6 +57,9 @@ describe("withdrawVaultV1 unit tests", () => {
     expect(tx.action.args.vault).toBe(GauntletWethVaultV1.address);
     expect(tx.action.args.amount).toBe(amount);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(
+      "0x000000000000000000000000000000000000dEaD",
+    );
     expect(tx.to).toBe(GauntletWethVaultV1.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);

--- a/packages/morpho-sdk/src/actions/vaultV1/withdraw.ts
+++ b/packages/morpho-sdk/src/actions/vaultV1/withdraw.ts
@@ -73,7 +73,7 @@ export const vaultV1Withdraw = ({
     ...tx,
     action: {
       type: "vaultV1Withdraw",
-      args: { vault: vaultAddress, amount, recipient },
+      args: { vault: vaultAddress, amount, recipient, onBehalf },
     },
   });
 };

--- a/packages/morpho-sdk/src/actions/vaultV2/redeem.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/redeem.test.ts
@@ -30,6 +30,7 @@ describe("redeemVaultV2 unit tests", () => {
     expect(tx.action.args.vault).toBe(KeyrockUsdcVaultV2.address);
     expect(tx.action.args.shares).toBe(shares);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(client.account.address);
     expect(tx.to).toBe(KeyrockUsdcVaultV2.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);
@@ -47,7 +48,7 @@ describe("redeemVaultV2 unit tests", () => {
       args: {
         shares,
         recipient: client.account.address,
-        onBehalf: client.account.address,
+        onBehalf: "0x000000000000000000000000000000000000dEaD",
       },
     });
 
@@ -56,6 +57,9 @@ describe("redeemVaultV2 unit tests", () => {
     expect(tx.action.args.vault).toBe(KpkWETHVaultV2.address);
     expect(tx.action.args.shares).toBe(shares);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(
+      "0x000000000000000000000000000000000000dEaD",
+    );
     expect(tx.to).toBe(KpkWETHVaultV2.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);

--- a/packages/morpho-sdk/src/actions/vaultV2/redeem.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/redeem.ts
@@ -74,7 +74,7 @@ export const vaultV2Redeem = ({
     ...tx,
     action: {
       type: "vaultV2Redeem",
-      args: { vault: vaultAddress, shares, recipient },
+      args: { vault: vaultAddress, shares, recipient, onBehalf },
     },
   });
 };

--- a/packages/morpho-sdk/src/actions/vaultV2/withdraw.test.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/withdraw.test.ts
@@ -30,6 +30,7 @@ describe("withdrawVaultV2 unit tests", () => {
     expect(tx.action.args.vault).toBe(KeyrockUsdcVaultV2.address);
     expect(tx.action.args.amount).toBe(amount);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(client.account.address);
     expect(tx.to).toBe(KeyrockUsdcVaultV2.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);
@@ -47,7 +48,7 @@ describe("withdrawVaultV2 unit tests", () => {
       args: {
         amount,
         recipient: client.account.address,
-        onBehalf: client.account.address,
+        onBehalf: "0x000000000000000000000000000000000000dEaD",
       },
     });
 
@@ -56,6 +57,9 @@ describe("withdrawVaultV2 unit tests", () => {
     expect(tx.action.args.vault).toBe(KpkWETHVaultV2.address);
     expect(tx.action.args.amount).toBe(amount);
     expect(tx.action.args.recipient).toBe(client.account.address);
+    expect(tx.action.args.onBehalf).toBe(
+      "0x000000000000000000000000000000000000dEaD",
+    );
     expect(tx.to).toBe(KpkWETHVaultV2.address);
     expect(tx.data).toBeDefined();
     expect(tx.value).toBe(0n);

--- a/packages/morpho-sdk/src/actions/vaultV2/withdraw.ts
+++ b/packages/morpho-sdk/src/actions/vaultV2/withdraw.ts
@@ -74,7 +74,7 @@ export const vaultV2Withdraw = ({
     ...tx,
     action: {
       type: "vaultV2Withdraw",
-      args: { vault: vaultAddress, amount, recipient },
+      args: { vault: vaultAddress, amount, recipient, onBehalf },
     },
   });
 };

--- a/packages/morpho-sdk/src/types/action.ts
+++ b/packages/morpho-sdk/src/types/action.ts
@@ -40,6 +40,7 @@ export interface VaultV2WithdrawAction
       vault: Address;
       amount: bigint;
       recipient: Address;
+      onBehalf: Address;
     }
   > {}
 
@@ -50,6 +51,7 @@ export interface VaultV2RedeemAction
       vault: Address;
       shares: bigint;
       recipient: Address;
+      onBehalf: Address;
     }
   > {}
 
@@ -108,6 +110,7 @@ export interface VaultV1WithdrawAction
       vault: Address;
       amount: bigint;
       recipient: Address;
+      onBehalf: Address;
     }
   > {}
 
@@ -118,6 +121,7 @@ export interface VaultV1RedeemAction
       vault: Address;
       shares: bigint;
       recipient: Address;
+      onBehalf: Address;
     }
   > {}
 


### PR DESCRIPTION
## Summary

Four Cantina AI Audit #2 low findings sharing one root cause: a runtime value did not match what its type or accessor promised. All fixes are local, no calldata or public signature changes.

- **SDK-431 `ConstantWrappedToken`** — `_wrap`/`_unwrap` ignored the inherited `rounding` argument and always used `mulDivDown`, so `toWrappedExactAmountIn(x, 0n, "Up")` / `toUnwrappedExactAmountOut(...)` (default `"Up"`) could under-quote by one unit when wrapped/underlying decimals differ. Now `MathLib.mulDiv(..., rounding)`. Equal-decimal tokens (the common case) are unaffected since the division is exact.
- **SDK-515 `PreLiquidationPosition.marketId`** — `AccrualPosition` derived `marketId` from the pre-LLTV-substituted market it receives for health math, so `position.marketId !== position.market.id`. The subclass now overrides `marketId` with `_baseMarket.id`; the substituted market is still what drives `isHealthy`/`seizableCollateral`. `accrueInterest()` re-spreads the position so the id survives accrual (tested).
- **SDK-525 vault `withdraw`/`redeem` metadata** — `onBehalf` was in calldata but missing from `transaction.action.args` for `vaultV1Withdraw|Redeem` and `vaultV2Withdraw|Redeem`. Added to the four `*Action` interfaces (`onBehalf: Address`) and builders.
- **SDK-511 `LiquidityLoader`** — `targetBorrowUtilization` is declared `bigint` but the GraphQL client returns the scalar as a string; now `BigInt(...)` at the loader boundary.

Changeset: patch for `blue-sdk`, `morpho-sdk`, `liquidity-sdk-viem`.


Link to Devin session: https://app.devin.ai/sessions/47b25991531f4a0cb471fb6526302197
Open in Devin Desktop: https://app.devin.ai/desktop/session/47b25991531f4a0cb471fb6526302197?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->