### PR TITLE
fix(midnight-sdk): validate rounded quote settlement

### DIFF
--- a/.changeset/quiet-books-settle.md
+++ b/.changeset/quiet-books-settle.md
@@ -1,0 +1,6 @@
+---
+"@morpho-org/midnight-sdk": minor
+"@morpho-org/morpho-sdk": minor
+---
+
+Compute Midnight quote guards from rounded per-fill settlement amounts and an optional current settlement fee so returned offers cannot imply a worse aggregate price than the requested guard.

--- a/packages/midnight-sdk/src/api/MidnightApi.test.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.test.ts
@@ -1076,6 +1076,30 @@ describe("MidnightApi.fetchBookQuote", () => {
     ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
   });
 
+  test("error: bid quote guards include per-fill settlement rounding", async () => {
+    const smallTake = {
+      ...apiBidTakeableOffer,
+      units: "1",
+    };
+    const secondSmallTake = {
+      ...smallTake,
+      offer: { ...smallTake.offer, maker: SECOND_MAKER },
+    };
+    const sellerPrice = TickLib.tickToPrice(smallTake.offer.tick);
+    const { fetch } = createQuoteFetch([smallTake, secondSmallTake]);
+
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "bids",
+        units: 2n,
+        averageWorstPrice: sellerPrice,
+        settlementFee: 0n,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
+  });
+
   test("error: asset quote guards include settlement-only asks", async () => {
     const settlementOnlyTake = {
       ...apiTakeableOffer,

--- a/packages/midnight-sdk/src/api/MidnightApi.test.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.test.ts
@@ -1,7 +1,12 @@
 import packageJson from "@morpho-org/midnight-sdk/package.json" with {
   type: "json",
 };
-import { ChainId, getChainAddress, MathLib } from "@morpho-org/morpho-ts";
+import {
+  ChainId,
+  getChainAddress,
+  MathLib,
+  NegativeValueError,
+} from "@morpho-org/morpho-ts";
 import { type Hex, maxUint256 } from "viem";
 import { describe, expect, test } from "vitest";
 
@@ -9,6 +14,7 @@ import { createFixtures } from "../__test__/fixtures.js";
 import {
   InvalidMidnightApiResponseError,
   MidnightApiError,
+  SettlementFeeExceedsPriceError,
 } from "../errors.js";
 import { MarketUtils } from "../market/index.js";
 import { TickLib } from "../math/index.js";
@@ -242,6 +248,31 @@ const apiTakeableOffer = {
   offer: apiOffer,
   ratifier_data: "0x1234",
 };
+
+const apiBidTakeableOffer = {
+  ...apiTakeableOffer,
+  units: (2n * MathLib.WAD).toString(),
+  offer: {
+    ...apiOffer,
+    buy: true,
+    tick: 5_000,
+    receiver_if_maker_is_seller: ZERO_ADDRESS,
+  },
+};
+
+function createQuoteFetch(
+  takeableOffers: readonly (typeof apiTakeableOffer)[],
+) {
+  return createJsonFetch({
+    data: {
+      average_best_price: "0",
+      average_worst_price: "0",
+      available_assets: "0",
+      available_units: "0",
+      takeable_offers: takeableOffers,
+    },
+  });
+}
 
 const expectedTakeableOffer = {
   marketId: MARKET_ID,
@@ -1031,15 +1062,7 @@ describe("MidnightApi.fetchBookQuote", () => {
       offer: { ...smallTake.offer, maker: SECOND_MAKER },
     };
     const price = TickLib.tickToPrice(smallTake.offer.tick);
-    const { fetch } = createJsonFetch({
-      data: {
-        average_best_price: price.toString(),
-        average_worst_price: price.toString(),
-        available_assets: "2",
-        available_units: "2",
-        takeable_offers: [smallTake, secondSmallTake],
-      },
-    });
+    const { fetch } = createQuoteFetch([smallTake, secondSmallTake]);
 
     await expect(
       MidnightApi.fetchBookQuote({
@@ -1053,28 +1076,121 @@ describe("MidnightApi.fetchBookQuote", () => {
     ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
   });
 
-  test("error: quote guards include the current settlement fee", async () => {
-    const price = TickLib.tickToPrice(apiOffer.tick);
-    const { fetch } = createJsonFetch({
-      data: {
-        average_best_price: price.toString(),
-        average_worst_price: price.toString(),
-        available_assets: apiTakeableOffer.units,
-        available_units: apiTakeableOffer.units,
-        takeable_offers: [apiTakeableOffer],
-      },
-    });
+  test("error: asset quote guards include settlement-only asks", async () => {
+    const settlementOnlyTake = {
+      ...apiTakeableOffer,
+      units: MathLib.WAD.toString(),
+      offer: { ...apiOffer, tick: 0 },
+    };
+    const { fetch } = createQuoteFetch([settlementOnlyTake]);
 
     await expect(
       MidnightApi.fetchBookQuote({
         marketId: MARKET_ID,
         side: "asks",
-        units: apiTakeableOffer.units,
-        averageWorstPrice: price,
+        assets: 1n,
+        averageWorstPrice: 0n,
         settlementFee: 1n,
         fetch,
       }),
     ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
+  });
+
+  test("behavior: bid unit guards use the seller settlement price", async () => {
+    const price = TickLib.tickToPrice(apiBidTakeableOffer.offer.tick);
+    const settlementFee = 5_000000000000000n;
+    const sellerPrice = price - settlementFee;
+    const { fetch } = createQuoteFetch([apiBidTakeableOffer]);
+
+    await MidnightApi.fetchBookQuote({
+      marketId: MARKET_ID,
+      side: "bids",
+      units: MathLib.WAD,
+      averageWorstPrice: sellerPrice,
+      settlementFee,
+      fetch,
+    });
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "bids",
+        units: MathLib.WAD,
+        averageWorstPrice: sellerPrice + 1n,
+        settlementFee,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
+  });
+
+  test("error: bid asset guards include zero seller-price fills", async () => {
+    const buyerPrice = TickLib.tickToPrice(apiBidTakeableOffer.offer.tick);
+    const { fetch } = createQuoteFetch([apiBidTakeableOffer]);
+
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "bids",
+        assets: buyerPrice,
+        averageWorstPrice: 1n,
+        settlementFee: buyerPrice,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
+  });
+
+  test("error: asset guards include a final partial fill", async () => {
+    const firstTake = {
+      ...apiTakeableOffer,
+      units: MathLib.WAD.toString(),
+      offer: { ...apiOffer, tick: 3_000 },
+    };
+    const secondTake = {
+      ...firstTake,
+      offer: { ...firstTake.offer, maker: SECOND_MAKER, tick: 5_000 },
+    };
+    const { fetch } = createQuoteFetch([firstTake, secondTake]);
+
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "asks",
+        assets: 138_000000000000000n,
+        averageWorstPrice: 141_000000000000000n,
+        settlementFee: 5_000000000000000n,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
+  });
+
+  test("error: NegativeValueError", async () => {
+    const { calls, fetch } = createQuoteFetch([]);
+
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "asks",
+        units: 0n,
+        settlementFee: -1n,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(NegativeValueError);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("error: SettlementFeeExceedsPriceError", async () => {
+    const price = TickLib.tickToPrice(apiBidTakeableOffer.offer.tick);
+    const { fetch } = createQuoteFetch([apiBidTakeableOffer]);
+
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "bids",
+        units: MathLib.WAD,
+        averageWorstPrice: price,
+        settlementFee: price + 1n,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(SettlementFeeExceedsPriceError);
   });
 });
 

--- a/packages/midnight-sdk/src/api/MidnightApi.test.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.test.ts
@@ -76,6 +76,7 @@ const SECOND_MARKET_ID =
 const GROUP_ID =
   "0x000000000000000000000000000000000000000000000000000000000008b8f4";
 const MAKER = "0x7b093658BE7f90B63D7c359e8f408e503c2D9401";
+const SECOND_MAKER = "0x1111111111111111111111111111111111111111";
 const LOAN_TOKEN = "0xC9A9C45C0eB717f8b5F193Af6bAa05A1c0Ac5078";
 const SECOND_LOAN_TOKEN = "0x1111111111111111111111111111111111111111";
 const COLLATERAL_TOKEN = "0x34Cf890dB685FC536E05652FB41f02090c3fb751";
@@ -1015,6 +1016,62 @@ describe("MidnightApi.fetchBookQuote", () => {
         side: "asks",
         assets: requestedAssets,
         averageWorstPrice: firstPrice,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
+  });
+
+  test("error: quote guards include per-fill settlement rounding", async () => {
+    const smallTake = {
+      ...apiTakeableOffer,
+      units: "1",
+    };
+    const secondSmallTake = {
+      ...smallTake,
+      offer: { ...smallTake.offer, maker: SECOND_MAKER },
+    };
+    const price = TickLib.tickToPrice(smallTake.offer.tick);
+    const { fetch } = createJsonFetch({
+      data: {
+        average_best_price: price.toString(),
+        average_worst_price: price.toString(),
+        available_assets: "2",
+        available_units: "2",
+        takeable_offers: [smallTake, secondSmallTake],
+      },
+    });
+
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "asks",
+        assets: 2n,
+        averageWorstPrice: price,
+        settlementFee: 0n,
+        fetch,
+      }),
+    ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);
+  });
+
+  test("error: quote guards include the current settlement fee", async () => {
+    const price = TickLib.tickToPrice(apiOffer.tick);
+    const { fetch } = createJsonFetch({
+      data: {
+        average_best_price: price.toString(),
+        average_worst_price: price.toString(),
+        available_assets: apiTakeableOffer.units,
+        available_units: apiTakeableOffer.units,
+        takeable_offers: [apiTakeableOffer],
+      },
+    });
+
+    await expect(
+      MidnightApi.fetchBookQuote({
+        marketId: MARKET_ID,
+        side: "asks",
+        units: apiTakeableOffer.units,
+        averageWorstPrice: price,
+        settlementFee: 1n,
         fetch,
       }),
     ).rejects.toBeInstanceOf(InvalidMidnightApiResponseError);

--- a/packages/midnight-sdk/src/api/MidnightApi.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.ts
@@ -339,7 +339,7 @@ export class MidnightApi {
    * @returns Quote and signed ABI-ready take caps mapped from the API response.
    * @throws {NegativeValueError} when `settlementFee` is negative.
    * @throws {MidnightApiError} when the API returns a non-2xx response.
-   * @throws {InvalidMidnightApiResponseError} when the API success response is not JSON.
+   * @throws {InvalidMidnightApiResponseError} when the API returns a malformed success response or the returned offers imply a rounded aggregate settlement price outside the effective average-worst-price guard.
    * @throws {SettlementFeeExceedsPriceError} when a bid's settlement fee exceeds its offer price.
    * @example
    * ```ts
@@ -801,7 +801,7 @@ export class MidnightApi {
    * @returns Quote and signed ABI-ready take caps mapped from the API response.
    * @throws {NegativeValueError} when `settlementFee` is negative.
    * @throws {MidnightApiError} when the API returns a non-2xx response.
-   * @throws {InvalidMidnightApiResponseError} when the API success response is not JSON.
+   * @throws {InvalidMidnightApiResponseError} when the API returns a malformed success response or the returned offers imply a rounded aggregate settlement price outside the effective average-worst-price guard.
    * @throws {SettlementFeeExceedsPriceError} when a bid's settlement fee exceeds its offer price.
    * @example
    * ```ts

--- a/packages/midnight-sdk/src/api/MidnightApi.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.ts
@@ -1,4 +1,4 @@
-import { MathLib } from "@morpho-org/morpho-ts";
+import { assertNonNegative, MathLib } from "@morpho-org/morpho-ts";
 import { InvalidMidnightApiResponseError } from "../errors.js";
 import { TakeAmountsLib } from "../math/index.js";
 import { Payload } from "../signatures/Payload.js";
@@ -337,9 +337,9 @@ export class MidnightApi {
    * @param params.fetch - Optional fetch implementation override.
    * @param params.request - Optional fetch options forwarded to this request.
    * @returns Quote and signed ABI-ready take caps mapped from the API response.
+   * @throws {NegativeValueError} when `settlementFee` is negative.
    * @throws {MidnightApiError} when the API returns a non-2xx response.
    * @throws {InvalidMidnightApiResponseError} when the API success response is not JSON.
-   * @throws {NegativeValueError} when `settlementFee` is negative.
    * @throws {SettlementFeeExceedsPriceError} when a bid's settlement fee exceeds its offer price.
    * @example
    * ```ts
@@ -358,6 +358,8 @@ export class MidnightApi {
     params: FetchBookQuoteParams,
   ): Promise<MidnightApiQuoteResult> {
     const input = params;
+    const settlementFee = BigInt(input.settlementFee ?? 0n);
+    assertNonNegative("settlementFee", settlementFee);
     const response = await requestMidnightApi<ApiQuoteResponse>({
       ...input,
       method: "GET",
@@ -389,7 +391,6 @@ export class MidnightApi {
           : undefined;
     if (averageWorstPrice != null) {
       const guard = BigInt(averageWorstPrice);
-      const settlementFee = BigInt(input.settlementFee ?? 0n);
       let filledUnits = 0n;
       let filledAssets = 0n;
       if ("units" in input && input.units != null) {
@@ -420,20 +421,21 @@ export class MidnightApi {
             offer: take.offer,
             settlementFee,
           });
-          const price = input.side === "asks" ? buyerPrice : sellerPrice;
-          const takeAssets =
+          const makerPrice = input.side === "asks" ? sellerPrice : buyerPrice;
+          const settlementPrice =
+            input.side === "asks" ? buyerPrice : sellerPrice;
+          const takeMakerAssets =
             input.side === "asks"
-              ? MathLib.mulDivUp(take.units, price, MathLib.WAD)
-              : MathLib.mulDivDown(take.units, price, MathLib.WAD);
-          if (takeAssets === 0n) continue;
+              ? MathLib.mulDivUp(take.units, makerPrice, MathLib.WAD)
+              : MathLib.mulDivDown(take.units, makerPrice, MathLib.WAD);
 
-          const fillsEntireTake = takeAssets <= remainingAssets;
+          const fillsEntireTake = takeMakerAssets <= remainingAssets;
           const filled = fillsEntireTake
             ? take.units
             : MathLib.mulDiv(
                 remainingAssets,
                 MathLib.WAD,
-                price,
+                makerPrice,
                 input.side === "asks" ? "Down" : "Up",
               );
           if (filled === 0n) continue;
@@ -441,11 +443,13 @@ export class MidnightApi {
           filledUnits += filled;
           filledAssets += MathLib.mulDiv(
             filled,
-            price,
+            settlementPrice,
             MathLib.WAD,
             input.side === "asks" ? "Up" : "Down",
           );
-          remainingAssets = fillsEntireTake ? remainingAssets - takeAssets : 0n;
+          remainingAssets = fillsEntireTake
+            ? remainingAssets - takeMakerAssets
+            : 0n;
         }
       }
       if (filledUnits > 0n) {
@@ -795,9 +799,9 @@ export class MidnightApi {
    * @param params.slippage - Optional slippage percentage used to derive the guard. Mutually exclusive with `params.averageWorstPrice`.
    * @param params.settlementFee - Optional current WAD-scaled settlement fee used for local guard validation. Defaults to zero.
    * @returns Quote and signed ABI-ready take caps mapped from the API response.
+   * @throws {NegativeValueError} when `settlementFee` is negative.
    * @throws {MidnightApiError} when the API returns a non-2xx response.
    * @throws {InvalidMidnightApiResponseError} when the API success response is not JSON.
-   * @throws {NegativeValueError} when `settlementFee` is negative.
    * @throws {SettlementFeeExceedsPriceError} when a bid's settlement fee exceeds its offer price.
    * @example
    * ```ts

--- a/packages/midnight-sdk/src/api/MidnightApi.ts
+++ b/packages/midnight-sdk/src/api/MidnightApi.ts
@@ -1,6 +1,6 @@
 import { MathLib } from "@morpho-org/morpho-ts";
 import { InvalidMidnightApiResponseError } from "../errors.js";
-import { TickLib } from "../math/index.js";
+import { TakeAmountsLib } from "../math/index.js";
 import { Payload } from "../signatures/Payload.js";
 import {
   buildBookPath,
@@ -332,12 +332,15 @@ export class MidnightApi {
    * @param params.units - Optional target unit amount. Mutually exclusive with `params.assets`.
    * @param params.averageWorstPrice - Optional WAD-scaled average worst price guard. Mutually exclusive with `params.slippage`.
    * @param params.slippage - Optional slippage percentage used to derive the guard. Mutually exclusive with `params.averageWorstPrice`.
+   * @param params.settlementFee - Optional current WAD-scaled settlement fee used for local guard validation. Defaults to zero.
    * @param params.baseUrl - Optional Midnight API base URL override.
    * @param params.fetch - Optional fetch implementation override.
    * @param params.request - Optional fetch options forwarded to this request.
    * @returns Quote and signed ABI-ready take caps mapped from the API response.
    * @throws {MidnightApiError} when the API returns a non-2xx response.
    * @throws {InvalidMidnightApiResponseError} when the API success response is not JSON.
+   * @throws {NegativeValueError} when `settlementFee` is negative.
+   * @throws {SettlementFeeExceedsPriceError} when a bid's settlement fee exceeds its offer price.
    * @example
    * ```ts
    * import { MidnightApi } from "@morpho-org/midnight-sdk/api";
@@ -386,24 +389,38 @@ export class MidnightApi {
           : undefined;
     if (averageWorstPrice != null) {
       const guard = BigInt(averageWorstPrice);
+      const settlementFee = BigInt(input.settlementFee ?? 0n);
       let filledUnits = 0n;
-      let weightedPrice = 0n;
+      let filledAssets = 0n;
       if ("units" in input && input.units != null) {
         let remainingUnits = BigInt(input.units);
         for (const take of takeableOffers) {
           if (remainingUnits === 0n) break;
-          const price = TickLib.tickToPrice(take.offer.tick);
+          const { buyerPrice, sellerPrice } = TakeAmountsLib.prices({
+            offer: take.offer,
+            settlementFee,
+          });
+          const price = input.side === "asks" ? buyerPrice : sellerPrice;
           const filled =
             take.units < remainingUnits ? take.units : remainingUnits;
           filledUnits += filled;
-          weightedPrice += filled * price;
+          filledAssets += MathLib.mulDiv(
+            filled,
+            price,
+            MathLib.WAD,
+            input.side === "asks" ? "Up" : "Down",
+          );
           remainingUnits -= filled;
         }
       } else {
         let remainingAssets = BigInt(input.assets);
         for (const take of takeableOffers) {
           if (remainingAssets === 0n) break;
-          const price = TickLib.tickToPrice(take.offer.tick);
+          const { buyerPrice, sellerPrice } = TakeAmountsLib.prices({
+            offer: take.offer,
+            settlementFee,
+          });
+          const price = input.side === "asks" ? buyerPrice : sellerPrice;
           const takeAssets =
             input.side === "asks"
               ? MathLib.mulDivUp(take.units, price, MathLib.WAD)
@@ -422,12 +439,22 @@ export class MidnightApi {
           if (filled === 0n) continue;
 
           filledUnits += filled;
-          weightedPrice += filled * price;
+          filledAssets += MathLib.mulDiv(
+            filled,
+            price,
+            MathLib.WAD,
+            input.side === "asks" ? "Up" : "Down",
+          );
           remainingAssets = fillsEntireTake ? remainingAssets - takeAssets : 0n;
         }
       }
       if (filledUnits > 0n) {
-        const averagePrice = MathLib.mulDivDown(weightedPrice, 1n, filledUnits);
+        const averagePrice = MathLib.mulDiv(
+          filledAssets,
+          MathLib.WAD,
+          filledUnits,
+          input.side === "asks" ? "Up" : "Down",
+        );
         const violatesGuard =
           input.side === "asks" ? averagePrice > guard : averagePrice < guard;
         if (violatesGuard) {
@@ -766,9 +793,12 @@ export class MidnightApi {
    * @param params.units - Optional target unit amount. Mutually exclusive with `params.assets`.
    * @param params.averageWorstPrice - Optional WAD-scaled average worst price guard. Mutually exclusive with `params.slippage`.
    * @param params.slippage - Optional slippage percentage used to derive the guard. Mutually exclusive with `params.averageWorstPrice`.
+   * @param params.settlementFee - Optional current WAD-scaled settlement fee used for local guard validation. Defaults to zero.
    * @returns Quote and signed ABI-ready take caps mapped from the API response.
    * @throws {MidnightApiError} when the API returns a non-2xx response.
    * @throws {InvalidMidnightApiResponseError} when the API success response is not JSON.
+   * @throws {NegativeValueError} when `settlementFee` is negative.
+   * @throws {SettlementFeeExceedsPriceError} when a bid's settlement fee exceeds its offer price.
    * @example
    * ```ts
    * import { MidnightApi } from "@morpho-org/midnight-sdk/api";

--- a/packages/midnight-sdk/src/api/types.ts
+++ b/packages/midnight-sdk/src/api/types.ts
@@ -203,6 +203,8 @@ export type FetchBookQuoteParams = MidnightApiConfig & {
   readonly marketId: Hash;
   /** Book side to quote. */
   readonly side: MidnightApiBookSide;
+  /** Current WAD-scaled settlement fee used for local guard validation. Defaults to zero. */
+  readonly settlementFee?: BigIntish;
 } & (MidnightApiQuoteAssetsTarget | MidnightApiQuoteUnitsTarget) &
   (
     | MidnightApiQuoteAverageWorstPriceGuard


### PR DESCRIPTION
## What

- [SDKS-59](https://linear.app/morpho-labs/issue/SDK-494/sdks-59medium-midnight-quote-guard-ignores-aggregate-integer): Validates `averageWorstPrice` from side-appropriate, per-fill rounded settlement amounts and accepts the current settlement fee for effective buyer or seller pricing. Example: two 1-unit asks priced at 0.5 asset units each settle to 1 asset unit apiece; a frontend now rejects the realized 1.0 average instead of accepting the theoretical 0.5 average.

## Why

Frontends use the quote guard to decide which signed offers to submit. Checking the same integer amounts settlement uses prevents a quote response from passing preflight with an aggregate price worse than the user's bound.
