### PR TITLE
ci(claude): allow morpho-sdks-release-bot to trigger PR reviews (SDK-552)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -95,7 +95,8 @@ jobs:
           # pull_request events run in agent mode with a fixed prompt; other events stay in @claude tag mode.
           prompt: ${{ github.event_name == 'pull_request' && format('Review pull request number {0} in {1} by following the trusted pr-review-ci instructions.', github.event.pull_request.number, github.repository) || '' }}
           track_progress: ${{ github.event_name == 'pull_request' }}
-          allowed_bots: 'morpho-apps-git-bot,prime-monorepo-git-bot,devin-ai-integration,prd-carapulse,cursor,morpho-sdks-release-bot'
+          # The release bot only needs the automatic pull_request review; keep it out of @claude comment triggers.
+          allowed_bots: ${{ github.event_name == 'pull_request' && 'morpho-apps-git-bot,prime-monorepo-git-bot,devin-ai-integration,prd-carapulse,cursor,morpho-sdks-release-bot' || 'morpho-apps-git-bot,prime-monorepo-git-bot,devin-ai-integration,prd-carapulse,cursor' }}
           claude_args: |
             --model fable
             --allowedTools Bash,Edit,Write,Read,Glob,Grep,Agent,Task,mcp__github_inline_comment__create_inline_comment

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -95,7 +95,7 @@ jobs:
           # pull_request events run in agent mode with a fixed prompt; other events stay in @claude tag mode.
           prompt: ${{ github.event_name == 'pull_request' && format('Review pull request number {0} in {1} by following the trusted pr-review-ci instructions.', github.event.pull_request.number, github.repository) || '' }}
           track_progress: ${{ github.event_name == 'pull_request' }}
-          allowed_bots: 'morpho-apps-git-bot,prime-monorepo-git-bot,devin-ai-integration,prd-carapulse,cursor'
+          allowed_bots: 'morpho-apps-git-bot,prime-monorepo-git-bot,devin-ai-integration,prd-carapulse,cursor,morpho-sdks-release-bot'
           claude_args: |
             --model fable
             --allowedTools Bash,Edit,Write,Read,Glob,Grep,Agent,Task,mcp__github_inline_comment__create_inline_comment


### PR DESCRIPTION
## Summary
The auto Claude review fails on `chore: version packages` PRs opened by `morpho-sdks-release-bot[bot]` (e.g. #1057):

```
Workflow initiated by non-human actor: morpho-sdks-release-bot (type: Bot). Add bot to allowed_bots list
```

The job-level `if:` lets bots through, but `claude-code-action` has its own bot gate. Adds `morpho-sdks-release-bot` to `allowed_bots` in `.github/workflows/claude.yml`.

Note: `pull_request` workflows run from the merge ref, so this also needs to land on `next` for #1057's check to go green (merge main into next, or cherry-pick).

Linear: SDK-552

Link to Devin session: https://app.devin.ai/sessions/75e67577ec54460a8b471c691b511820
Open in Devin Desktop: https://app.devin.ai/desktop/session/75e67577ec54460a8b471c691b511820?variant=devin
Requested by: @Foulks-Plb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morpho-org/sdks/pull/1058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->