### PR TITLE
fix(blue-sdk): floor totalBorrowAssets at zero in Market.repay (SDK-480)

### DIFF
--- a/.changeset/floor-repay-borrow-assets.md
+++ b/.changeset/floor-repay-borrow-assets.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk": patch
+---
+
+Floor `totalBorrowAssets` at zero in `Market.repay` when a full-share repayment rounds borrow assets up above the market total, instead of throwing a `bigint` underflow. Mirrors the protocol's `zeroFloorSub` accounting.

--- a/.changeset/floor-repay-borrow-assets.md
+++ b/.changeset/floor-repay-borrow-assets.md
@@ -1,5 +1,6 @@
 ---
 "@morpho-org/blue-sdk": patch
+"@morpho-org/morpho-sdk": patch
 ---
 
 Floor `totalBorrowAssets` at zero in `Market.repay` when a full-share repayment rounds borrow assets up above the market total, instead of throwing a `bigint` underflow. Mirrors the protocol's `zeroFloorSub` accounting.

--- a/packages/blue-sdk/src/market/Market.test.ts
+++ b/packages/blue-sdk/src/market/Market.test.ts
@@ -149,6 +149,24 @@ describe("Market accrueInterest and accounting actions", () => {
     expect(m.repay(100n, 0n).assets).toBe(100n);
     expect(m.repay(0n, 100n).shares).toBe(100n);
   });
+
+  test("repay floors total borrow assets at zero when rounded-up assets exceed the total", () => {
+    const m = market({
+      totalBorrowAssets: 1n,
+      totalBorrowShares: 3_000_000n,
+    });
+
+    const {
+      market: repaid,
+      assets,
+      shares,
+    } = m.repay(0n, 3_000_000n, m.lastUpdate);
+
+    expect(assets).toBe(2n);
+    expect(shares).toBe(3_000_000n);
+    expect(repaid.totalBorrowAssets).toBe(0n);
+    expect(repaid.totalBorrowShares).toBe(0n);
+  });
 });
 
 describe("Market conversion and risk delegation", () => {

--- a/packages/blue-sdk/src/market/Market.ts
+++ b/packages/blue-sdk/src/market/Market.ts
@@ -435,7 +435,11 @@ export class Market implements IMarket {
     // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
     else assets = market.toBorrowAssets(shares, "Up");
 
-    market.totalBorrowAssets -= assets;
+    // Mirrors Morpho.repay: repaid assets rounded up can exceed the market total.
+    market.totalBorrowAssets = MathLib.zeroFloorSub(
+      market.totalBorrowAssets,
+      assets,
+    );
     market.totalBorrowShares -= shares;
 
     return { market, assets, shares };

--- a/packages/blue-sdk/src/market/Market.ts
+++ b/packages/blue-sdk/src/market/Market.ts
@@ -423,6 +423,21 @@ export class Market implements IMarket {
     return { market, assets, shares };
   }
 
+  /**
+   * Simulates a repayment on this market and returns the resulting market state.
+   * Exactly one of `assets` or `shares` must be non-zero.
+   * When repaying by shares, the repaid `assets` are rounded up and may exceed
+   * `totalBorrowAssets`; the market total is then floored at zero, mirroring `Morpho.repay`.
+   * @param assets The amount of loan assets to repay (`0n` when repaying by shares).
+   * @param shares The amount of borrow shares to repay (`0n` when repaying by assets).
+   * @param timestamp The timestamp at which to accrue interest before repaying. Defaults to now.
+   * @returns The accrued market after repayment, along with the resolved `assets` and `shares` repaid.
+   * @throws {BlueErrors.InconsistentInput} If both or neither of `assets` and `shares` are non-zero.
+   * @example
+   * ```ts
+   * const { market: after, assets } = market.repay(0n, position.borrowShares);
+   * ```
+   */
   // biome-ignore lint/complexity/useMaxParams: TODO refactor to ≤2 params
   public repay(assets: bigint, shares: bigint, timestamp?: BigIntish) {
     if ((assets === 0n) === (shares === 0n))
@@ -435,7 +450,6 @@ export class Market implements IMarket {
     // biome-ignore lint/style/noParameterAssign: TODO refactor to avoid mutating parameter
     else assets = market.toBorrowAssets(shares, "Up");
 
-    // Mirrors Morpho.repay: repaid assets rounded up can exceed the market total.
     market.totalBorrowAssets = MathLib.zeroFloorSub(
       market.totalBorrowAssets,
       assets,


### PR DESCRIPTION
## Summary

Cantina finding SDKS-197 / [SDK-480](https://linear.app/morpho-labs/issue/SDK-480).

`Market.repay(0n, shares)` converts shares with `toBorrowAssets(shares, "Up")`. When the rounded-up asset amount exceeds `totalBorrowAssets` (e.g. a full-share repayment on a market whose borrow assets are smaller than the rounded-up value), `market.totalBorrowAssets -= assets` produced a negative `bigint`, so the simulated market carried an invalid accounting state.

```diff
- market.totalBorrowAssets -= assets;
+ market.totalBorrowAssets = MathLib.zeroFloorSub(market.totalBorrowAssets, assets);
  market.totalBorrowShares -= shares;
```

This mirrors Morpho Blue's `repay`, which uses `zeroFloorSub` on `totalBorrowAssets`. The returned `assets` value is unchanged (still the rounded-up amount the user actually pays).

Includes a regression test (`totalBorrowAssets: 1n`, repay all shares → `assets == 2n`, `totalBorrowAssets == 0n`) and a patch changeset for `@morpho-org/blue-sdk`.

Link to Devin session: https://app.devin.ai/sessions/a7efbe77489148b7a9becd86d5f15ae7
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7efbe77489148b7a9becd86d5f15ae7?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->