### PR TITLE
fix(blue-sdk-viem): rethrow failed lostAssets read for V1.1 vaults in fetchVault fallback (SDK-477)

### DIFF
--- a/.changeset/vault-fallback-lost-assets.md
+++ b/.changeset/vault-fallback-lost-assets.md
@@ -1,5 +1,6 @@
 ---
 "@morpho-org/blue-sdk-viem": patch
+"@morpho-org/morpho-sdk": patch
 ---
 
 `fetchVault` multicall fallback no longer silently drops `lostAssets` when the read fails on a MetaMorpho V1.1 vault: the read error is rethrown once the vault is confirmed V1.1. V1.0 vaults keep `lostAssets: undefined`.

--- a/.changeset/vault-fallback-lost-assets.md
+++ b/.changeset/vault-fallback-lost-assets.md
@@ -1,0 +1,5 @@
+---
+"@morpho-org/blue-sdk-viem": patch
+---
+
+`fetchVault` multicall fallback no longer silently drops `lostAssets` when the read fails on a MetaMorpho V1.1 vault: the read error is rethrown once the vault is confirmed V1.1. V1.0 vaults keep `lostAssets: undefined`.

--- a/packages/blue-sdk-viem/src/fetch/Vault.ts
+++ b/packages/blue-sdk-viem/src/fetch/Vault.ts
@@ -22,6 +22,9 @@ import type { DeploylessFetchParameters } from "../types.js";
 import { fetchVaultConfig } from "./VaultConfig.js";
 import { fetchVaultMarketAllocation } from "./VaultMarketAllocation.js";
 
+/** Settled `lostAssets()` read, kept until the vault version is known. */
+type LostAssetsRead = { value: bigint } | { error: unknown };
+
 /**
  * Fetches MetaMorpho vault state, accounting, queues, and public allocator config.
  *
@@ -148,7 +151,7 @@ export async function fetchVault(
     totalSupply,
     totalAssets,
     lastTotalAssets,
-    lostAssets,
+    lostAssetsRead,
     supplyQueueSize,
     withdrawQueueSize,
     hasPublicAllocator,
@@ -238,7 +241,10 @@ export async function fetchVault(
       address,
       abi: metaMorphoAbi,
       functionName: "lostAssets",
-    }).catch(() => undefined),
+    }).then(
+      (value): LostAssetsRead => ({ value }),
+      (error: unknown): LostAssetsRead => ({ error }),
+    ),
     readContract(client, {
       ...parameters,
       address,
@@ -346,6 +352,12 @@ export async function fetchVault(
   if (!isMetaMorpho) {
     throw new UnknownOfFactory(metaMorphoFactory, address);
   }
+
+  // `lostAssets` only exists on MetaMorpho V1.1: a failed read is expected on V1.0
+  // but must not silently downgrade a V1.1 vault to V1.0 accounting.
+  if (isMetaMorphoV1_1 && "error" in lostAssetsRead) throw lostAssetsRead.error;
+  const lostAssets =
+    "value" in lostAssetsRead ? lostAssetsRead.value : undefined;
 
   return new Vault({
     ...config,

--- a/packages/blue-sdk-viem/src/fetch/fetch.test.ts
+++ b/packages/blue-sdk-viem/src/fetch/fetch.test.ts
@@ -28,6 +28,7 @@ import {
 import { createMockClient, mockRead } from "@morpho-org/test/mock";
 import {
   type Address,
+  ContractFunctionExecutionError,
   erc20Abi,
   erc20Abi_bytes32,
   maxUint256,
@@ -1688,6 +1689,127 @@ describe("vault fetchers", () => {
     await expect(
       fetchVault(VAULT, handle.client, { chainId: CHAIN_ID }),
     ).rejects.toThrow(UnknownOfFactory);
+  });
+
+  test("fetchVault rethrows a failed lostAssets read on a MetaMorpho V1.1 vault", async () => {
+    const handle = createMockClient(mainnet);
+    mockDeploylessReads(handle, ["0x"]);
+    mockVaultConfigReads(handle);
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "curator",
+      result: RECIPIENT,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "owner",
+      result: USER,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "guardian",
+      result: COLLATERAL,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "timelock",
+      result: 1n,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "pendingTimelock",
+      result: [1n, 2n],
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "pendingGuardian",
+      result: [ORACLE, 3n],
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "pendingOwner",
+      result: TOKEN,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "fee",
+      result: 1n,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "feeRecipient",
+      result: USER,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "skimRecipient",
+      result: RECIPIENT,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "totalSupply",
+      result: 1n,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "totalAssets",
+      result: 1n,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "lastTotalAssets",
+      result: 1n,
+    });
+    mockReadFailure(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "lostAssets",
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "supplyQueueLength",
+      result: 0n,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "withdrawQueueLength",
+      result: 0n,
+    });
+    mockRead(handle, {
+      address: VAULT,
+      abi: metaMorphoAbi,
+      functionName: "isAllocator",
+      result: false,
+    });
+    mockRead(handle, {
+      address: ADDRESSES.metaMorphoFactory,
+      abi: metaMorphoFactoryIsMetaMorphoAbi,
+      functionName: "isMetaMorpho",
+      result: true,
+    });
+
+    const error = await fetchVault(VAULT, handle.client, {
+      chainId: CHAIN_ID,
+      deployless: false,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ContractFunctionExecutionError);
+    expect(error).not.toBeInstanceOf(UnknownOfFactory);
   });
 
   test("fetchVaultMarketAllocation composes market config and accrual position", async () => {


### PR DESCRIPTION
## Summary

Cantina finding SDKS-194 / [SDK-477](https://linear.app/morpho-labs/issue/SDK-477).

In the multicall fallback of `fetchVault`, the `lostAssets()` read was issued with `.catch(() => undefined)` *before* the vault's version was known. That tolerance exists for MetaMorpho V1.0 (no `lostAssets()`), but it also swallowed transient RPC / pinned-block read errors on V1.1 vaults, silently returning a V1.1 vault with `lostAssets: undefined` — i.e. V1.0 accounting on a V1.1 vault.

The read is now settled into `{ value } | { error }` and resolved after factory detection:

```ts
if (isMetaMorphoV1_1 && "error" in lostAssetsRead) throw lostAssetsRead.error;
const lostAssets = "value" in lostAssetsRead ? lostAssetsRead.value : undefined;
```

So V1.1 vaults propagate the original viem error, V1.0 vaults keep `lostAssets: undefined`, and unknown vaults still throw `UnknownOfFactory` first. The deployless path was already correct (`hasLostAssets` is computed onchain).

Adds a mock-transport unit test (V1.1 factory membership + failing `lostAssets` → `ContractFunctionExecutionError`) and a patch changeset for `@morpho-org/blue-sdk-viem`.

Link to Devin session: https://app.devin.ai/sessions/a7efbe77489148b7a9becd86d5f15ae7
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7efbe77489148b7a9becd86d5f15ae7?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->