### PR TITLE
chore(morpho-sdk): refactor VaultExitBundlesV1 in-kind redemption

### DIFF
--- a/.changeset/vault-exit-bundles-inkind-refactor.md
+++ b/.changeset/vault-exit-bundles-inkind-refactor.md
@@ -1,0 +1,14 @@
+---
+"@morpho-org/morpho-sdk": minor
+"@morpho-org/wdk-protocol-lending-morpho-evm": patch
+---
+
+Reuse the shared bundles permit converter for VaultExitBundlesV1 in-kind redemptions while
+preserving `VaultExitBundlesV1PermitMismatchError`. Deprecate
+`getVaultExitBundlesV1PermitStruct`, `GetVaultExitBundlesV1PermitStructParams`, and
+`VaultExitBundlesV1PermitStruct` in favor of `getBundlesSharesPermit` and `BundleSharesPermit`.
+
+Use `computeVaultMaxShareAllowance` for VaultV1 in-kind redemption requirements. The cap rounds
+shares up, includes pending performance-fee dilution, and adds the default 0.03% loss buffer for
+MetaMorpho 1.0 while preserving MetaMorpho 1.1's lost-assets clamp. Both approval and permit
+requirements use this cap. In-kind redemptions continue to call VaultExitBundlesV1.

--- a/packages/morpho-sdk/src/actions/signatures/getVaultExitBundlesV1PermitStruct.test.ts
+++ b/packages/morpho-sdk/src/actions/signatures/getVaultExitBundlesV1PermitStruct.test.ts
@@ -9,6 +9,7 @@ import {
 } from "viem";
 import { describe, expect, test } from "vitest";
 import {
+  BundlesPermitMismatchError,
   type PermitRequirementSignature,
   VaultExitBundlesV1PermitMismatchError,
 } from "../../types/index.js";
