### PR TITLE
fix(midnight-sdk): validate settlement fee for unit-capped offers in getConsumableUnits (SDK-436)

### DIFF
--- a/.changeset/consumable-units-fee-check.md
+++ b/.changeset/consumable-units-fee-check.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/midnight-sdk": patch
+---
+
+`OfferUtils.getConsumableUnits` now validates the settlement fee against the offer price before returning unit-capped capacity, so a unit-capped buy offer whose fee exceeds its price throws `SettlementFeeExceedsPriceError` instead of being reported as consumable.

--- a/.changeset/consumable-units-fee-check.md
+++ b/.changeset/consumable-units-fee-check.md
@@ -1,5 +1,6 @@
 ---
 "@morpho-org/midnight-sdk": patch
+"@morpho-org/morpho-sdk": patch
 ---
 
 `OfferUtils.getConsumableUnits` now validates the settlement fee against the offer price before returning unit-capped capacity, so a unit-capped buy offer whose fee exceeds its price throws `SettlementFeeExceedsPriceError` instead of being reported as consumable.

--- a/packages/midnight-sdk/src/offers/OfferUtils.test.ts
+++ b/packages/midnight-sdk/src/offers/OfferUtils.test.ts
@@ -563,6 +563,24 @@ describe("OfferUtils.getConsumableUnits", () => {
       }),
     ).toThrow(SettlementFeeExceedsPriceError);
   });
+
+  test("error: SettlementFeeExceedsPriceError for unit-capped buy offer", () => {
+    expect(() =>
+      OfferUtils.getConsumableUnits({
+        offer: baseOffer({
+          market: zeroFeeMarket({
+            settlementFeeCbps: [1, 1, 1, 1, 1, 1, 1],
+          }),
+          buy: true,
+          tick: 0n,
+          maxUnits: 100n,
+          maxAssets: 0n,
+        }),
+        consumed: 0n,
+        timestamp: 1_000n,
+      }),
+    ).toThrow(SettlementFeeExceedsPriceError);
+  });
 });
 
 describe("OfferUtils.validateOfferGroup", () => {

--- a/packages/midnight-sdk/src/offers/OfferUtils.ts
+++ b/packages/midnight-sdk/src/offers/OfferUtils.ts
@@ -1020,26 +1020,24 @@ export namespace OfferUtils {
     const market = Market.from(offer.market);
     if (timestamp < start || timestamp > expiry) return 0n;
     if (continuousFeeCap < BigInt(market.continuousFee)) return 0n;
-    if (maxUnits > 0n) return MathLib.zeroFloorSub(maxUnits, consumed);
 
-    const remainingAssets = MathLib.zeroFloorSub(maxAssets, consumed);
     const settlementFee = market.getSettlementFee(
       market.timeToMaturity(timestamp),
     );
+    // Validates the settlement fee against the offer price for both cap modes.
+    const { sellerPrice, buyerPrice } = TakeAmountsLib.prices({
+      offer,
+      settlementFee,
+    });
+    if (maxUnits > 0n) return MathLib.zeroFloorSub(maxUnits, consumed);
+
+    const remainingAssets = MathLib.zeroFloorSub(maxAssets, consumed);
     if (!offer.buy) {
-      const { sellerPrice } = TakeAmountsLib.prices({
-        offer,
-        settlementFee,
-      });
       if (sellerPrice === 0n) return MathLib.MAX_UINT_256;
 
       return MathLib.mulDivDown(remainingAssets, MathLib.WAD, sellerPrice);
     }
 
-    const { buyerPrice } = TakeAmountsLib.prices({
-      offer,
-      settlementFee,
-    });
     if (buyerPrice === 0n) return MathLib.MAX_UINT_256;
 
     return ((remainingAssets + 1n) * MathLib.WAD - 1n) / buyerPrice;


### PR DESCRIPTION
## Summary

Cantina finding SDKS-153 / [SDK-436](https://linear.app/morpho-labs/issue/SDK-436).

`OfferUtils.getConsumableUnits` returned early for unit-capped offers (`maxUnits > 0n`) *before* computing the settlement fee, so a buy offer whose settlement fee exceeds its price was reported as consumable when unit-capped, but threw `SettlementFeeExceedsPriceError` when asset-capped. Takeability now depends only on the offer's economics, not on which cap it uses:

```diff
  export function getConsumableUnits({ offer, consumed, timestamp }) {
    const { market, maxUnits, maxAssets } = offer;
-   if (maxUnits > 0n) return MathLib.zeroFloorSub(maxUnits, consumed);
    const settlementFee = market.getSettlementFee(market.timeToMaturity(timestamp));
    const { sellerPrice, buyerPrice } = TakeAmountsLib.prices({ offer, settlementFee });
+   if (maxUnits > 0n) return MathLib.zeroFloorSub(maxUnits, consumed);
    ...asset-capped path unchanged
  }
```

Adds a regression test for the unit-capped buy-offer case and a patch changeset for `@morpho-org/midnight-sdk`.

Link to Devin session: https://app.devin.ai/sessions/a7efbe77489148b7a9becd86d5f15ae7
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7efbe77489148b7a9becd86d5f15ae7?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->