### PR TITLE
fix(evm-simulation): map ExecutionRevertedError to SimulationRevertedError (SDK-453)

### DIFF
--- a/.changeset/simulate-v1-execution-reverted.md
+++ b/.changeset/simulate-v1-execution-reverted.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/evm-simulation": patch
+---
+
+Map a node-level viem `ExecutionRevertedError` thrown by `eth_simulateV1` to `SimulationRevertedError` instead of `ExternalServiceError`, so a reverting bundle is never classified as a fallback-eligible service failure.

--- a/packages/evm-simulation/src/errors.test.ts
+++ b/packages/evm-simulation/src/errors.test.ts
@@ -68,6 +68,14 @@ describe("SimulationRevertedError", () => {
   it("attaches optional details payload", () => {
     const err = new SimulationRevertedError("x", { raw: "tenderly response" });
     expect(err.details).toEqual({ raw: "tenderly response" });
+    expect(err.cause).toBeUndefined();
+  });
+
+  it("forwards an Error details payload as cause", () => {
+    const cause = new Error("execution reverted");
+    const err = new SimulationRevertedError("x", cause);
+    expect(err.details).toBe(cause);
+    expect(err.cause).toBe(cause);
   });
 });
 

--- a/packages/evm-simulation/src/errors.ts
+++ b/packages/evm-simulation/src/errors.ts
@@ -20,7 +20,10 @@ export class SimulationRevertedError extends SimulationPackageError {
     public readonly reason: string | undefined,
     public readonly details?: unknown,
   ) {
-    super(reason ?? "Transaction simulation reverted");
+    super(
+      reason ?? "Transaction simulation reverted",
+      details instanceof Error ? { cause: details } : undefined,
+    );
   }
 }
 

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.test.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.test.ts
@@ -324,6 +324,7 @@ describe.sequential("simulateV1", () => {
     expect(error).toBeInstanceOf(SimulationRevertedError);
     expect(error).not.toBeInstanceOf(ExternalServiceError);
     expect((error as SimulationRevertedError).details).toBe(cause);
+    expect((error as SimulationRevertedError).cause).toBe(cause);
   });
 
   it("throws ExternalServiceError when results is not an array", async () => {

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.test.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.test.ts
@@ -1,5 +1,6 @@
 import {
   type Address,
+  ExecutionRevertedError,
   ethAddress,
   type Hex,
   maxUint256,
@@ -306,6 +307,23 @@ describe.sequential("simulateV1", () => {
         transactions: [BASIC_TX],
       }),
     ).rejects.toThrow(SimulationRevertedError);
+  });
+
+  it("maps a node-level ExecutionRevertedError to SimulationRevertedError", async () => {
+    const cause = new ExecutionRevertedError({
+      message: "execution reverted: insufficient collateral",
+    });
+    mockSimulateCalls.mockRejectedValueOnce(cause);
+
+    const error = await simulateV1({
+      rpcUrl: "http://rpc.local",
+      chainId: 1,
+      transactions: [BASIC_TX],
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(SimulationRevertedError);
+    expect(error).not.toBeInstanceOf(ExternalServiceError);
+    expect((error as SimulationRevertedError).details).toBe(cause);
   });
 
   it("throws ExternalServiceError when results is not an array", async () => {

--- a/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
+++ b/packages/evm-simulation/src/simulate/backends/eth-simulate-v1.ts
@@ -2,6 +2,7 @@ import {
   type Address,
   type BlockTag,
   createPublicClient,
+  ExecutionRevertedError,
   getAddress,
   http,
   maxUint256,
@@ -136,6 +137,9 @@ export async function simulateV1(params: {
   } catch (error) {
     if (error instanceof SimulationRevertedError) throw error;
     if (error instanceof ExternalServiceError) throw error;
+    // A node-level "execution reverted" is a property of the bundle, not the backend.
+    if (error instanceof ExecutionRevertedError)
+      throw new SimulationRevertedError(error.shortMessage, error);
     throw new ExternalServiceError(
       `eth_simulateV1 error: ${error instanceof Error ? error.message : String(error)}`,
       { cause: error },


### PR DESCRIPTION
## Summary

Cantina finding SDKS-170 / [SDK-453](https://linear.app/morpho-labs/issue/SDK-453).

Some nodes answer `eth_simulateV1` with a top-level JSON-RPC `execution reverted` error instead of a per-call `status: 0x0` result. viem surfaces that as `ExecutionRevertedError`, which fell through the generic `catch` in `simulateV1` and was wrapped as `ExternalServiceError` — the class the pipeline treats as a fallback-eligible backend failure. A reverting bundle must never be classified that way.

```diff
  } catch (error) {
    if (error instanceof SimulationRevertedError) throw error;
    if (error instanceof ExternalServiceError) throw error;
+   if (error instanceof ExecutionRevertedError)
+     throw new SimulationRevertedError(error.shortMessage, error);
    throw new ExternalServiceError(`eth_simulateV1 error: ...`, { cause: error });
  }
```

Transport/HTTP/schema failures keep the existing `ExternalServiceError` classification. Adds a unit test asserting the mapping (and that the result is not an `ExternalServiceError`) plus a patch changeset for `@morpho-org/evm-simulation`.

Link to Devin session: https://app.devin.ai/sessions/a7efbe77489148b7a9becd86d5f15ae7
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7efbe77489148b7a9becd86d5f15ae7?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->