@@ -200,7 +201,10 @@ describe("getVaultExitBundlesV1PermitStruct", () => {
     if (!(thrown instanceof VaultExitBundlesV1PermitMismatchError))
       throw thrown;
     expect(thrown.field).toBe("signature");
-    expect(thrown.cause).toBeInstanceOf(Error);
+    expect(thrown.cause).toBeInstanceOf(BundlesPermitMismatchError);
+    if (!(thrown.cause instanceof BundlesPermitMismatchError))
+      throw thrown.cause;
+    expect(thrown.cause.cause).toBeInstanceOf(Error);
   });
 
   test("behavior: permit tuple round-trips across valid scalar inputs", () => {

--- a/packages/morpho-sdk/src/actions/signatures/getVaultExitBundlesV1PermitStruct.ts
+++ b/packages/morpho-sdk/src/actions/signatures/getVaultExitBundlesV1PermitStruct.ts
@@ -1,22 +1,26 @@
+import type { Address } from "viem";
 import {
-  type Address,
-  compactSignatureToSignature,
-  isAddressEqual,
-  parseCompactSignature,
-  parseSignature,
-  size,
-  zeroHash,
-} from "viem";
-import {
+  BundlesPermitMismatchError,
   type PermitRequirementSignature,
   VaultExitBundlesV1PermitMismatchError,
 } from "../../types/index.js";
-import type { BundleSharesPermit } from "../bundles/common.js";
+import {
+  type BundleSharesPermit,
+  getBundlesSharesPermit,
+} from "../bundles/common.js";
 
-/** Compatibility alias for the canonical {@link BundleSharesPermit} tuple consumed by VaultExitBundlesV1. */
+/**
+ * Compatibility alias for the canonical {@link BundleSharesPermit} tuple consumed by VaultExitBundlesV1.
+ *
+ * @deprecated Use {@link BundleSharesPermit}.
+ */
 export type VaultExitBundlesV1PermitStruct = BundleSharesPermit;
 
-/** Parameters for {@link getVaultExitBundlesV1PermitStruct}. */
+/**
+ * Parameters for {@link getVaultExitBundlesV1PermitStruct}.
+ *
+ * @deprecated Use the parameters of `getBundlesSharesPermit`.
+ */
 export interface GetVaultExitBundlesV1PermitStructParams {
   /** Vault share token authorized by the permit. */
   readonly vault: Address;
@@ -27,92 +31,40 @@ export interface GetVaultExitBundlesV1PermitStructParams {
 }
 
 /**
- * Returns the permit struct consumed by VaultExitBundlesV1 from an optional vault-share
- * requirement signature.
- *
- * Without a signature, returns the contract's empty-permit sentinel. With a signature, validates
- * the ERC-2612 kind and vault asset before splitting the serialized signature.
- * Owner, spender, deadline, nonce, and cryptographic validity are verified onchain by the vault.
+ * Compatibility wrapper for the former VaultExitBundlesV1-specific permit reshaper.
  *
  * @param params.vault - Vault share token authorized by the permit.
  * @param params.deadline - Bundle deadline used by the empty-permit sentinel.
- * @param params.requirementSignature - Optional signed bounded ERC-2612 requirement.
- * @returns The VaultExitBundlesV1 permit tuple.
- * @throws {VaultExitBundlesV1PermitMismatchError} when the requirement has the wrong permit kind, asset, or signature encoding.
+ * @param params.requirementSignature - Optional signed ERC-2612 vault-share requirement.
+ * @returns The shared bundles share-permit tuple.
+ * @throws {VaultExitBundlesV1PermitMismatchError} when the requirement is incompatible.
+ * @deprecated Use `getBundlesSharesPermit`; this wrapper preserves the legacy error identity.
  * @example
  * ```ts
  * import { getVaultExitBundlesV1PermitStruct } from "@morpho-org/morpho-sdk";
+ * import { zeroAddress } from "viem";
  *
  * const permit = getVaultExitBundlesV1PermitStruct({
- *   vault,
- *   deadline,
- *   requirementSignature,
+ *   vault: zeroAddress,
+ *   deadline: 1_900_000_000n,
  * });
- * // permit satisfies VaultExitBundlesV1PermitStruct
+ * // permit.value === 0n
  * ```
  */
 export const getVaultExitBundlesV1PermitStruct = (
   params: GetVaultExitBundlesV1PermitStructParams,
 ): VaultExitBundlesV1PermitStruct => {
-  const { requirementSignature } = params;
-  if (requirementSignature == null) {
-    return {
-      value: 0n,
-      nonce: 0n,
-      deadline: params.deadline,
-      v: 0,
-      r: zeroHash,
-      s: zeroHash,
-    };
-  }
-
-  if (requirementSignature.action.type !== "permit") {
-    throw new VaultExitBundlesV1PermitMismatchError({
-      field: "type",
-      expected: "permit",
-      actual: requirementSignature.action.type,
-    });
-  }
-  if (!isAddressEqual(requirementSignature.args.asset, params.vault)) {
-    throw new VaultExitBundlesV1PermitMismatchError({
-      field: "asset",
-      expected: params.vault,
-      actual: requirementSignature.args.asset,
-    });
-  }
-  const signature = (() => {
-    try {
-      const serializedSignature = requirementSignature.args.signature;
-      return size(serializedSignature) === 64
-        ? compactSignatureToSignature(
-            parseCompactSignature(serializedSignature),
-          )
-        : parseSignature(serializedSignature);
-    } catch (cause) {
+  try {
+    return getBundlesSharesPermit(params);
+  } catch (cause) {
+    if (cause instanceof BundlesPermitMismatchError) {
       throw new VaultExitBundlesV1PermitMismatchError({
-        field: "signature",
-        expected: "a 64-byte compact or 65-byte serialized ECDSA signature",
-        actual: requirementSignature.args.signature,
+        field: cause.field,
+        expected: cause.expected,
+        actual: cause.actual,
         cause,
       });
     }
-  })();
-
-  const { r, s, v, yParity } = signature;
-  const normalizedV = v ?? (yParity == null ? undefined : BigInt(yParity + 27));
-  if (normalizedV == null) {
-    throw new VaultExitBundlesV1PermitMismatchError({
-      field: "signature",
-      expected: "a signature containing v or yParity",
-      actual: requirementSignature.args.signature,
-    });
+    throw cause;
   }
-  return {
-    value: requirementSignature.args.amount,
-    nonce: requirementSignature.args.nonce,
-    deadline: requirementSignature.args.deadline,
-    v: Number(normalizedV),
-    r,
-    s,
-  };
 };

--- a/packages/morpho-sdk/src/entities/vaultV1/vaultV1.inKindRedeem.test.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1/vaultV1.inKindRedeem.test.ts
@@ -280,7 +280,7 @@ describe("MorphoVaultV1.inKindRedeem", () => {
 
     expect(approval?.action).toEqual({
       type: "erc20Approval",
-      args: { spender: IN_KIND_BUNDLER, amount: 500n },
+      args: { spender: IN_KIND_BUNDLER, amount: 501n },
     });
   });
 
@@ -304,7 +304,7 @@ describe("MorphoVaultV1.inKindRedeem", () => {
 
     expect(approval?.action).toEqual({
       type: "erc20Approval",
-      args: { spender: IN_KIND_BUNDLER, amount: 505n },
+      args: { spender: IN_KIND_BUNDLER, amount: 506n },
     });
   });
 
@@ -343,13 +343,13 @@ describe("MorphoVaultV1.inKindRedeem", () => {
 
     expect(requirement?.action).toMatchObject({
       type: "permit",
-      args: { spender: IN_KIND_BUNDLER, amount: 500n },
+      args: { spender: IN_KIND_BUNDLER, amount: 501n },
     });
   });
 
   test("behavior: an exact bounded allowance needs no authorization", async () => {
     const handle = createMockClient(mainnet);
-    mockV1Requirements(handle, { allowance: 500n });
+    mockV1Requirements(handle, { allowance: 501n });
     const vault = handle.client
       .extend(morphoViemExtension())
       .morpho.vaultV1(IN_KIND_VAULT, mainnet.id);

--- a/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
+++ b/packages/morpho-sdk/src/entities/vaultV1/vaultV1.ts
@@ -324,9 +324,9 @@ export interface VaultV1Actions {
    * The caller controls market order and must call `getRequirements()` before `buildTx()` so the
    * RPC-backed Blue-balance and Morpho-deployment checks run. The SDK validates market coverage but
    * intentionally does not validate the user's share balance; size `amount` in asset terms against
-   * `previewRedeem(sharesHeld)`. The share allowance first accrues pending performance-fee shares,
-   * then uses the current rounded-up share preview; future interest can only reduce the required
-   * burn.
+   * `previewRedeem(sharesHeld)`. The share allowance uses the greater rounded-up share preview
+   * before and after accruing pending performance-fee shares. MetaMorpho 1.0 adds the default
+   * 0.03% loss buffer; MetaMorpho 1.1 retains its lost-assets clamp without that buffer.
    *
    * Snapshot state can drift before inclusion, so a later reallocation may still make the on-chain
    * loop under-cover even after pre-flight succeeds.
@@ -874,11 +874,12 @@ export class MorphoVaultV1 implements VaultV1Actions {
       });
     }
 
-    // Account for pending performance-fee shares before previewing the burn. Once accrued, future
-    // V1 interest cannot lower the share price, so this upper-bounds execution.
-    const requiredShareAllowance = vaultData
-      .accrueInterest(now)
-      .toShares(amount);
+    const requiredShareAllowance = computeVaultMaxShareAllowance({
+      vaultData,
+      deadline: now,
+      assets: amount,
+      slippageTolerance: DEFAULT_SLIPPAGE_TOLERANCE,
+    });
 
     return {
       getRequirements: async (): Promise<readonly ActionRequirement[]> => {


### PR DESCRIPTION
VaultExitBundlesV1 in-kind redemptions duplicate permit conversion and share-allowance calculations already provided by the shared bundles helpers. Reuse those helpers and keep this work independently reviewable from the VaultBundlesV1 withdrawal migration in #999.

- Delegate `getVaultExitBundlesV1PermitStruct` to `getBundlesSharesPermit`, preserving the legacy error class and the underlying parser cause. Deprecate the older helper and type names.
- Use `computeVaultMaxShareAllowance` for VaultV1 in-kind approval and permit requirements. This rounds shares up, includes pending performance-fee dilution, and applies the default 0.03% loss buffer to MetaMorpho 1.0. A fixture requesting 500 shares now requests 501; MetaMorpho 1.1 retains its lost-assets clamp.
- Include updated tests, JSDoc, and a minor SDK changeset with a patch for its maintained WDK runtime dependent. The liquidity SDK's existing `^5.4.0 || ^6.0.0` peer range remains compatible.

## Stack

Top PR in GitHub stack #1016: merged prerequisites #997 → merged deposits #998 → withdrawals #999 → redemptions/migration #1000 → this chore.

This PR targets #1000's redemption branch. Its five-file diff contains only the VaultExitBundlesV1 in-kind refactor, tests, JSDoc, and changeset; the lower PRs retain the original in-kind implementation.

## Validation

- 120 unit tests across permit conversion, share-cap math, and both in-kind redemption paths
- 4 pinned-mainnet fork tests across VaultV1 and VaultV2 in-kind redemptions
- morpho-sdk TypeScript check
- `pnpm lint`
- `git diff --check`
